### PR TITLE
Fix Headless Firefox in Selenium Tests

### DIFF
--- a/modules/lti/requirements.txt
+++ b/modules/lti/requirements.txt
@@ -1,2 +1,2 @@
-selenium
+selenium>=4.13.0
 urllib3

--- a/modules/lti/selenium-tests
+++ b/modules/lti/selenium-tests
@@ -172,6 +172,6 @@ def main():
 if __name__ == '__main__':
     options = webdriver.FirefoxOptions()
     if sys.argv[-1] != 'gui':
-        options.headless = True
+        options.add_argument('--headless')
     driver = webdriver.Firefox(options=options)
     main()


### PR DESCRIPTION
With new versions of Selenium, the way headless mode is invoked has changed:

- https://www.selenium.dev/blog/2023/headless-is-going-away/

This pull request fixes the Selenium code so that the LTI tests continue to work on our CI system.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
