### PR TITLE
Add config-keys to set minimum rules for cuts and segments duration

### DIFF
--- a/etc/org.opencastproject.videoeditor.impl.VideoEditorServiceImpl.cfg
+++ b/etc/org.opencastproject.videoeditor.impl.VideoEditorServiceImpl.cfg
@@ -5,11 +5,13 @@ audio.fade = 0.2
 video.fade = 0.2
 
 # Editor segments configuration
-# Set segments minimum duration Default: At least 2000 milliseconds long
-segments.min.duration = 2000
-# Set minimum duration of a cut between 2 segments, if the cut is shorter than this, the segments will be merged
-# Default: At 2000 milliseconds long
-segments.min.cut.duration = 2000
+# Set segments minimum duration (In milliseconds), if a segment is shorter, it will considered a cut.
+# Default: 2000 milliseconds
+#segments.min.duration = 2000
+
+# Set minimum duration (In milliseconds) of a cut between 2 segments, if the cut is shorter, it will be ignored.
+# Default: 2000 milliseconds
+#segments.min.cut.duration = 2000
 
 # if not specified, default codec is same as input file
 audio.codec = aac

--- a/etc/org.opencastproject.videoeditor.impl.VideoEditorServiceImpl.cfg
+++ b/etc/org.opencastproject.videoeditor.impl.VideoEditorServiceImpl.cfg
@@ -4,6 +4,13 @@
 audio.fade = 0.2
 video.fade = 0.2
 
+# Editor segments configuration
+# Set segments minimum duration Default: At least 2000 milliseconds long
+segments.min.duration = 2000
+# Set minimum duration of a cut between 2 segments, if the cut is shorter than this, the segments will be merged
+# Default: At 2000 milliseconds long
+segments.min.cut.duration = 2000
+
 # if not specified, default codec is same as input file
 audio.codec = aac
 video.codec = libx264

--- a/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/impl/VideoEditorServiceImpl.java
+++ b/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/impl/VideoEditorServiceImpl.java
@@ -583,10 +583,14 @@ public class VideoEditorServiceImpl extends AbstractJobProducer implements Video
     logger.debug("Properties updated!");
 
     jobload = LoadUtil.getConfiguredLoadValue(properties, JOB_LOAD_KEY, DEFAULT_JOB_LOAD, serviceRegistry);
-    segmentsMinDuration = (int) LoadUtil.getConfiguredLoadValue(properties, SEGMENTS_MIN_DURATION_KEY,
-        Float.valueOf(DEFAULT_SEGMENTS_MIN_DURATION), serviceRegistry);
-    segmentsMinCutDuration = (int) LoadUtil.getConfiguredLoadValue(properties, SEGMENTS_MIN_CUT_DURATION_KEY,
-        Float.valueOf(DEFAULT_SEGMENTS_MIN_CUT_DURATION), serviceRegistry);
+    segmentsMinDuration = Integer.parseInt(this.properties.getProperty(SEGMENTS_MIN_DURATION_KEY,
+        String.valueOf(DEFAULT_SEGMENTS_MIN_DURATION)));
+    segmentsMinCutDuration = Integer.parseInt(this.properties.getProperty(SEGMENTS_MIN_CUT_DURATION_KEY,
+        String.valueOf(DEFAULT_SEGMENTS_MIN_CUT_DURATION)));
+    //segmentsMinDuration = (int) LoadUtil.getConfiguredLoadValue(properties, SEGMENTS_MIN_DURATION_KEY,
+    //    Float.valueOf(DEFAULT_SEGMENTS_MIN_DURATION), serviceRegistry);
+    //segmentsMinCutDuration = (int) LoadUtil.getConfiguredLoadValue(properties, SEGMENTS_MIN_CUT_DURATION_KEY,
+    //    Float.valueOf(DEFAULT_SEGMENTS_MIN_CUT_DURATION), serviceRegistry);
 
   }
 

--- a/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/impl/VideoEditorServiceImpl.java
+++ b/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/impl/VideoEditorServiceImpl.java
@@ -324,7 +324,7 @@ public class VideoEditorServiceImpl extends AbstractJobProducer implements Video
 
       // If we are cutting video/audio, use ffmpeg
       if (videoclips.size() > 0) {
-        // remove very shortcuts that will look bad
+        // remove very short cuts that will look bad
         List<VideoClip> cleanclips = sortSegments(videoclips, segmentsMinDuration, segmentsMinCutDuration);
         String error = null;
         String outputResolution = "";    //TODO: fetch the largest output resolution from SMIL.head.layout.root-layout

--- a/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/impl/VideoEditorServiceImpl.java
+++ b/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/impl/VideoEditorServiceImpl.java
@@ -465,12 +465,12 @@ public class VideoEditorServiceImpl extends AbstractJobProducer implements Video
     VideoClip nextclip;
     while (it.hasNext()) {     // Check for legal durations
       clip = it.next();
-      if (clip.getDurationInMilliseconds() > segmentsMinDuration) { // Keep segments at least 2 seconds long
+      if (clip.getDurationInMilliseconds() > segmentsMinDuration) { // Keep segments longer than segmentsMinDuration
         ll.add(clip);
       }
     }
     clip = ll.pop();        // initialize
-    while (!ll.isEmpty()) { // Check that 2 consecutive segments from same src are at least 2 secs apart
+    while (!ll.isEmpty()) { // Check that 2 consecutive segments from same src are at least segmentsMinCutDuration apart
       if (ll.peek() != null) {
         nextclip = ll.pop();  // check next consecutive segment
         // collapse two segments into one

--- a/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/impl/VideoEditorServiceImpl.java
+++ b/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/impl/VideoEditorServiceImpl.java
@@ -587,11 +587,6 @@ public class VideoEditorServiceImpl extends AbstractJobProducer implements Video
         String.valueOf(DEFAULT_SEGMENTS_MIN_DURATION)));
     segmentsMinCutDuration = Integer.parseInt(this.properties.getProperty(SEGMENTS_MIN_CUT_DURATION_KEY,
         String.valueOf(DEFAULT_SEGMENTS_MIN_CUT_DURATION)));
-    //segmentsMinDuration = (int) LoadUtil.getConfiguredLoadValue(properties, SEGMENTS_MIN_DURATION_KEY,
-    //    Float.valueOf(DEFAULT_SEGMENTS_MIN_DURATION), serviceRegistry);
-    //segmentsMinCutDuration = (int) LoadUtil.getConfiguredLoadValue(properties, SEGMENTS_MIN_CUT_DURATION_KEY,
-    //    Float.valueOf(DEFAULT_SEGMENTS_MIN_CUT_DURATION), serviceRegistry);
-
   }
 
   @Reference

--- a/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/impl/VideoEditorServiceImpl.java
+++ b/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/impl/VideoEditorServiceImpl.java
@@ -106,6 +106,18 @@ public class VideoEditorServiceImpl extends AbstractJobProducer implements Video
 
   private float jobload = DEFAULT_JOB_LOAD;
 
+  public static final String SEGMENTS_MIN_DURATION_KEY = "segments.min.duration";
+
+  private static final int DEFAULT_SEGMENTS_MIN_DURATION = 2000;
+
+  private int segmentsMinDuration = DEFAULT_SEGMENTS_MIN_DURATION;
+
+  public static final String SEGMENTS_MIN_CUT_DURATION_KEY = "segments.min.cut.duration";
+
+  private static final int DEFAULT_SEGMENTS_MIN_CUT_DURATION = 2000;
+
+  private int segmentsMinCutDuration = DEFAULT_SEGMENTS_MIN_CUT_DURATION;
+
   /**
    * The logging instance
    */
@@ -312,7 +324,8 @@ public class VideoEditorServiceImpl extends AbstractJobProducer implements Video
 
       // If we are cutting video/audio, use ffmpeg
       if (videoclips.size() > 0) {
-        List<VideoClip> cleanclips = sortSegments(videoclips);    // remove very short cuts that will look bad
+        // remove very shortcuts that will look bad
+        List<VideoClip> cleanclips = sortSegments(videoclips, segmentsMinDuration, segmentsMinCutDuration);
         String error = null;
         String outputResolution = "";    //TODO: fetch the largest output resolution from SMIL.head.layout.root-layout
         // When outputResolution is set to WxH, all clips are scaled to that size in the output video.
@@ -332,7 +345,8 @@ public class VideoEditorServiceImpl extends AbstractJobProducer implements Video
       // Or give up
       // TODO: It might be better if subtitle tracks were assigned the mediatype "texttrack" in the first place
       if (refElements.size() > 0) {
-        List<VideoClip> cleanclips = sortSegments(refElements);    // remove very short cuts that will look bad
+        // remove very short cuts that will look bad
+        List<VideoClip> cleanclips = sortSegments(refElements, segmentsMinDuration, segmentsMinCutDuration);
         String extension = FilenameUtils.getExtension(sourceTrackUri);
         if (VideoEditorProperties.WEBVTT_EXTENSION.equals(extension)) {
           // Parse
@@ -442,7 +456,8 @@ public class VideoEditorServiceImpl extends AbstractJobProducer implements Video
   /* Clean up the edit points, make sure they are at least 2 seconds apart (default fade duration)
    * Otherwise it can be very slow to run and output will be ugly because of the cross fades
    */
-  private static List<VideoClip> sortSegments(List<VideoClip> edits) {
+  private static List<VideoClip> sortSegments(List<VideoClip> edits, int segmentsMinDuration,
+      int segmentsMinCutDuration) {
     LinkedList<VideoClip> ll = new LinkedList<>();
     List<VideoClip> clips = new ArrayList<>();
     Iterator<VideoClip> it = edits.iterator();
@@ -450,7 +465,7 @@ public class VideoEditorServiceImpl extends AbstractJobProducer implements Video
     VideoClip nextclip;
     while (it.hasNext()) {     // Check for legal durations
       clip = it.next();
-      if (clip.getDurationInSeconds() > 2) { // Keep segments at least 2 seconds long
+      if (clip.getDurationInMilliseconds() > segmentsMinDuration) { // Keep segments at least 2 seconds long
         ll.add(clip);
       }
     }
@@ -459,8 +474,9 @@ public class VideoEditorServiceImpl extends AbstractJobProducer implements Video
       if (ll.peek() != null) {
         nextclip = ll.pop();  // check next consecutive segment
         // collapse two segments into one
-        if (nextclip.getSrc() == clip.getSrc() && nextclip.getStartInSeconds() - clip.getEndInSeconds() < 2) {
-          clip.setEnd(nextclip.getEndInMilliseconds());   // by using inpt of seg 1 and outpoint of seg 2
+        if (nextclip.getSrc() == clip.getSrc()
+            && nextclip.getStartInMilliseconds() - clip.getEndInMilliseconds() < segmentsMinCutDuration) {
+          clip.setEnd(nextclip.getEndInMilliseconds());   // by using input of seg 1 and outpoint of seg 2
         } else {
           clips.add(clip);   // keep last segment
           clip = nextclip;   // check next segment
@@ -567,6 +583,11 @@ public class VideoEditorServiceImpl extends AbstractJobProducer implements Video
     logger.debug("Properties updated!");
 
     jobload = LoadUtil.getConfiguredLoadValue(properties, JOB_LOAD_KEY, DEFAULT_JOB_LOAD, serviceRegistry);
+    segmentsMinDuration = (int) LoadUtil.getConfiguredLoadValue(properties, SEGMENTS_MIN_DURATION_KEY,
+        Float.valueOf(DEFAULT_SEGMENTS_MIN_DURATION), serviceRegistry);
+    segmentsMinCutDuration = (int) LoadUtil.getConfiguredLoadValue(properties, SEGMENTS_MIN_CUT_DURATION_KEY,
+        Float.valueOf(DEFAULT_SEGMENTS_MIN_CUT_DURATION), serviceRegistry);
+
   }
 
   @Reference


### PR DESCRIPTION
The editor WoH that applies the Opencast Built-in editor has some hidden configurations that are not user reachable.

These configurations are:

- Minimum segment duration: If a segment has a lower duration as this parameter, it will be discarded.
- Minimum Cut segment duration: If the cut between two segments is less than the threshold, it will be discarded.

The PR adds these two parameters to the `etc/org.opencastproject.videoeditor.impl.VideoEditorServiceImpl.cfg` file.

Ready for Review

~~It will keep as a draft because I need to fix this undesirable log message:~~

```
2023-10-06 15:07:15,981 | WARN  | (LoadUtil:95) - No hosts found that can process jobs of type segments.min.duration with load 100.0
2023-10-06 15:07:15,982 | WARN  | (LoadUtil:95) - No hosts found that can process jobs of type segments.min.cut.duration with load 100.0
```

~~That error is because I used the same method to read the properties as `jobLoad` variable. I will fix it soon.~~


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
