### PR TITLE
Log cached FFmpeg files

### DIFF
--- a/.github/workflows/store-ffmpeg-builds.yml
+++ b/.github/workflows/store-ffmpeg-builds.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Unpack FFmpeg
         run: |
-          tar xf ffmpeg-release-${{ matrix.arch }}-static.tar.xz
+          tar xvf ffmpeg-release-${{ matrix.arch }}-static.tar.xz
 
       - name: Repack FFmpeg
         run: |


### PR DESCRIPTION
This just adds a verbose flag to the `tar` command extracting the FFmpeg build so you can check what is being cached. This is just to make the process a bit more transparent.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
