### PR TITLE
Update Editor to 2023-10-17

### DIFF
--- a/etc/ui-config/mh_default_org/editor/editor-settings.toml
+++ b/etc/ui-config/mh_default_org/editor/editor-settings.toml
@@ -101,7 +101,7 @@
 [subtitles.languages]
 ## A list of languages for which new subtitles can be created
 # For each language, various tags can be specified
-# A list of officially recommended tags can be found at: TODO: link to opencast documentation for subtitle tags
+# A list of officially recommended tags can be found at https://docs.opencast.org/develop/admin/#modules/subtitles/#tags
 # At least the "lang" tag MUST be specified
 german = { lang = "de-DE" }
 english = { lang = "en-US", type = "closed-caption" }

--- a/etc/ui-config/mh_default_org/editor/editor-settings.toml
+++ b/etc/ui-config/mh_default_org/editor/editor-settings.toml
@@ -2,6 +2,34 @@
 # Opencast Stand-alone Video Editor
 ##
 
+# This file contains the editord default configuration and our recommendation for production use.
+# All values in here aer set to their defaults.
+
+# ⚠️  When deployed, this file is publicly accessibly!
+
+
+####
+# General Settings
+##
+
+# Allowed prefixes in callback urls to prevent malicious urls
+# If empty, no callback url is allowed
+# Type: string[]
+# Default: []
+#allowedCallbackPrefixes = []
+
+# Url to go back after finishing editing
+# If undefined, no return link will be shown on the end pages
+# Type: string | undefined
+# Default: undefined
+#callbackUrl =
+
+# Name of system to go back to
+# If undefined, a generic system name is used instead of a speficic name
+# Type: string | undefined
+# Default: undefined
+#callbackSystem =
+
 
 ####
 # Metadata
@@ -71,18 +99,21 @@
 #mainFlavor = "captions"
 
 [subtitles.languages]
-## A list of languages for which subtitles can be created
-"captions/source+de" = "Deutsch"
-"captions/source+en" = "English"
-"captions/source+es" = "Español"
+## A list of languages for which new subtitles can be created
+# For each language, various tags can be specified
+# A list of officially recommended tags can be found at: TODO: link to opencast documentation for subtitle tags
+# At least the "lang" tag MUST be specified
+german = { lang = "de-DE" }
+english = { lang = "en-US", type = "closed-caption" }
+spanish = { lang = "es" }
 
 [subtitles.icons]
 # A list of icons to be displayed for languages defined above.
 # Values are strings but should preferably be Unicode icons.
 # These are optional and you can also choose to have no icons.
-"captions/source+de" = "🇩🇪"
-"captions/source+en" = "🇺🇸"
-"captions/source+es" = "🇪🇸"
+"de-DE" = "DE"
+"en-US" = "EN"
+"es" = "ES"
 
 [subtitles.defaultVideoFlavor]
 # Specify the default video in the subtitle video player by flavor

--- a/modules/editor/pom.xml
+++ b/modules/editor/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <editor.url>https://github.com/opencast/opencast-editor/releases/download/2023-04-20/oc-editor-2023-04-20.tar.gz</editor.url>
-    <editor.sha256>91ced444262b1d40506fd53c5ca5141c34b1578befc16993ca82e207305942d4</editor.sha256>
+    <editor.url>https://github.com/opencast/opencast-editor/releases/download/2023-10-17/oc-editor-2023-10-17.tar.gz</editor.url>
+    <editor.sha256>77b2b5842d14d7f33125e47ea035292b009b0cb8aa1b253c6051c18700c346ac</editor.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
The biggest (and most obvious) change is the graphical redesign, akin to #5318. Furthermore, this also makes the editor work with the changes to subtitles coming with Opencast 15.

This goes into develop as most agreed that the redesign is too big of a change to release it as a minor version.

Known major issues (may or may not be related to this release):
- opencast/opencast-editor#1154
- opencast/opencast-editor#1161

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
