### PR TITLE
Use OpencastConstants for ADMIN_EMAIL_PROPERTY

### DIFF
--- a/modules/oaipmh/src/main/java/org/opencastproject/oaipmh/server/DefaultRepository.java
+++ b/modules/oaipmh/src/main/java/org/opencastproject/oaipmh/server/DefaultRepository.java
@@ -27,6 +27,7 @@ import org.opencastproject.oaipmh.matterhorn.MatterhornInlinedMetadataProvider;
 import org.opencastproject.oaipmh.matterhorn.MatterhornMetadataProvider;
 import org.opencastproject.oaipmh.persistence.OaiPmhDatabase;
 import org.opencastproject.oaipmh.util.ResumptionTokenStore;
+import org.opencastproject.systems.OpencastConstants;
 import org.opencastproject.util.data.Collections;
 import org.opencastproject.util.data.Option;
 
@@ -51,7 +52,6 @@ import java.util.List;
     }
 )
 public class DefaultRepository extends OaiPmhRepository {
-  private static final String PROP_ADMIN_EMAIL = "org.opencastproject.admin.email";
 
   private OaiPmhDatabase persistence;
   private String adminEmail;
@@ -68,7 +68,7 @@ public class DefaultRepository extends OaiPmhRepository {
   /** OSGi callback */
   @Activate
   public void activate(ComponentContext cc) {
-    adminEmail = getContextProperty(cc, PROP_ADMIN_EMAIL);
+    adminEmail = getContextProperty(cc, OpencastConstants.ADMIN_EMAIL_PROPERTY);
   }
 
   @Override

--- a/modules/transcription-service-ibm-watson-impl/src/main/java/org/opencastproject/transcription/ibmwatson/IBMWatsonTranscriptionService.java
+++ b/modules/transcription-service-ibm-watson-impl/src/main/java/org/opencastproject/transcription/ibmwatson/IBMWatsonTranscriptionService.java
@@ -20,6 +20,8 @@
  */
 package org.opencastproject.transcription.ibmwatson;
 
+import static org.opencastproject.systems.OpencastConstants.ADMIN_EMAIL_PROPERTY;
+
 import org.opencastproject.assetmanager.api.AssetManager;
 import org.opencastproject.assetmanager.api.fn.Enrichments;
 import org.opencastproject.assetmanager.api.query.AQueryBuilder;
@@ -143,7 +145,6 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
 
   // Global configuration (custom.properties)
   public static final String ADMIN_URL_PROPERTY = "org.opencastproject.admin.ui.url";
-  private static final String ADMIN_EMAIL_PROPERTY = "org.opencastproject.admin.email";
   private static final String DIGEST_USER_PROPERTY = "org.opencastproject.security.digest.user";
 
   // Cluster name

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/AdminUserAndGroupLoader.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/AdminUserAndGroupLoader.java
@@ -32,6 +32,7 @@ import org.opencastproject.security.impl.jpa.JpaOrganization;
 import org.opencastproject.security.impl.jpa.JpaRole;
 import org.opencastproject.security.impl.jpa.JpaUser;
 import org.opencastproject.security.util.SecurityUtil;
+import org.opencastproject.systems.OpencastConstants;
 
 import org.apache.commons.lang3.StringUtils;
 import org.osgi.framework.BundleContext;
@@ -73,9 +74,6 @@ public class AdminUserAndGroupLoader implements OrganizationDirectoryListener {
    * Note that this is not set if it is not defined in the configuration file.
    **/
   private static final String DEFAULT_ADMIN_PASSWORD_CONFIGURATION = "opencast";
-
-  /** The administrator email configuration option */
-  public static final String OPT_ADMIN_EMAIL = "org.opencastproject.admin.email";
 
   /** The administrator roles configuration option */
   public static final String OPT_ADMIN_ROLES = "org.opencastproject.security.admin.roles";
@@ -122,7 +120,7 @@ public class AdminUserAndGroupLoader implements OrganizationDirectoryListener {
     BundleContext bundleCtx = cc.getBundleContext();
     adminUserName = StringUtils.trimToNull(bundleCtx.getProperty(SecurityConstants.GLOBAL_ADMIN_USER_PROPERTY));
     adminPassword = StringUtils.trimToNull(bundleCtx.getProperty(OPT_ADMIN_PASSWORD));
-    adminEmail = StringUtils.trimToNull(bundleCtx.getProperty(OPT_ADMIN_EMAIL));
+    adminEmail = StringUtils.trimToNull(bundleCtx.getProperty(OpencastConstants.ADMIN_EMAIL_PROPERTY));
     adminRoles = StringUtils.trimToNull(bundleCtx.getProperty(OPT_ADMIN_ROLES));
 
     if (DEFAULT_ADMIN_PASSWORD_CONFIGURATION.equals(adminPassword)) {


### PR DESCRIPTION
We have `ADMIN_EMAIL_PROPERTY` in `OpencastConstants` and should use it instead of defining the constant over and over again in several classes.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
