### PR TITLE
Fixes connection test on NCast Hydra with CA user

### DIFF
--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -325,6 +325,7 @@
     <sec:intercept-url pattern="/capture-admin/**" access="ROLE_ADMIN, ROLE_CAPTURE_AGENT" />
     <sec:intercept-url pattern="/recordings/**" method="GET" access="ROLE_ADMIN, ROLE_CAPTURE_AGENT" />
     <sec:intercept-url pattern="/ingest/**" access="ROLE_ADMIN, ROLE_CAPTURE_AGENT, ROLE_STUDIO" />
+    <sec:intercept-url pattern="/workflow/definitions.xml" method="GET" access="ROLE_ADMIN, ROLE_CAPTURE_AGENT" />
 
     <!-- Secure the user management URLs for admins only -->
     <sec:intercept-url pattern="/users/**" access="ROLE_ADMIN" />


### PR DESCRIPTION
The connection test on NCast Hydra devices call /workflow/definitions.xml endpoint. If you have configured an unprivileged capture agent digest user, the test will always fail because the endpoint security enforce users to be admins. You can test it yourself by uncommenting the line [capture_agent.user...](https://github.com/opencast/opencast/blob/60576c4c9acdba0ad00f37819b8bc5d0d328e543/etc/org.opencastproject.userdirectory.InMemoryUserAndRoleProvider.cfg#L18) and call curl:

```
curl -i --digest -u opencast_capture_agent:some_password -H "X-Requested-Auth: Digest"   http://localhost:8080/workflow/definitions.xml
```

Before, the response was `http/403`, with this patch the response is `http/200` and workflow definitions xml as body.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
