### PR TITLE
Set publication variables in analyze-MP

### DIFF
--- a/docs/guides/admin/docs/configuration/workflow.md
+++ b/docs/guides/admin/docs/configuration/workflow.md
@@ -329,7 +329,7 @@ As the formal description above explains, such boolean expressions may contain�
 - …strings, which must be surrounded by single-quotes. Escaping of single quotes is supported, just use two single
   quotes next to each other: `'foo''bar'`
 - …as well as references to the variables of the workflow instance that contain these data types. Variables
-  are enclosed in in `${}`, as shown below. A default value may be specified for a variable, after the name, 
+  are enclosed in `${}`, as shown below. A default value may be specified for a variable, after the name, 
   separated by a colon, as such: `${foo:1}`. The default value will be used in case the variable doesn’t exist. 
   If no default value is specified, `false` will be used. This, of course, only makes sense in boolean contexts. Be
   aware to specify a default value in relations such as `${foo} < ${bar}`.
@@ -370,6 +370,10 @@ Example:
       …
     </operation>
 
+Some workflow operation handlers can generate or import variables during a workflow's run, for example:
+- [analyze-tracks](../workflowoperationhandlers/analyze-tracks-woh.md)
+- [analyze-mediapackage](../workflowoperationhandlers/analyze-mediapackage-woh.md)
+- [import-wf-properties](../workflowoperationhandlers/import-wf-properties-woh.md)
 
 ## Thumbnail Support
 

--- a/docs/guides/admin/docs/releasenotes/analyze-mp-publication-variables
+++ b/docs/guides/admin/docs/releasenotes/analyze-mp-publication-variables
@@ -1,0 +1,2 @@
+The analyze-mediapackage WOH was extended so it will also create variables regarding the existence of publications
+(example: `publication_engage_player_exists`). These new variables are not created by default.

--- a/docs/guides/admin/docs/workflowoperationhandlers/analyze-mediapackage-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/analyze-mediapackage-woh.md
@@ -14,11 +14,12 @@ operations should be executed or skipped.
 Workflow Instance Variables
 ---------------------------
 
-| Name                    | Example                           | Description                                                                                               |
-|-------------------------|-----------------------------------|-----------------------------------------------------------------------------------------------------------|
-| `*flavor*_exists`       | `presenter_source_exists=true`    | Whether an element with given flavor is in the mediapackage.                                              |
-| `*flavor*_type`         | `presenter_source_type=Track`     | The type of the element with the given flavor. Possible values are: `Attachment`, `Catalog`, `Track`.     |
-| `*flavor*_hastag_*tag*` | `presenter_source_hastag_archive` | Whether an element with given flavor and tag is in the mediapackage (only if `set-tag-variables` is set). |
+| Name                           | Example                            | Description                                                                                                  |
+|--------------------------------|------------------------------------|--------------------------------------------------------------------------------------------------------------|
+| `*flavor*_exists`              | `presenter_source_exists=true`     | Whether an element with given flavor is in the mediapackage.                                                 |
+| `*flavor*_type`                | `presenter_source_type=Track`      | The type of the element with the given flavor. Possible values are: `Attachment`, `Catalog`, `Track`.        |
+| `*flavor*_hastag_*tag*`        | `presenter_source_hastag_archive`  | Whether an element with given flavor and tag is in the mediapackage (only if `set-tag-variables` is set).    |
+| `publication_*channel*_exists` | `publication_engage_player_exists` | Whether a publication with this channel is in the mediapackage (only if `set-publication-variables` is set). |
 
 
 Parameter Table
@@ -28,11 +29,12 @@ If no configuration keys are specified, workflow instance variables will be set 
 
 If no mediapackage element matches a configuration key, no workflow instance variables will be set for that key. For example, the operation will never generate `presentation_work_exists=false`.
 
-| Configuration Key | Example           | Description                                                                |
-|-------------------|-------------------|----------------------------------------------------------------------------|
-| source-flavors    | `*/work`          | The comma separated list of flavors of the elements we are interested in.  |
-| source-tags       | `delivery, 1080p` | The comma separated list of tags of the elements we are interested in.     |
-| set-tag-variables | `true`            | Whether to set tag variables (default: false).                             |
+| Configuration Key         | Example           | Description                                                                                           |
+|---------------------------|-------------------|-------------------------------------------------------------------------------------------------------|
+| source-flavors            | `*/work`          | The comma separated list of flavors of the elements we are interested in.                             |
+| source-tags               | `delivery, 1080p` | The comma separated list of tags of the elements we are interested in.                                |
+| set-tag-variables         | `true`            | Whether to set tag variables (default: false).                                                        |
+| set-publication-variables | `true`            | Whether to set publication variables (default: false, independent from `source-flavors` and `-tags`). |
 
 
 Operation Example
@@ -40,8 +42,12 @@ Operation Example
 
 ```xml
 <operation
-    id="analyze-mediapackage"
-    description="Analyze media package and set control variables">
+  id="analyze-mediapackage"
+  description="Analyze media package and set control variables">
+  <configurations>
+    <configuration key="source-flavors">*/source</configuration>
+    <configuration key="set-publication-variables">true</configuration>
+  </configurations>
 </operation>
 ```
 


### PR DESCRIPTION
Similar to #5243 except this creates variables that contain which publication channels are part of the media package. These new variables are not created by default.

The use case for this was that I wanted to publish everything if the event wasn't published before, including encoding and all, but only merge specific assets into the publication if it existed. Here's a snippet if you want to test this for yourself:

```
    <operation
      id="include"
      description="Publish to Engage"
      if="NOT ${publication_engage_player_exists}">
      <configurations>
        <configuration key="workflow-id">partial-publish</configuration>
      </configurations>
    </operation>

    <operation
      id="include"
      description="Update Engage publication"
      if="${publication_engage_player_exists}">
      <configurations>
        <configuration key="workflow-id">partial-publish-generated-captions</configuration>
      </configurations>
    </operation>

```

Since the other one went into 14.x I'm aiming this at that branch as well, but I can aim at develop instead if somebody disagrees.

This also contains a small change to the docs that explains which WOHs can generate workflow variables, because I keep forgetting this.