### PR TITLE
Silence detection: Skip attaching smil file if empty

### DIFF
--- a/modules/silencedetection-impl/src/main/java/org/opencastproject/silencedetection/ffmpeg/FFmpegSilenceDetector.java
+++ b/modules/silencedetection-impl/src/main/java/org/opencastproject/silencedetection/ffmpeg/FFmpegSilenceDetector.java
@@ -177,11 +177,7 @@ public class FFmpegSilenceDetector {
      */
 
     LinkedList<MediaSegment> segmentsTmp = new LinkedList<>();
-    if (segmentsStrings.size() == 0) {
-      /* No silence found -> Add one segment for the whole track */
-      logger.info("No silence found. Adding one large segment.");
-      segmentsTmp.add(new MediaSegment(0, track.getDuration()));
-    } else {
+    if (!segmentsStrings.isEmpty()) {
       long lastSilenceEnd = 0;
       long lastSilenceStart = 0;
       Pattern patternStart = Pattern.compile("silence_start\\:\\ \\d+\\.\\d+");

--- a/modules/videoeditor-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videoeditor/SilenceDetectionWorkflowOperationHandler.java
+++ b/modules/videoeditor-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videoeditor/SilenceDetectionWorkflowOperationHandler.java
@@ -211,6 +211,12 @@ public class SilenceDetectionWorkflowOperationHandler extends AbstractWorkflowOp
           throw new WorkflowOperationException("Silence Detection failed");
         }
         Smil smil = smilService.fromXml(detectionJob.getPayload()).getSmil();
+
+        if (smil.getBody().getMediaElements().isEmpty()) {
+          logger.debug("No segments detected in track {}, skip attaching smil file.", sourceTrack.getIdentifier());
+          continue;
+        }
+
         InputStream is = null;
         try {
           is = IOUtils.toInputStream(smil.toXML(), "UTF-8");


### PR DESCRIPTION
Under certain circumstances, for example, if the non-silent segments were smaller than the configured minimum voice length, the SMIL file contained no segments.

This patch changes the behavior so the smil file won't be attached to the media package if it contains no segments.

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
