### PR TITLE
Update the default admin interface

### DIFF
--- a/docs/guides/admin/docs/modules/admin-ui.md
+++ b/docs/guides/admin/docs/modules/admin-ui.md
@@ -1,37 +1,25 @@
-New Admin UI
-========================
+Admin Interface
+===============
 
-<div class=warn>
-The new Admin UI is still <b>beta</b>.
-</div>
-
-Opencast comes with two Admin UIs, the classic one and a new one. The new Admin UI continues with the same look and
+Opencast comes with two admin interfaces. The new Admin UI continues with the same look and
 feel, but uses new technologies under the hood. It strives to be robust and easy to work with, while having all the
 same functionality users expect from the old UI.
 
 
-Accessing The New Admin UI
---------------------
+Accessing Old And New Admin Interface
+-------------------------------------
 
-You can access the new Admin UI by replacing the `ng` in your address bar with `ui`
+You can access the admin interfaces by replacing the `ng` in your address bar with `ui` and vice versa.
 
-```
-/admin-ui/index.html
-```
+- New: `/admin-ui/index.html`
+- Old: `/admin-ng/index.html`
 
 
-Replacing the old Admin UI
-------------------------------------
+Configuring the Default Admin Interface
+---------------------------------------
 
-To use the new Admin UI per default, go to the configuration file located in
-`etc/ui-config/{organizationID}/runtime-info-ui/settings.json` and change
+To configure the default admin interface, go to the configuration file located in
+`etc/ui-config/{organizationID}/runtime-info-ui/settings.json` and change `adminUIUrl`:
 
-```
-"adminUIUrl": "/admin-ng/index.html"
-```
-
-to
-
-```
-"adminUIUrl": "/admin-ui/index.html"
-```
+- New: `"adminUIUrl": "/admin-ui/index.html"` (default)
+- Old: `"adminUIUrl": "/admin-ng/index.html"`

--- a/docs/guides/admin/docs/releasenotes/admin-interface.txt
+++ b/docs/guides/admin/docs/releasenotes/admin-interface.txt
@@ -1,0 +1,1 @@
+The default admin interface has changed.

--- a/etc/ui-config/mh_default_org/runtime-info-ui/settings.json
+++ b/etc/ui-config/mh_default_org/runtime-info-ui/settings.json
@@ -1,3 +1,3 @@
 {
-  "adminUIUrl": "/admin-ng/index.html"
+  "adminUIUrl": "/admin-ui/index.html"
 }


### PR DESCRIPTION
This patch switches to the new admin interface as the default interface for Opencast.

Users can still switch back to the old interface, but this move should push adoption, ensure that people actually test the new interface and force people to develop features against the new, not the old interface.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
