### PR TITLE
Docs: Make Developer Overview page more verbose

### DIFF
--- a/docs/guides/developer/docs/index.md
+++ b/docs/guides/developer/docs/index.md
@@ -1,5 +1,17 @@
 Opencast Development Guides
 ===========================
 
-These guides will help you if you want to participate in Opencast development.
+Welcome to the Opencast development documentation! If you are new to Opencast, be sure to check out our
+[Administration Guide](https://docs.opencast.org/stable/admin/).
 
+This documentation will help you if you want to participate in Opencast development. It is split into three main
+sections:
+
+- [Participate](./participate/development-process.md) contains information on all the different ways you can take a
+  part in the Opencast project. Besides programming, there are many other tasks required to keep the project running.
+  Consider helping with translations or even becoming a release manager!
+- [Develop](./develop/setup-opencast-for-develop.md) provides helpful tips and tricks on how set up your development
+  environment, as well as write and debug your code.
+- [Opencast Architecture](./architecture/overview.md) supplies in depth, technical description on the different parts
+  that make up Opencast, such as the External API. If you are looking for information on how to configure certain parts,
+  check the [Administration Guide](https://docs.opencast.org/stable/admin/#configuration/) instead.


### PR DESCRIPTION
There's but a single sentence of introduction on the landing page of the developer docs. This aims to change that, so users do not feel quite as lost.

This also tries to provide a loose definition for the different sections, based on what should be in those sections, not what is actually in them.
