### PR TITLE
Remove metadata layer from preview image (presenter)

### DIFF
--- a/docs/guides/admin/docs/releasenotes/remove-metadata-from-image.txt
+++ b/docs/guides/admin/docs/releasenotes/remove-metadata-from-image.txt
@@ -1,0 +1,3 @@
+The default workflow for publishing videos will no longer render the video metadata on the preview Image.
+Instead, a simple cover image without any text will be created and displayed.
+You can revert this by simply adding the "coverimage" WOH back to the "partial-publish" workflow (look out for the target-flavor and tags).

--- a/etc/workflows/partial-publish.xml
+++ b/etc/workflows/partial-publish.xml
@@ -163,35 +163,21 @@
     </operation>
 
 
-    <!-- Create a cover image with the default template -->
+    <!-- Create a cover image -->
 
     <operation
-      id="image"
-      exception-handler-workflow="partial-error"
-      description="Creating player preview image for presenter video">
+        id="image"
+        exception-handler-workflow="partial-error"
+        description="Creating player preview image for presenter video">
       <configurations>
         <configuration key="source-flavor">presenter/trimmed</configuration>
-        <configuration key="target-flavor">presenter/coverbackground</configuration>
+        <configuration key="target-flavor">presenter/player+preview</configuration>
+        <configuration key="target-tags">engage-download</configuration>
         <configuration key="encoding-profile">player-preview.http</configuration>
         <configuration key="time">3</configuration>
       </configurations>
     </operation>
 
-    <operation
-      id="cover-image"
-      if="${presenter_work_media}"
-      fail-on-error="true"
-      exception-handler-workflow="partial-error"
-      description="Create a cover image">
-      <configurations>
-        <configuration key="stylesheet">file://${karaf.etc}/branding/coverimage.xsl</configuration>
-        <configuration key="width">1920</configuration>
-        <configuration key="height">1080</configuration>
-        <configuration key="posterimage-flavor">presenter/coverbackground</configuration>
-        <configuration key="target-flavor">presenter/player+preview</configuration>
-        <configuration key="target-tags">engage-download</configuration>
-     </configurations>
-    </operation>
 
     <!-- Generate timeline preview images -->
 


### PR DESCRIPTION
This PR removes the WOH `cover-image` from the default `partial-publish` workflow. The presenter preview image will no longer contain any metadata. Here is the [discussion](https://groups.google.com/a/opencast.org/g/users/c/42vfpsuFjXY) to this topic. 