### PR TITLE
Fix Unsaved ACL Changes popup if user can't request ACL

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
@@ -1121,8 +1121,8 @@ angular.module('adminNg.controllers')
       getCurrentPolicies();
     };
 
-    let oldPolicies = {};
-    let oldPoliciesUser = {};
+    let oldPolicies = [];
+    let oldPoliciesUser = [];
 
     function getCurrentPolicies () {
       oldPolicies = JSON.parse(JSON.stringify($scope.policies));

--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/serieController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/serieController.js
@@ -679,8 +679,8 @@ angular.module('adminNg.controllers')
       return { ace, hasRights, rulesValid, override };
     };
 
-    let oldPolicies = {};
-    let oldPoliciesUser = {};
+    let oldPolicies = [];
+    let oldPoliciesUser = [];
 
     function getCurrentPolicies () {
       oldPolicies = JSON.parse(JSON.stringify($scope.policies));


### PR DESCRIPTION
When the user doesn't have the rights to request the event or series ACL they would always get the Unsaved Changes popup when trying to close the event or series details. We were comparing apples and oranges - an empty array vs an empty object. This fixes that.