### PR TITLE
Fix access policy tab always showing unsaved changes

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
@@ -221,6 +221,7 @@ angular.module('adminNg.controllers')
               UserResource.get({ username: id }).$promise.then(function (data) {
                 policy.user = data;
                 $scope.policiesUser.push(policy);
+                getCurrentPolicies();
                 // Did we get a user not present in Opencast (e.g. LDAP)? Add it to the list!
                 if ($scope.users.map(user => user.id).indexOf(id) == -1) {
                   if ($scope.aclCreateDefaults['sanitize']) {
@@ -234,6 +235,7 @@ angular.module('adminNg.controllers')
               }).catch(function() {
                 policy.userDoesNotExist = id;
                 $scope.policiesUser.push(policy);
+                getCurrentPolicies();
               });
             }
           });

--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/serieController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/serieController.js
@@ -81,6 +81,7 @@ angular.module('adminNg.controllers')
               UserResource.get({ username: id }).$promise.then(function (data) {
                 policy.user = data;
                 $scope.policiesUser.push(policy);
+                getCurrentPolicies();
                 // Did we get a user not present in Opencast (e.g. LDAP)? Add it to the list!
                 if ($scope.users.map(user => user.id).indexOf(id) == -1) {
                   if ($scope.aclCreateDefaults['sanitize']) {
@@ -94,6 +95,7 @@ angular.module('adminNg.controllers')
               }).catch(function() {
                 policy.userDoesNotExist = id;
                 $scope.policiesUser.push(policy);
+                getCurrentPolicies();
               });
             }
           });


### PR DESCRIPTION
Caused by #5269, the access policy tab causes an unsaved changes prompt when trying to close event/series details, even if no changes were made. This fixes that, by updating the relevant arrays for the check.

Thanks to @KatrinIhler for basically doing the debugging for me.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
