### PR TITLE
add chevron to <details> in docs

### DIFF
--- a/docs/guides/admin/docs/css/extra.css
+++ b/docs/guides/admin/docs/css/extra.css
@@ -167,6 +167,21 @@ details {
   margin-left: 10px;
 }
 
+details summary::after {
+  position: relative;
+  top: 1px;
+  font-family: 'Glyphicons Halflings';
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1;
+  padding-left: 1ex;
+  content: '\e114'; /* glyphicon-chevron-down*/
+}
+
+details[open] summary::after {
+  content: '\e113'; /* glyphicon-chevron-up*/
+}
+
 details summary {
   color: darkblue;
   cursor: pointer;


### PR DESCRIPTION
This adds a little up/down chevron using the glyphicons font, making it easier to spot and also shows the current status: folded/unfolded.

### Your pull request should…

* [x] have a concise title
* [x] ~~[close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] ~~include migration scripts and documentation, if appropriate~~
* [x] pass automated tests
* [x] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
