### PR TITLE
Update events in archive in order on series change

### DIFF
--- a/modules/conductor/src/main/java/org/opencastproject/event/handler/AssetManagerUpdatedEventHandler.java
+++ b/modules/conductor/src/main/java/org/opencastproject/event/handler/AssetManagerUpdatedEventHandler.java
@@ -48,6 +48,8 @@ import org.opencastproject.security.util.SecurityUtil;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.workspace.api.Workspace;
 
+import com.entwinemedia.fn.Stream;
+
 import org.apache.commons.io.FilenameUtils;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
@@ -58,6 +60,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Comparator;
 
 /**
  * Responds to series events by re-distributing metadata and security policy files to episodes.
@@ -175,7 +178,9 @@ public class AssetManagerUpdatedEventHandler {
 
       final AQueryBuilder q = assetManager.createQuery();
       final AResult result = q.select(q.snapshot()).where(q.seriesId().eq(seriesId).and(q.version().isLatest())).run();
-      for (Snapshot snapshot : enrich(result).getSnapshots()) {
+      Stream<Snapshot> snapshots = enrich(result).getSnapshots().sort(
+              Comparator.comparing(s->s.getMediaPackage().getIdentifier().toString()));
+      for (Snapshot snapshot : snapshots) {
         final String orgId = snapshot.getOrganizationId();
         final Organization organization = organizationDirectoryService.getOrganization(orgId);
         if (organization == null) {


### PR DESCRIPTION
When a series is changed (e.g. its ACL), all its events are automatically updated in the archive. Since this process isn't locked in any way, it's possible for the phenomenon of a lost update to occur when a series is changed multiple times in quick succession.

This is exacerbated by the fact that the events aren't updated in any particular order, meaning that event x can be updated last in one case and first in the next, massively increasing the changes that the wrong process gets to it first.

Since sorting isn't possible when querying from the AssetManager, I sort the list in place afterwards by the event id. This doesn't eliminate the possibility of lost updates entirely, but should make them way more unlikely.




