### PR TITLE
Update Editor to 2023-10-05

### DIFF
--- a/etc/ui-config/mh_default_org/editor/editor-settings.toml
+++ b/etc/ui-config/mh_default_org/editor/editor-settings.toml
@@ -4,6 +4,29 @@
 
 
 ####
+# General Settings
+##
+
+# Allowed prefixes in callback urls to prevent malicious urls
+# If empty, no callback url is allowed
+# Type: string[]
+# Default: []
+#allowedCallbackPrefixes = []
+
+# Url to go back after finishing editing
+# If undefined, no return link will be shown on the end pages
+# Type: string | undefined
+# Default: undefined
+#callbackUrl =
+
+# Name of system to go back to
+# If undefined, a generic system name is used instead of a speficic name
+# Type: string | undefined
+# Default: undefined
+#callbackSystem =
+
+
+####
 # Metadata
 ##
 

--- a/modules/editor/pom.xml
+++ b/modules/editor/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <editor.url>https://github.com/opencast/opencast-editor/releases/download/2023-04-20/oc-editor-2023-04-20.tar.gz</editor.url>
-    <editor.sha256>91ced444262b1d40506fd53c5ca5141c34b1578befc16993ca82e207305942d4</editor.sha256>
+    <editor.url>https://github.com/opencast/opencast-editor/releases/download/2023-10-05/oc-editor-2023-10-05.tar.gz</editor.url>
+    <editor.sha256>a47ae8d3c5c32b8eb199e5048223a76f2a8ab7fbaaa2d6c94ca17511bad09903</editor.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
Updates the editor to https://github.com/opencast/opencast-editor/releases/tag/2023-10-05, with highlights being the UI redesign and editor locking.

Based on the branch https://github.com/opencast/opencast-editor/tree/release-for-oc-14.5 which includes a revert regarding subtitles. The revert is necessary to work with OC14.

It would be great if someone could test if everything still works, or if the revert mentioned above (or something that should have been reverted but wasn't) broke anything.

Known issues not related to the revert:
- https://github.com/opencast/opencast-editor/issues/1154
- https://github.com/opencast/opencast-editor/issues/1161
