### PR TITLE
Avoid a potential nullpointer exception in thumbnail generation

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/impl/ThumbnailImpl.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/impl/ThumbnailImpl.java
@@ -462,15 +462,22 @@ public final class ThumbnailImpl {
 
     final Collection<URI> deletionUris = new ArrayList<>(0);
     try {
+      boolean downscale;
       if (optPreview.isPresent()) {
         createTempThumbnail(mp, optPreview.get().getA(), optPreview.get().getB());
         archive(mp);
+        downscale = false;
+      } else {
+        tempThumbnail = composerService.imageSync(track, this.masterProfile, position).get(0).getURI();
+        tempThumbnailMimeType = MimeTypes.fromURI(tempThumbnail);
+        tempThumbnailFileName = tempThumbnail.getPath().substring(tempThumbnail.getPath().lastIndexOf('/') + 1);
+        downscale = true;
       }
 
       // Remove any uploaded thumbnails
       Arrays.stream(mp.getElementsByFlavor(uploadedFlavor)).forEach(mp::remove);
 
-      final Tuple<URI, List<MediaPackageElement>> internalPublicationResult = updateInternalPublication(mp, false);
+      final Tuple<URI, List<MediaPackageElement>> internalPublicationResult = updateInternalPublication(mp, downscale);
       deletionUris.add(internalPublicationResult.getA());
 
       if (distributionConfigurable.getEnabled()) {


### PR DESCRIPTION
One of our clients had a bug in Opencast 14.4 when using the old editor (the editor integrated in the old admin ui (the admin ui based on angularjs). When they tried to start processing the changes with a workflow, this would fail with a nullpointer exception.

This attempts to fix the exception, by setting `tempThumbnail` to something in case `optPreview.isPresent()` is `false`. Because code later down the line expects this semi-global variable to be set to something.

I have no idea if this actually fixes the issue, since our client could also solve the issue by simply turning off thumbnails in the editor altogether. Furthermore, I could not reproduce their issue. So the only thing I could test is that this does not break anything :/. Still, I'll leave this here in case anyone else runs into the same issue.

