### PR TITLE
Fix update translations workflow

### DIFF
--- a/.crowdin.yaml
+++ b/.crowdin.yaml
@@ -1,4 +1,5 @@
-project_identifier: opencast-community
+project_id: 285795
+api_token_env: CROWDIN_TOKEN
 base_path: .
 preserve_hierarchy: true
 


### PR DESCRIPTION
The update translations workflow always reaches three release branches into the past to ensure all edge cases are covered. That means `r/15.x`, `r/14.x` and `r/13.x` are updated right now.

Unfortunately, `r/13.x` still has a now invalid Crowdin configuration which causes the workflow to fail. This will continue until mid 2024.

See https://github.com/opencast/opencast/actions/workflows/update-translations.yml

That's annoying and therefor, this pull request updates the configuration in `r/13.x` to ensure the update does not fail any longer.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
