### PR TITLE
Fix Docs Landing Page

### DIFF
--- a/docs/guides/.infrastructure/index.html.j2
+++ b/docs/guides/.infrastructure/index.html.j2
@@ -134,25 +134,29 @@
           You can subscribe via Google Groups (linked above) or simply by sending a mail to
           <em>[list]+subscribe@opencast.org</em> (e.g. <em>users+subscribe@opencast.org</em>).
         </div>
+
+        <div class="col-md-6">
+          <h4>Meetings</h4>
+
+          <p>You can find an overview of all meetings and events in our
+          <a href="https://calendar.google.com/calendar/u/0/embed?src=opencast.org_tje2fm34ernnbm0f9saiogp8g0@group.calendar.google.com&ctz=Europe/Amsterdam&pli=1">community calender</a>.
+
+          <h5>Technical meeting</h5>
+          <p>Weekly open meeting of developers and dev-ops at
+          <a href="https://opencast.blindsidenetworks.net">meet.opencast.video</a> (room 1, p: welcome), check the calendar link for dates and times.
+          This is where you want to be to talk technical Opencast issues with developers.</p>
+
+          <h5>SysAdmin meeting</h5>
+          <p>Monthly adopters and sys-admins meeting at
+          <a href="https://opencast.blindsidenetworks.net">meet.opencast.video</a> (room 1, p: welcome), check the calendar link for dates and times.
+          The goal of this meeting is to talk about current challenges, as well as upcoming development and testing coordination.  If you run Opencast, or are thinking about doing so, this is the meeting to attend.</p>
+        </div>
+      </div>
+      <div class="row">
         <div class="col-md-6">
           <h4>Matrix room (Chat)</h4>
           <p>For occasional quick questions join us in Matrix:
           <a href="https://matrix.to/#/#opencast-community:matrix.org"><em>#opencast-community:matrix.org</em></a>.</p>
-        </div>
-        <div class="col-md-6">
-          <h4>Meetings</h4>
-          <p>Our meeting calendar can be found <a href="https://calendar.google.com/calendar/ical/opencast.org_tje2fm34ernnbm0f9saiogp8g0%40group.calendar.google.com/public/basic.ics">here</a>, and consists mainly of two meetings
-        <div class="col-md-6">
-          <h5>Dev meeting</h5>
-          <p>Our weekly open meeting of developers and dev-ops takes place at
-          <a href="https://opencast.blindsidenetworks.net">meet.opencast.video</a> (room 1, p: welcome), check the calendar link above for dates and times.
-          This is where you want to be to talk technical Opencast issues with developers.</p>
-        </div>
-        <div class="col-md-6">
-          <h5>SysAdmin meeting</h5>
-          <p>Monthly adopters and sys-admins meeting at
-          <a href="https://opencast.blindsidenetworks.net">meet.opencast.video</a> (room 1, p: welcome), check the calendar link above for dates and times.
-          The goal of this meeting is to talk about current challenges, as well as upcoming development and testing coordination.  If you run Opencast, or are thinking about doing so, this is the meeting to attend.</p>
         </div>
       </div>
 


### PR DESCRIPTION
This patch fixes the docs landing page which has  a broken HTML (and arguably also bootstrap) syntax: Missing closing tags and too many columns for them to be actually rendered.

Additionally, this changes the calendar link from an ICS file you have to import into your calendar to the web view. The reason for that change is that as a new user, I might want to take a look, but I don't necessarily want to immediately import the whole calender into my own calender.

![Screenshot from 2023-11-21 18-28-58](https://github.com/opencast/opencast/assets/1008395/664aaee6-c27c-4e75-95a5-903592993d23)
*Rendered, updated landing page*

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
