### PR TITLE
Set generator tags in speech-to-text WOH

### DIFF
--- a/docs/guides/admin/docs/releasenotes/speech-to-text-tags.txt
+++ b/docs/guides/admin/docs/releasenotes/speech-to-text-tags.txt
@@ -1,0 +1,2 @@
+The `generator` and `generator-type` tags will be set automatically by the speech-to-text WOH and no longer have to be
+configured in the workflow.

--- a/docs/guides/admin/docs/workflowoperationhandlers/speechtotext-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/speechtotext-woh.md
@@ -14,15 +14,15 @@ engines available, [Whisper](../modules/transcription.modules/whisper.md) and
 Parameter Table
 ---------------
 
-| configuration keys | required | Example           | description                                                                                                                                        |
-|--------------------|----------|-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
-| source-flavor      | yes      | source/presenter  | The source media package to use                                                                                                                    |
-| target-flavor      | yes      | archive           | Flavor of the produced subtitle file.                                                                                                              |
-| target-element     | no       | track             | Define where to append the subtitles file. Possibilities are: as a 'track' or as an 'attachment'. The default is "track".                          |
-| language-code      | no       | de                | The language of the video or audio source (default is "eng"). Vosk only: It has to match the name of the language model directory. See 'vosk-cli'. |
-| language-fallback  | yes*     | en                | The fallback value if the dublin core/media package language field is not present.                                                                 |
-| target-tags        | no       | delivery/captions | Tags for the subtitle file** (Whisper only: If no `language-code`,the tag `lang:{code}` will be auto generated)                                    |
-| translate          | no       | true              | Transcription is translated into English, valid values `true` or `false` (Whisper Only)                                                            |
+| configuration keys | required | Example           | description                                                                                                                                                                             |
+|--------------------|----------|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| source-flavor      | yes      | source/presenter  | The source media package to use                                                                                                                                                         |
+| target-flavor      | yes      | archive           | Flavor of the produced subtitle file.                                                                                                                                                   |
+| target-element     | no       | track             | Define where to append the subtitles file. Possibilities are: as a 'track' or as an 'attachment'. The default is "track".                                                               |
+| language-code      | no       | de                | The language of the video or audio source (default is "eng"). Vosk only: It has to match the name of the language model directory. See 'vosk-cli'.                                      |
+| language-fallback  | yes*     | en                | The fallback value if the dublin core/media package language field is not present.                                                                                                      |
+| target-tags        | no       | delivery/captions | Tags for the subtitle file.** The `generator` and `generator-type` tags will be set automatically. (Whisper only: If no `language-code` is set, the `lang` tag will be auto-generated.) |
+| translate          | no       | true              | Transcription is translated into English, valid values `true` or `false` (Whisper Only)                                                                                                 |
 
 
 *Vosk Only, default value can be modified on Vosk config file.

--- a/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/SpeechToTextServiceImpl.java
+++ b/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/SpeechToTextServiceImpl.java
@@ -175,7 +175,7 @@ public class SpeechToTextServiceImpl extends AbstractJobProducer implements Spee
         FileUtils.deleteQuietly(subtitlesFile);
       }
     }
-    return subtitleFilesURI.toString() + "," + language;
+    return subtitleFilesURI.toString() + "," + language + "," + speechToTextEngine.getEngineName();
   }
 
 

--- a/modules/speech-to-text-workflowoperation/src/main/java/org/opencastproject/workflow/handler/speechtotext/SpeechToTextWorkflowOperationHandler.java
+++ b/modules/speech-to-text-workflowoperation/src/main/java/org/opencastproject/workflow/handler/speechtotext/SpeechToTextWorkflowOperationHandler.java
@@ -194,6 +194,7 @@ public class
       String[] jobOutput = job.getPayload().split(",");
       URI output = new URI(jobOutput[0]);
       String outputLanguage = jobOutput[1];
+      String engineType = jobOutput[2];
 
       String mediaPackageIdentifier = UUID.randomUUID().toString();
 
@@ -218,6 +219,8 @@ public class
 
       List<String> targetTags = tagsAndFlavors.getTargetTags();
       targetTags.add("lang:" + outputLanguage);
+      targetTags.add("generator-type:auto");
+      targetTags.add("generator:" + engineType.toLowerCase());
 
       // this is used to set some values automatically, like the correct mimetype
       Job inspection = mediaInspectionService.enrich(subtitleMediaPackageElement, true);


### PR DESCRIPTION
Since we know the subtitles were automatically generated and by which engine, might as well set the respective tags so we don't have to do that in the workflow.
