### PR TITLE
Get thumbnail for editor frontend from archive

### DIFF
--- a/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
+++ b/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
@@ -1007,12 +1007,26 @@ public class EditorServiceImpl implements EditorService {
       final TrackSubData video = new TrackSubData(track.hasVideo(), videoPreview,
                         videoEnable);
 
-      final String thumbnailURI = Arrays.stream(internalPub.getAttachments())
-              .filter(attachment -> attachment.getFlavor().getType().equals(track.getFlavor().getType()))
-              .filter(attachment -> attachment.getFlavor().getSubtype().equals(getThumbnailSubtype()))
-              .map(MediaPackageElement::getURI).map(this::signIfNecessary)
-              .findAny()
-              .orElse(null);
+      // Get thumbnail from archive
+      // If a thumbnail got generated in the frontend, it will be saved to the archive. So if no workflow runs,
+      // the saved, thumbnail will not show up in the frontend if we get it from the internal publication
+      String thumbnailURI = Arrays.stream(mp.getAttachments())
+          .filter(attachment -> attachment.getFlavor().getType().equals(track.getFlavor().getType()))
+          .filter(attachment -> attachment.getFlavor().getSubtype().equals(getThumbnailSubtype()))
+          .map(MediaPackageElement::getURI).map(this::signIfNecessary)
+          .findAny()
+          .orElse(null);
+
+      // If thumbnail is not in archive, try getting it from the internal publication
+      // Because our default workflows don't save thumbnails in the archive but only publish them.
+      if (thumbnailURI == null) {
+        thumbnailURI = Arrays.stream(internalPub.getAttachments())
+            .filter(attachment -> attachment.getFlavor().getType().equals(track.getFlavor().getType()))
+            .filter(attachment -> attachment.getFlavor().getSubtype().equals(getThumbnailSubtype()))
+            .map(MediaPackageElement::getURI).map(this::signIfNecessary)
+            .findAny()
+            .orElse(null);
+      }
 
       final int priority = thumbnailSourcePrimary.indexOf(track.getFlavor());
 


### PR DESCRIPTION
Intends to fix https://github.com/opencast/opencast-editor/issues/1154

When generating a thumbnail in the editor frontend, saving it and then reloading the editor, the generated thumbnail would not show up. This is because thumbnails are loaded from the internal publication, but the generated thumbnails are only saved to the archive.

This changes it so that thumbnails are loaded from the archive. If they cannot be found there, they are loaded from the internal publication instead.
