### PR TITLE
Fix Crowdin Package Name

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -21,7 +21,7 @@ jobs:
     - name: prepare crowdin client
       run: |
         wget --quiet https://artifacts.crowdin.com/repo/deb/crowdin3.deb
-        sudo dpkg -i crowdin.deb
+        sudo dpkg -i crowdin3.deb
 
     - name: prepare github ssh key
       env:
@@ -36,7 +36,7 @@ jobs:
       run: |
         git clone "git@github.com:opencast/opencast.git" ~/oc
 
-    - name: upload translation source
+    - name: update translations
       env:
         CROWDIN_TOKEN: ${{ secrets.CROWDIN_TOKEN }}
       run: |


### PR DESCRIPTION
Pull request #5114 changed the Debian package downloaded to install the Crowdin client but failed to change the name of the package being installed. This patch fixes the problem and adjusts the package name.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
