### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -26,15 +26,6 @@
     <bundle start-level="55">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.commons-httpclient/3.1_7</bundle>
     <bundle start-level="55">mvn:commons-codec/commons-codec/${commons-codec.version}</bundle>
 
-    <!-- General specifications -->
-    <bundle>mvn:javax.el/javax.el-api/3.0.0</bundle>
-    <bundle>mvn:javax.servlet.jsp/javax.servlet.jsp-api/2.3.1</bundle>
-    <bundle>mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/1.1.1</bundle>
-    <bundle>mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/1.1.1</bundle>
-    <bundle>mvn:org.apache.geronimo.specs/geronimo-j2ee-management_1.1_spec/1.0.1</bundle>
-    <bundle>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jsr339-api-2.0.1/2.6.0</bundle>
-    <bundle>mvn:org.fusesource.hawtbuf/hawtbuf/1.11</bundle>
-
     <!-- JPA -->
     <feature>jndi</feature>
     <feature>jpa</feature>
@@ -64,7 +55,6 @@
     <bundle>mvn:org.apache.commons/commons-csv/${commons-csv.version}</bundle>
     <bundle>mvn:org.apache.commons/commons-lang3/${commons-lang3.version}</bundle>
     <bundle>mvn:org.apache.commons/commons-text/${commons-text.version}</bundle>
-    <bundle>mvn:org.apache.neethi/neethi/3.0.1</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xalan/2.7.2_3</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.bcel/5.2_3</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.batik/1.7_3</bundle>
@@ -78,7 +68,6 @@
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlresolver/1.2_1</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlschema/1.4.3_1</bundle>
     <bundle>mvn:org.codehaus.jettison/jettison/${jettison.version}</bundle>
-    <bundle>mvn:org.codehaus.groovy/groovy/2.4.3</bundle>
     <bundle>mvn:org.opencastproject/android-mms/1.2</bundle>
     <bundle>wrap:mvn:com.googlecode.json-simple/json-simple/${json-simple.version}</bundle>
 

--- a/modules/common/pom.xml
+++ b/modules/common/pom.xml
@@ -256,6 +256,8 @@
               !org.mozilla.javascript.*,
               !org.python.*,
               !org.zeroturnaround.javarebel.*,
+              !groovy.*,
+              !org.codehaus.groovy.*,
               javax.ws.rs;version=2.0.1,
               javax.ws.rs.core;version=2.0.1,
               javax.ws.rs.ext;version=2.0.1,

--- a/modules/db/pom.xml
+++ b/modules/db/pom.xml
@@ -116,6 +116,7 @@
               !org.jboss.resource.adapter.jdbc.*,
               !software.amazon.awssdk.*,
               !waffle.*,
+              !org.codehaus.groovy*,
               org.w3c.dom;version=0,
               *
             </Import-Package>

--- a/pom.xml
+++ b/pom.xml
@@ -819,11 +819,6 @@
         <version>3.1.0</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.geronimo.specs</groupId>
-        <artifactId>geronimo-jms_1.1_spec</artifactId>
-        <version>1.1.1</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.solr</groupId>
         <artifactId>solr-core</artifactId>
         <exclusions>
@@ -1281,11 +1276,6 @@
             <artifactId>hamcrest-core</artifactId>
           </exclusion>
         </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.groovy</groupId>
-        <artifactId>groovy-all</artifactId>
-        <version>2.5.8</version>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
Opencast did not use removed dependencies, according to the Karaf console.

Is this change still allowed in a release after a feature freeze? It could break Opencast because you can't test all possible configurations. It works for me ;)

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
