### PR TITLE
Improve Performance of Permission Check in AssetManager

### DIFF
--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
@@ -1081,7 +1081,7 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
         return getDatabase().selectProperties(mediaPackageId, SECURITY_NAMESPACE).parallelStream()
                 .map(p -> p.getId().getName())
                 .filter(p -> p.endsWith(action))
-                .anyMatch(p -> roles.parallelStream().anyMatch(r -> r.equals(p)));
+                .anyMatch(p -> roles.stream().anyMatch(r -> r.equals(p)));
     }
   }
 

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
@@ -1080,6 +1080,7 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
                 .collect(Collectors.toList());
         return getDatabase().selectProperties(mediaPackageId, SECURITY_NAMESPACE).parallelStream()
                 .map(p -> p.getId().getName())
+                .filter(p -> p.endsWith(action))
                 .anyMatch(p -> roles.parallelStream().anyMatch(r -> r.equals(p)));
     }
   }


### PR DESCRIPTION
During the permission check in the AssetManager, each security property of a media package (containing a role and an action) is compared to each role of the user simultaneously. This can create a large number of threads. 

We have seen this actually cause exceptions in a production system, however I couldn't reproduce these locally, maybe not enough other things going on in an idle system. Still I felt like it wouldn't do any harm to reduce this a bit, so this filters the security properties by the action we're looking for before doing the comparing.
