### PR TITLE
Youtube-Publication: Throw explicit error if client_secret is malformed

### DIFF
--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
@@ -179,6 +179,8 @@ public class YouTubeV3PublicationServiceImpl
   public synchronized void activate(final ComponentContext cc) {
     super.activate(cc);
     properties.setBundleContext(cc.getBundleContext());
+
+    logger.debug("Activated Youtube Publication Service");
   }
 
   @Override

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
@@ -180,7 +180,7 @@ public class YouTubeV3PublicationServiceImpl
     super.activate(cc);
     properties.setBundleContext(cc.getBundleContext());
 
-    logger.debug("Activated Youtube Publication Service");
+    logger.debug("Activated YouTube Publication Service");
   }
 
   @Override

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/auth/ClientCredentials.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/auth/ClientCredentials.java
@@ -95,19 +95,19 @@ public final class ClientCredentials {
    * @throws java.io.FileNotFoundException
    * @throws java.io.IOException
    */
-  private String getValueFromArray(final File file) throws IOException, ParseException {
+  private String getValueFromArray(final File file) throws IOException, ParseException, IllegalArgumentException {
     final JSONParser parser = new JSONParser();
     final FileReader reader = new FileReader(file);
     final JSONObject jsonObject = (JSONObject) parser.parse(reader);
 
     if (!jsonObject.containsKey("installed")) {
-      throw new IOException("client_secret file does not contain \"installed\" as a top level key. Did you set the "
-          + "type for your 'OAuth 2.0-Client-ID' correctly?");
+      throw new IllegalArgumentException("client_secret file does not contain \"installed\" as a top level key. Did you"
+          + "set the type for your 'OAuth 2.0-Client-ID' correctly?");
     }
     final JSONObject array = (JSONObject) jsonObject.get("installed");
 
     if (!array.containsKey("client_id")) {
-      throw new IOException("client_secret file does not contain \"client_id\".");
+      throw new IllegalArgumentException("client_secret file does not contain \"client_id\".");
     }
     return (String) array.get("client_id");
   }

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/auth/ClientCredentials.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/auth/ClientCredentials.java
@@ -91,9 +91,10 @@ public final class ClientCredentials {
    *
    * @param file
    *          file to parse
-   * @return matching value, or null if no match or there was a parse exception
+   * @return matching value. Throws an exception if there is no matching value.
    * @throws java.io.FileNotFoundException
    * @throws java.io.IOException
+   * @throws java.lang.IllegalArgumentException
    */
   private String getValueFromArray(final File file) throws IOException, ParseException, IllegalArgumentException {
     final JSONParser parser = new JSONParser();

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/auth/ClientCredentials.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/auth/ClientCredentials.java
@@ -99,7 +99,16 @@ public final class ClientCredentials {
     final JSONParser parser = new JSONParser();
     final FileReader reader = new FileReader(file);
     final JSONObject jsonObject = (JSONObject) parser.parse(reader);
+
+    if (!jsonObject.containsKey("installed")) {
+      throw new IOException("client_secret file does not contain \"installed\" as a top level key. Did you set the "
+          + "type for your 'OAuth 2.0-Client-ID' correctly?");
+    }
     final JSONObject array = (JSONObject) jsonObject.get("installed");
+
+    if (!array.containsKey("client_id")) {
+      throw new IOException("client_secret file does not contain \"client_id\".");
+    }
     return (String) array.get("client_id");
   }
 


### PR DESCRIPTION
Parsing of the client_secret.json may go wrong, but currently the stack trace is not very helpful in making clear when that happens. This should help.
