### PR TITLE
Add option to pass additional args to Whisper

### DIFF
--- a/etc/org.opencastproject.speechtotext.impl.engine.WhisperEngine.cfg
+++ b/etc/org.opencastproject.speechtotext.impl.engine.WhisperEngine.cfg
@@ -7,6 +7,10 @@
 # Default: base
 #whisper.model=base
 
+# Additional args to pass to Whisper separated by spaces
+# Default: none
+#whisper.args=
+
 ### Additional config options for whisper-ctranslate2
 # The following options are for use with whisper-ctranslate2.
 # Will only work when using whisper-ctranslate2 and lead to exceptions otherwise!

--- a/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/WhisperEngine.java
+++ b/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/WhisperEngine.java
@@ -95,6 +95,11 @@ public class WhisperEngine implements SpeechToTextEngine {
   /** Enable Voice Activity Detection for whisper-ctranslate2 */
   private Option<Boolean> isVADEnabled = Option.none();
 
+  /** Config key for additional Whisper args */
+  private static final String WHISPER_ARGS_CONFIG_KEY = "whisper.args";
+
+  /** Currently used Whisper args */
+  private String[] whisperArgs = {};
 
   @Override
   public String getEngineName() {
@@ -121,6 +126,14 @@ public class WhisperEngine implements SpeechToTextEngine {
 
     isVADEnabled = OsgiUtil.getOptCfgAsBoolean(cc.getProperties(), WHISPER_VAD);
     logger.debug("Whisper Voice Activity Detection  set to {}", isVADEnabled);
+
+    String whisperArgsString = (String) cc.getProperties().get(WHISPER_ARGS_CONFIG_KEY);
+    if (!StringUtils.isBlank(whisperArgsString)) {
+      logger.debug("Additional args for Whisper configured: {}", whisperArgsString);
+      whisperArgs = whisperArgsString.trim().split("\\s+");
+    } else {
+      logger.debug("No additional args for Whisper configured.");
+    }
 
     logger.debug("Finished activating/updating speech-to-text service");
   }
@@ -169,6 +182,8 @@ public class WhisperEngine implements SpeechToTextEngine {
       command.add("--vad_filter");
       command.add(isVADEnabled.get().toString());
     }
+
+    command.addAll(Arrays.asList(whisperArgs));
 
     logger.info("Executing Whisper's transcription command: {}", command);
 


### PR DESCRIPTION
This allows us to pass additional arguments to Whisper without having to deal with every single option separately. 

For example, I'm using this to pass the location for the model to Whisper with `--model_dir`, since at least whisper-ctranslate2 defaults to the home directory of the user... but if your user doesn't have a home directory, this doesn't work. This is also the reason I'm aiming this at 13.x, though this might be controversial.
