### PR TITLE
Add calendar link, and sysadmin meeting to docs.opencast.org

### DIFF
--- a/docs/guides/.infrastructure/index.html.j2
+++ b/docs/guides/.infrastructure/index.html.j2
@@ -141,7 +141,7 @@
         </div>
         <div class="col-md-6">
           <h4>Meetings</h4>
-          <p>Our meeting calendar can be found <a href="https://calendar.google.com/calendar/u/0?cid=b3BlbmNhc3Qub3JnX3RqZTJmbTM0ZXJubmJtMGY5c2Fpb2dwOGcwQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20">here</a>, and consists mainly of two meetings
+          <p>Our meeting calendar can be found <a href="https://calendar.google.com/calendar/ical/opencast.org_tje2fm34ernnbm0f9saiogp8g0%40group.calendar.google.com/public/basic.ics">here</a>, and consists mainly of two meetings
         <div class="col-md-6">
           <h5>Technical meeting</h5>
           <p>Our weekly open meeting of developers and dev-ops takes place on
@@ -154,9 +154,7 @@
           <h5>SysAdmin meeting</h5>
           <p>Last Wednesday of every month, adopters and sys-admins meet on
           <a href="https://opencast.blindsidenetworks.net">meet.opencast.video</a> (room 1, p: welcome).
-          The goal of this meeting is to talk about current challenges, as well as upcoming development and testing coordination.  If you run Opencast, or are thinking about doing so, this is the meeting to attend.
-          Meetings are usually
-          <a href="https://opencast.blindsidenetworks.net/opencast/recordings-5720cd14621.jsp">recorded</a>.</p>
+          The goal of this meeting is to talk about current challenges, as well as upcoming development and testing coordination.  If you run Opencast, or are thinking about doing so, this is the meeting to attend.</p>
         </div>
       </div>
 

--- a/docs/guides/.infrastructure/index.html.j2
+++ b/docs/guides/.infrastructure/index.html.j2
@@ -140,20 +140,22 @@
           <a href="https://matrix.to/#/#opencast-community:matrix.org"><em>#opencast-community:matrix.org</em></a>.</p>
         </div>
         <div class="col-md-6">
-          <h4>Technical meeting</h4>
+          <h4>Meetings</h4>
+          <p>Our meeting calendar can be found <a href="https://calendar.google.com/calendar/u/0?cid=b3BlbmNhc3Qub3JnX3RqZTJmbTM0ZXJubmJtMGY5c2Fpb2dwOGcwQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20">here</a>, and consists mainly of two meetings
+        <div class="col-md-6">
+          <h5>Technical meeting</h5>
           <p>Our weekly open meeting of developers and dev-ops takes place on
           <a href="https://opencast.blindsidenetworks.net">meet.opencast.video</a> (room 1, p: welcome) on every
           Tuesday at
           <a href="https://arewemeetingyet.com/UTC/2019-02-26/15:15/w/Opencast's%20Technical%20Meeting#eyJ1cmwiOiJodHRwczovL29wZW5jYXN0LmJsaW5kc2lkZW5ldHdvcmtzLm5ldCJ9">
-            3:15pm UTC</a>.</p>
+            3:15pm UTC</a>.  This is where you want to be to talk technical Opencast issues with developers.</p>
         </div>
         <div class="col-md-6">
-          <h4>Adopters meeting</h4>
-          <p>Every last Wednesday of a month, adopters meet on
+          <h5>SysAdmin meeting</h5>
+          <p>Last Wednesday of every month, adopters and sys-admins meet on
           <a href="https://opencast.blindsidenetworks.net">meet.opencast.video</a> (room 1, p: welcome).
-          The meeting alternates between the international adopters meeting at 3pm UTC
-          and the German speaking community meeting at 2pm Europe/Berlin timezone.
-          Watch the users list for announcements and feel free to join! Meetings are usually
+          The goal of this meeting is to talk about current challenges, as well as upcoming development and testing coordination.  If you run Opencast, or are thinking about doing so, this is the meeting to attend.
+          Meetings are usually.</p>
           <a href="https://opencast.blindsidenetworks.net/opencast/recordings-5720cd14621.jsp">recorded</a>.</p>
         </div>
       </div>

--- a/docs/guides/.infrastructure/index.html.j2
+++ b/docs/guides/.infrastructure/index.html.j2
@@ -155,7 +155,7 @@
           <p>Last Wednesday of every month, adopters and sys-admins meet on
           <a href="https://opencast.blindsidenetworks.net">meet.opencast.video</a> (room 1, p: welcome).
           The goal of this meeting is to talk about current challenges, as well as upcoming development and testing coordination.  If you run Opencast, or are thinking about doing so, this is the meeting to attend.
-          Meetings are usually.</p>
+          Meetings are usually
           <a href="https://opencast.blindsidenetworks.net/opencast/recordings-5720cd14621.jsp">recorded</a>.</p>
         </div>
       </div>

--- a/docs/guides/.infrastructure/index.html.j2
+++ b/docs/guides/.infrastructure/index.html.j2
@@ -143,17 +143,15 @@
           <h4>Meetings</h4>
           <p>Our meeting calendar can be found <a href="https://calendar.google.com/calendar/ical/opencast.org_tje2fm34ernnbm0f9saiogp8g0%40group.calendar.google.com/public/basic.ics">here</a>, and consists mainly of two meetings
         <div class="col-md-6">
-          <h5>Technical meeting</h5>
-          <p>Our weekly open meeting of developers and dev-ops takes place on
-          <a href="https://opencast.blindsidenetworks.net">meet.opencast.video</a> (room 1, p: welcome) on every
-          Tuesday at
-          <a href="https://arewemeetingyet.com/UTC/2019-02-26/15:15/w/Opencast's%20Technical%20Meeting#eyJ1cmwiOiJodHRwczovL29wZW5jYXN0LmJsaW5kc2lkZW5ldHdvcmtzLm5ldCJ9">
-            3:15pm UTC</a>.  This is where you want to be to talk technical Opencast issues with developers.</p>
+          <h5>Dev meeting</h5>
+          <p>Our weekly open meeting of developers and dev-ops takes place at
+          <a href="https://opencast.blindsidenetworks.net">meet.opencast.video</a> (room 1, p: welcome), check the calendar link above for dates and times.
+          This is where you want to be to talk technical Opencast issues with developers.</p>
         </div>
         <div class="col-md-6">
           <h5>SysAdmin meeting</h5>
-          <p>Last Wednesday of every month, adopters and sys-admins meet on
-          <a href="https://opencast.blindsidenetworks.net">meet.opencast.video</a> (room 1, p: welcome).
+          <p>Monthly adopters and sys-admins meeting at
+          <a href="https://opencast.blindsidenetworks.net">meet.opencast.video</a> (room 1, p: welcome), check the calendar link above for dates and times.
           The goal of this meeting is to talk about current challenges, as well as upcoming development and testing coordination.  If you run Opencast, or are thinking about doing so, this is the meeting to attend.</p>
         </div>
       </div>


### PR DESCRIPTION
This PR:
- Adds the community calendar as a link in the root of docs.opencast.org
- Massages the meeting section to make is easier (IMO) to read
- Adds the Sysadmin meeting to the list of meetings


### Your pull request should…

* [X] have a concise title
* ~[ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* ~[ ] include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
