### PR TITLE
Don't Drop Tags in Editor WOH

### DIFF
--- a/docs/guides/admin/docs/releasenotes/editor-woh-tags
+++ b/docs/guides/admin/docs/releasenotes/editor-woh-tags
@@ -1,0 +1,2 @@
+Copy over tags from source tracks to trimmed tracks in the editor WOH. Was already the case when trimming was skipped.
+If you relied on the old behavior, you might need to amend your workflows.

--- a/modules/common/src/main/java/org/opencastproject/mediapackage/AbstractMediaPackageElement.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/AbstractMediaPackageElement.java
@@ -34,6 +34,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -187,6 +188,14 @@ public abstract class AbstractMediaPackageElement implements MediaPackageElement
   @Override
   public String getIdentifier() {
     return id;
+  }
+
+  /**
+   * @see org.opencastproject.mediapackage.MediaPackageElement#setTags(java.lang.String[])
+   */
+  @Override
+  public void setTags(String[] tags) {
+    this.tags = new TreeSet<String>(Arrays.asList(tags));
   }
 
   /**

--- a/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageElement.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageElement.java
@@ -79,6 +79,14 @@ public interface MediaPackageElement extends ManifestContributor, Comparable<Med
   void setElementDescription(String description);
 
   /**
+   * Sets the given tags for the media package element, overwriting any that may have been set previously.
+   *
+   * @param tags
+   *          array of tags
+   */
+  void setTags(String [] tags);
+
+  /**
    * Tags the media package element with the given tag.
    *
    * @param tag

--- a/modules/videoeditor-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videoeditor/VideoEditorWorkflowOperationHandler.java
+++ b/modules/videoeditor-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videoeditor/VideoEditorWorkflowOperationHandler.java
@@ -571,6 +571,7 @@ public class VideoEditorWorkflowOperationHandler extends ResumableWorkflowOperat
         editedTrack.setURI(editedTrackNewUri);
         for (Track track : sourceTracks) {
           if (track.getFlavor().getType().equals(editedTrackFlavor.getType())) {
+            editedTrack.setTags(track.getTags());
             mp.addDerived(editedTrack, track);
             mpAdded = true;
             break;


### PR DESCRIPTION
This closes #5242. The trimmed tracks resulting from the editor operation will now have the same tags as the input tracks. This is especially relevant for subtitle tracks, as we otherwise drop relevant information (about generator type, language and so on) that is difficult to restore afterwards. 

I consider this a bug fix (especially because the tags are kept if no trimming happens), but changing this behavior in a minor release is unexpected imo, so I'm aiming this at develop. Speak up if you disagree.