### PR TITLE
Fail on broken configuration

### DIFF
--- a/etc/org.opencastproject.external.endpoint.EventsEndpoint.cfg
+++ b/etc/org.opencastproject.external.endpoint.EventsEndpoint.cfg
@@ -2,7 +2,7 @@
 # from the external api events endpoint until its signed URL will expire.
 # Default is 7200 seconds (2 hours) which should give the user more than enough
 # time to access the content.
-# url.signing.expires.seconds=7200
+#url.signing.expires.seconds=7200
 
 # Episode start date meta data field format to use for external API
 # Remove if you want to have the same format as in admin-ui.

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -156,6 +156,7 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
@@ -359,19 +360,15 @@ public class EventsEndpoint implements ManagedService {
   public void updated(Dictionary<String, ?> properties) throws ConfigurationException {
     // Ensure properties is not null
     if (properties == null) {
-      properties = new Hashtable();
+      properties = new Hashtable<>();
       logger.debug("No configuration set");
     }
 
     // Read URL Signing Expiration duration
     // Default to DEFAULT_URL_SIGNING_EXPIRE_DURATION.toString()));
-    try {
-      expireSeconds = Long.parseLong(StringUtils.defaultString(
-              (String) properties.get(URL_SIGNING_EXPIRES_DURATION_SECONDS_KEY),
-              DEFAULT_URL_SIGNING_EXPIRE_DURATION.toString()));
-    } catch (NumberFormatException e) {
-      logger.error("Error parsing URL signing expiration configuration value", e);
-    }
+    expireSeconds = Long.parseLong(Objects.toString(
+        properties.get(URL_SIGNING_EXPIRES_DURATION_SECONDS_KEY),
+        DEFAULT_URL_SIGNING_EXPIRE_DURATION.toString()));
     logger.debug("URLs signatures are configured to expire in {}.", DateTimeSupport.humanReadableTime(expireSeconds));
 
     // Read preview subtype configuration


### PR DESCRIPTION
Instead of skipping over a broken configuration, leaving the service in an unknown state, this patch makes the configuration update of the events endpoint fail if the configuration is invalid. This way, an admin should realize immediately that there is a problem and can fix it.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
