### PR TITLE
Fix concurrency problem in Whisper integration

### DIFF
--- a/modules/speech-to-text-api/src/main/java/org/opencastproject/speechtotext/api/SpeechToTextEngine.java
+++ b/modules/speech-to-text-api/src/main/java/org/opencastproject/speechtotext/api/SpeechToTextEngine.java
@@ -22,10 +22,27 @@
 package org.opencastproject.speechtotext.api;
 
 import java.io.File;
-import java.util.Map;
 
 /** Interface for speech-to-text implementations. */
 public interface SpeechToTextEngine {
+
+  class Result {
+    private final String language;
+    private final File subtitleFile;
+
+    public Result(String language, File subtitleFile) {
+      this.language = language;
+      this.subtitleFile = subtitleFile;
+    }
+
+    public String getLanguage() {
+      return language;
+    }
+
+    public File getSubtitleFile() {
+      return subtitleFile;
+    }
+  }
 
   /**
    * Returns the name of the implemented engine.
@@ -38,13 +55,13 @@ public interface SpeechToTextEngine {
    * Generates the subtitles file.
    *
    * @param mediaFile          The media package containing the audio track.
-   * @param preparedOutputFile The prepared output file where the subtitle's data should be saved.
+   * @param workingDirectory   A unique working directory to safely operate in.
    * @param language           The language of the audio track.
    * @param translate          If the subtitles should be translated into english
-   * @return HashMap which contains the language code and the subtitles file path.
+   * @return Result containing the language code and the subtitles file path.
    * @throws SpeechToTextEngineException Thrown when an error occurs at the process.
    */
-  Map<String, Object> generateSubtitlesFile(File mediaFile, File preparedOutputFile, String language,
+  Result generateSubtitlesFile(File mediaFile, File workingDirectory, String language,
           Boolean translate) throws SpeechToTextEngineException;
 
 }


### PR DESCRIPTION
The SpeechToTextService interface ensures that a unique file is passed to transcription engines which these can safely use to store output files. Unfortunately, most Whisper implementations work slightly different and you cannot specify a single output file. That is probably why the Whisper engine throes the safe file name overboard and just uses the parent directly to store files.

This has the side-effect that if `mediapackage-a/presenter.mp4` and `mediapackage-b/presenter.mp4` are processed concurrently, both write to the same file and an incorrect output file will end up being attached to one of the media packages.

This patch fixes that problem by creating an unique directory instead and passing that to the engines to operate in.

This also fixes the problem that most Whisper implementations create many more output files which whould have never been deleted before, slowly filling up the workspace.

This fixes  #5437

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
