### PR TITLE
Skip Invalid Default Admin Email

### DIFF
--- a/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/EmailWorkflowOperationHandler.java
+++ b/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/EmailWorkflowOperationHandler.java
@@ -122,6 +122,11 @@ public class EmailWorkflowOperationHandler extends AbstractWorkflowOperationHand
       return createResult(srcPackage, Action.SKIP);
     }
 
+    if (to.length == 1 && cc.length + bcc.length == 0 && "admin@localhost".equals(to[0])) {
+      logger.info("Skipping invalid default admin email address `admin@localhost`.");
+      return createResult(srcPackage, Action.SKIP);
+    }
+
     String subject = applyTemplateIfNecessary(workflowInstance, operation, SUBJECT_PROPERTY);
 
     String bodyCfg = operation.getConfiguration(BODY_PROPERTY);


### PR DESCRIPTION
We can safely assume the default email address for the admin user (`admin@localhost`= to not be a valid email address. This means that workflows which send mails to users will fail with a stack trace like this:

```
2023-10-02T21:28:20,993 | ERROR | (WorkflowOperationWorker:140) - Workflow operation 'operation:'send-email, state:'FAILED'' failed
org.opencastproject.workflow.api.WorkflowOperationException: javax.mail.SendFailedException: Invalid Addresses;
  nested exception is:
        com.sun.mail.smtp.SMTPAddressFailedException: 550 5.1.1 <admin@localhost>: Recipient address rejected: User unknown in local recipient table
        at org.opencastproject.workflow.handler.notification.EmailWorkflowOperationHandler.start(EmailWorkflowOperationHandler.java:161) ~[?:?]
        at org.opencastproject.workflow.impl.WorkflowOperationWorker.start(WorkflowOperationWorker.java:212) ~[?:?]
        at org.opencastproject.workflow.impl.WorkflowOperationWorker.execute(WorkflowOperationWorker.java:117) ~[?:?]
        at org.opencastproject.workflow.impl.WorkflowServiceImpl.runWorkflowOperation(WorkflowServiceImpl.java:725) ~[?:?]
        at org.opencastproject.workflow.impl.WorkflowServiceImpl.process(WorkflowServiceImpl.java:1758) ~[?:?]
        at org.opencastproject.workflow.impl.WorkflowServiceImpl$JobRunner.call(WorkflowServiceImpl.java:2119) ~[?:?]
        at org.opencastproject.workflow.impl.WorkflowServiceImpl$JobRunner.call(WorkflowServiceImpl.java:2085) ~[?:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
        at java.lang.Thread.run(Thread.java:829) ~[?:?]
Caused by: javax.mail.SendFailedException: Invalid Addresses
        at com.sun.mail.smtp.SMTPTransport.rcptTo(SMTPTransport.java:2064) ~[?:?]
        at com.sun.mail.smtp.SMTPTransport.sendMessage(SMTPTransport.java:1286) ~[?:?]
        at org.opencastproject.kernel.mail.BaseSmtpService.send(BaseSmtpService.java:260) ~[?:?]
        at org.opencastproject.kernel.mail.SmtpService.send(SmtpService.java:326) ~[?:?]
        at org.opencastproject.workflow.handler.notification.EmailWorkflowOperationHandler.start(EmailWorkflowOperationHandler.java:158) ~[?:?]
        ... 10 more
Caused by: com.sun.mail.smtp.SMTPAddressFailedException: 550 5.1.1 <admin@localhost>: Recipient address rejected: User unknown in local recipient table
        at com.sun.mail.smtp.SMTPTransport.rcptTo(SMTPTransport.java:1917) ~[?:?]
        at com.sun.mail.smtp.SMTPTransport.sendMessage(SMTPTransport.java:1286) ~[?:?]
        at org.opencastproject.kernel.mail.BaseSmtpService.send(BaseSmtpService.java:260) ~[?:?]
        at org.opencastproject.kernel.mail.SmtpService.send(SmtpService.java:326) ~[?:?]
        at org.opencastproject.workflow.handler.notification.EmailWorkflowOperationHandler.start(EmailWorkflowOperationHandler.java:158) ~[?:?]
        ... 10 more
```

This patch lets Opencast detect these cases and skips the operation instead.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
