### PR TITLE
Fix Paella Player 7 login redirect

### DIFF
--- a/modules/engage-paella-player-7/src/js/PaellaOpencast.js
+++ b/modules/engage-paella-player-7/src/js/PaellaOpencast.js
@@ -139,7 +139,7 @@ const initParams = {
       const data = await fetch(getUrlFromOpencastServer('/info/me.json'));
       const me = await data.json();
 
-      if (me.userRole === 'ROLE_USER_ANONYMOUS') {
+      if (!me.roles.includes('ROLE_USER')) {
         player.log.info('Video not found and user is not authenticated. Try to log in.');
         location.href = getUrlFromOpencastPaella('auth.html?redirect=' + encodeURIComponent(window.location.href));
       }


### PR DESCRIPTION
Our code for the Paella Player 7 checks the user role to decide whether to redirect to the login page. However, the user role can be different if you have configured a different user role prefix or simply turned sanitize off. A safer assumption seems to be to expect any logged-in user to have ROLE_USER.