### PR TITLE
Paella 7: Hide/Show timeline bar on live events

### DIFF
--- a/docs/guides/admin/docs/configuration/player/paella.player7/configuration.md
+++ b/docs/guides/admin/docs/configuration/player/paella.player7/configuration.md
@@ -119,3 +119,24 @@ You can enable/disable the cookie consent banner in `config.json` file:
     ...
 }
 ```
+
+Hide/Show the timeline bar on Live events
+-----------------------------------------
+Paella can hide the timeline bar in live events using the `opencast.hideTimeLineOnLive` property
+in the configuration file.
+
+If your live stream offers a time buffer to go back in time, you can configure paella so that
+the time buffer bar is displayed and visitors will be able to go back in time.
+
+Example:
+
+```json
+{
+    ...
+    "opencast": {
+        "hideTimeLineOnLive": false
+        ...
+    }
+    ...
+}
+```

--- a/etc/ui-config/mh_default_org/paella7/config.json
+++ b/etc/ui-config/mh_default_org/paella7/config.json
@@ -63,7 +63,8 @@
             "presenter/player+preview",
             "presentation/player+preview"
         ],
-        "theme": "custom_theme"
+        "theme": "custom_theme",
+        "hideTimeLineOnLive": false
     },
 
     "cookieConsent": [

--- a/modules/engage-paella-player-7/src/js/EpisodeConversor.js
+++ b/modules/engage-paella-player-7/src/js/EpisodeConversor.js
@@ -106,7 +106,7 @@ function getSourceData(track, config) {
   return data;
 }
 
-function getMetadata(episode) {
+function getMetadata(episode, config) {
   const { duration, title, language, series, seriestitle, subjects, license, type } = episode.mediapackage;
   const startDate = new Date(episode.dcCreated);
   const presenters = episode?.mediapackage?.creators?.creator
@@ -119,6 +119,9 @@ function getMetadata(episode) {
       ? episode.mediapackage.contributors.contributor
       : [episode.mediapackage.contributors.contributor])
     : [];
+
+  const isLive = episode?.mediapackage?.media?.track?.some((track) => track.live === true);
+  const visibleTimeLine = !(isLive && config?.hideTimeLineOnLive);
 
   const result = {
     title,
@@ -136,7 +139,8 @@ function getMetadata(episode) {
     location: episode?.dcSpatial,
     UID: episode?.id,
     type,
-    opencast: {episode}
+    opencast: {episode},
+    visibleTimeLine
   };
 
   return result;


### PR DESCRIPTION
Paella player used to start playing live streams from the beginning of the buffer, so in case the stream had a time buffer, paella started playing from the beginning of the buffer and not from the current moment.

This PR updates paella to version 1.46.1 that fixes that bug and also adds a property to the configuration file that allows to show or hide the time bar in live events.


### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
