### PR TITLE
#5663 Paella7 patches frameList undefined exception

### DIFF
--- a/modules/engage-paella-player-7/src/js/EpisodeConversor.js
+++ b/modules/engage-paella-player-7/src/js/EpisodeConversor.js
@@ -223,77 +223,97 @@ function processSegments(episode, manifest) {
   }
 }
 
+// Extract the player preview to show prior to loading videos
 export function getVideoPreview(mediapackage, config) {
   const { attachments } = mediapackage;
-  let videoPreview = null;
+  let playerPreviewImage = null;
 
   let attachment = attachments?.attachment || [];
   if (!Array.isArray(attachment)) {
     attachment = [attachment];
   }
 
-  const videoPreviewAttachments = config.videoPreviewAttachments || [
+  const playerPreviewImageAttachments = config.playerPreviewImageAttachments || [
     'presenter/player+preview',
     'presentation/player+preview'
   ];
+
   attachment.forEach(att => {
-    videoPreviewAttachments.some(validAttachment => {
+    playerPreviewImageAttachments.some(validAttachment => {
       if (validAttachment === att.type) {
-        videoPreview = att.url;
+        playerPreviewImage = att.url;
       }
-      return videoPreview !== null;
+      return playerPreviewImage !== null;
     });
   });
   // Get first preview if no predefined was found
-  if (videoPreview === null) {
+  if (playerPreviewImage === null) {
     const firstPreviewAttachment = attachment.find(att => {
       return att.type.split('/').pop() === 'player+preview';
     });
-    videoPreview = firstPreviewAttachment?.url ?? null;
+    playerPreviewImage = firstPreviewAttachment?.url ?? null;
   }
 
-  return videoPreview;
+  return playerPreviewImage;
 }
 
 function processAttachments(episode, manifest, config) {
   const { attachments } = episode.mediapackage;
-  const previewImages = [];
-  let videoPreview = null;
+  const navigationPreviewImages = [];
+  let playerPreviewImage = null;
 
   let attachment = attachments?.attachment || [];
   if (!Array.isArray(attachment)) {
     attachment = [attachment];
   }
 
-  const previewAttachment = config.previewAttachment || 'presentation/segment+preview';
+  // Fallback array of segment preview images, when config flavor is not found
+  let previewAttachments = config.previewAttachment || [
+    'presenter/segment+preview',
+    'presentation/segment+preview'
+  ];
+  // Ensure format is array, incase config flavor was a string
+  if (!(previewAttachments instanceof Array)) {
+    previewAttachments = [previewAttachments];
+  }
+  // Capture the video flavor of the segment preview images, used when
+  // overlaying preview images on the video container
+  let targetContent;
   attachment.forEach(att => {
     const timeRE = /time=T(\d+):(\d+):(\d+)/.exec(att.ref);
-    if (att.type === previewAttachment && timeRE) {
+    // By default, Opencast workflows create segment preview slides for one media.
+    // However, the following might cause duplicates if your workflow creates navigation
+    // preview slides for all videos in a mediapackage.
+    if (previewAttachments.includes(att.type) && timeRE) {
       const h = Number(timeRE[1]) * 60 * 60;
       const m = Number(timeRE[2]) * 60;
       const s = Number(timeRE[3]);
       const t = h + m + s;
-      previewImages.push({
+      navigationPreviewImages.push({
         mimetype: att.mimetype,
         url: att.url,
         thumb: att.url,
         id: `frame_${t}`,
         time: t
       });
+      // Capture the target flavor (e.g. 'presenter', 'presentation', etc)
+      targetContent = att.type.split('/')[0];
     }
-    else {
-      videoPreview = getVideoPreview(episode.mediapackage, config);
+    else if (playerPreviewImage === null) {
+      playerPreviewImage = getVideoPreview(episode.mediapackage, config);
     }
   });
 
-  if (previewImages.length > 0) {
-    manifest.frameList = previewImages;
-  }
-
-  if (videoPreview) {
-    manifest.metadata = manifest.metadata || {};
-    manifest.metadata.preview = videoPreview;
-  }
+  // Define frameList, even when there are no navigation segment preview slides
+  // Include the video target, used to position the navigation frame
+  // Otherwise the target video for navigation slides might not be found.
+  // https://github.com/polimediaupv/paella-core/blob/main/src/js/core/ManifestParser.js#L101-L114
+  manifest.frameList = {};
+  manifest.frameList.frames = navigationPreviewImages || [];
+  manifest.frameList.targetContent = targetContent;
+  // Define manifest metadata even if a player preview image doesn't exist
+  manifest.metadata = manifest.metadata || {};
+  manifest.metadata.preview = playerPreviewImage;
 }
 
 function readCaptions(potentialNewCaptions, captions) {

--- a/pom.xml
+++ b/pom.xml
@@ -1527,7 +1527,7 @@
     <developer>
       <id>karen</id>
       <name>Karen Dolan</name>
-      <email>kdolan@dce.harvard.edu</email>
+      <email>karen_dolan@harvard.edu</email>
       <organization>Harvard University, Division of Continuing Education</organization>
       <organizationUrl>http://www.dce.harvard.edu</organizationUrl>
       <roles>


### PR DESCRIPTION
### Your pull request should…

* [1/2] have a concise title
* [x ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x ] pass automated tests
* [ x] have a clean commit history
* [x ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)

This patch fixes issues:
1. For sites that publish either "presenter" OR "presentation" or both, to have preview slides, by changing the fixed ONE type of flavor for navigation slides to be a fallback array, and also allowing the config list to be an array instead of a single string.
2. The paella-core issue of https://github.com/polimediaupv/paella-core/issues/343 that throws a fatal undefined exception when the manifest.frameList is undefined, by sending an empty array when neither the config NOR the fallback presenter NOR presentation has any "segment+preview" flavored images
3. Corrects Karen Dolan's committer email in the main pom
4. Adds a question about the recursion loop `f4454f61f2f (Dennis Benz         2023-07-20 21:29:55 +0200 295)       videoPreview = getVideoPreview(episode.mediapackage, config);`