### PR TITLE
Add maven wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ phantomjsdriver.log
 
 # Ignore python cache folder
 __pycache__
+
+# Ignore maven wrapper windows batch file
+mvnw.cmd

--- a/.mvn/wrapper/.gitignore
+++ b/.mvn/wrapper/.gitignore
@@ -1,0 +1,1 @@
+maven-wrapper.jar

--- a/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/.mvn/wrapper/MavenWrapperDownloader.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+
+public final class MavenWrapperDownloader
+{
+    private static final String WRAPPER_VERSION = "3.2.0";
+
+    private static final boolean VERBOSE = Boolean.parseBoolean( System.getenv( "MVNW_VERBOSE" ) );
+
+    public static void main( String[] args )
+    {
+        log( "Apache Maven Wrapper Downloader " + WRAPPER_VERSION );
+
+        if ( args.length != 2 )
+        {
+            System.err.println( " - ERROR wrapperUrl or wrapperJarPath parameter missing" );
+            System.exit( 1 );
+        }
+
+        try
+        {
+            log( " - Downloader started" );
+            final URL wrapperUrl = new URL( args[0] );
+            final String jarPath = args[1].replace( "..", "" ); // Sanitize path
+            final Path wrapperJarPath = Paths.get( jarPath ).toAbsolutePath().normalize();
+            downloadFileFromURL( wrapperUrl, wrapperJarPath );
+            log( "Done" );
+        }
+        catch ( IOException e )
+        {
+            System.err.println( "- Error downloading: " + e.getMessage() );
+            if ( VERBOSE )
+            {
+                e.printStackTrace();
+            }
+            System.exit( 1 );
+        }
+    }
+
+    private static void downloadFileFromURL( URL wrapperUrl, Path wrapperJarPath )
+        throws IOException
+    {
+        log( " - Downloading to: " + wrapperJarPath );
+        if ( System.getenv( "MVNW_USERNAME" ) != null && System.getenv( "MVNW_PASSWORD" ) != null )
+        {
+            final String username = System.getenv( "MVNW_USERNAME" );
+            final char[] password = System.getenv( "MVNW_PASSWORD" ).toCharArray();
+            Authenticator.setDefault( new Authenticator()
+            {
+                @Override
+                protected PasswordAuthentication getPasswordAuthentication()
+                {
+                    return new PasswordAuthentication( username, password );
+                }
+            } );
+        }
+        try ( InputStream inStream = wrapperUrl.openStream() )
+        {
+            Files.copy( inStream, wrapperJarPath, StandardCopyOption.REPLACE_EXISTING );
+        }
+        log( " - Downloader complete" );
+    }
+
+    private static void log( String msg )
+    {
+        if ( VERBOSE )
+        {
+            System.out.println( msg );
+        }
+    }
+
+}

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar

--- a/docs/guides/admin/docs/installation/source-linux.md
+++ b/docs/guides/admin/docs/installation/source-linux.md
@@ -94,7 +94,7 @@ Building Opencast
 Automatically build all Opencast modules and assemble distributions for different server types:
 
     cd opencast-dir
-    mvn clean install
+    ./mvnw clean install
 
 Deploy all-in-one distribution:
 

--- a/docs/guides/admin/docs/installation/source-macosx.md
+++ b/docs/guides/admin/docs/installation/source-macosx.md
@@ -115,7 +115,7 @@ Switch to the opencast folder. If you downloaded the tarball, this is the folder
 like `opencast-community-opencast-[…]`). If you chose to download via git, use `cd opencast`. You can proceed by
 building opencast (depending on the folder permissions, you might need to start the command with `sudo`):
 
-    mvn clean install -Pdev
+    ./mvnw clean install -Pdev
 
 Please be patient, as building Opencast for the first time will take quite long.
 

--- a/docs/guides/developer/docs/develop/admin-ui/development.md
+++ b/docs/guides/developer/docs/develop/admin-ui/development.md
@@ -158,7 +158,7 @@ Update Node Dependencies
 Installing `npm-check-updates` and running it at the start of developing / improving a component can ensure that the
 node modules stays up-to-date and dependency bugs are reduced.
 
-*Note: Test the build (`mvn install`, `npm install`, `grunt`) thoroughly when upgrading modules as this might cause some
+*Note: Test the build (`./mvnw install`, `npm install`, `grunt`) thoroughly when upgrading modules as this might cause some
 unexpected build failures (resetting the grunt version to "grunt": "^0.4.0" might resolve some of the initial issues).*
 
 1. Installation.

--- a/docs/guides/developer/docs/develop/development-tips.md
+++ b/docs/guides/developer/docs/develop/development-tips.md
@@ -27,13 +27,13 @@ Developer Builds
 Besides the default `dist` Maven profile, the assemblies project defines a second `dev` profile which will cause only
 one `allinone` distribution to be created. It is already unpacked and ready to be started. Activate the profile using:
 
-    mvn clean install -Pdev
+    ./mvnw clean install -Pdev
 
 The administrative user interface needs nodejs to build and phantomjs for testing purposes. These will be downloaded as
 prebuilt binaries during the maven build process. If there are no prebuilt binaries for your operating system, you can
 build the tools manually and then build opencast using the `frontend-no-prebuilt` maven profile:
 
-    mvn clean install -Pdev,frontend-no-prebuilt
+    ./mvnw clean install -Pdev,frontend-no-prebuilt
 
 Logging During Builds
 ---------------------
@@ -52,7 +52,7 @@ be as follows:
 * Start Opencast and use `la -u` in the Karaf console to list all installed bundles/modules. Note down the IDs of the
   bundles you want to watch.
 * Use `bundle:watch IDs` to watch the desired modules, e.g. `bundle:watch 190 199`
-* Make your changes and rebuild the module (e.g. execute `mvn clean install` in the module folder).
+* Make your changes and rebuild the module (e.g. execute `./mvnw clean install` in the module folder).
 * Watch how Karaf automatically redeploys the changed jars from your local Maven repository. You can verify that
   everything went smoothly by checking the log with `log:tail`.
 
@@ -61,7 +61,7 @@ To see this technique in action, you can watch the following short video:
 * [Opencast development: Watch and reload modules](https://asciinema.org/a/348132)
 
 The updated bundles are only available in the currently running Karaf instance. To create a Opencast version that has
-this changes permanently, you have to run `mvn clean install` in the the assemblies directory again. Your current
+this changes permanently, you have to run `./mvnw clean install` in the the assemblies directory again. Your current
 instance will be deleted by the new assembly!
 
 In several cases the `bundle:watch` can bring Karaf in an unstable condition, as dependencies between bundles will not

--- a/docs/guides/developer/docs/develop/devops/local-cluster.md
+++ b/docs/guides/developer/docs/develop/devops/local-cluster.md
@@ -6,7 +6,7 @@ A list of commands to quickly build and configure a local Opencast cluster.
 First, build and extract distributions:
 
 ```sh
-mvn clean install
+./mvnw clean install
 cd build
 tar xf opencast-dist-admin-10-SNAPSHOT.tar.gz
 tar xf opencast-dist-presentation-10-SNAPSHOT.tar.gz

--- a/docs/guides/developer/docs/develop/setup-opencast-for-develop.md
+++ b/docs/guides/developer/docs/develop/setup-opencast-for-develop.md
@@ -12,7 +12,7 @@ For the installation of a production cluster, take a look at the admin guides.
 ```sh
 $ git clone https://github.com/opencast/opencast.git
 $ cd opencast
-$ mvn clean install -Pdev
+$ ./mvnw clean install -Pdev
 $ cd build/opencast-dist-develop-*
 $ ./bin/start-opencast
 ```
@@ -74,7 +74,7 @@ install them.
 
 You can now build opencast by changing into your opencast directory and running:
 
-    $ mvn clean install [Options]
+    $ ./mvnw clean install [Options]
 
 After the successful compilation you can start opencast with:
 
@@ -113,7 +113,7 @@ When working on a single Opencast module, it can be extremely helpful having the
 * Start Opencast and use `la -u` in the Karaf console to list all installed bundles/modules. Note down the IDs of the
   bundles you want to watch.
 * Use `bundle:watch IDs` to watch the desired modules, e.g. `bundle:watch 190 199`
-* Make your changes and rebuild the module (e.g. execute `mvn clean install` in the module folder).
+* Make your changes and rebuild the module (e.g. execute `./mvnw clean install` in the module folder).
 * Watch how Karaf automatically redeploys the changed jars from your local Maven repository. You can verify that
   everything went smoothly by checking the log with `log:tail`.
 
@@ -121,7 +121,7 @@ To see this technique in action, you can watch the following short video:
 
 * [Opencast development: Watch and reload modules](https://asciinema.org/a/348132)
 
-The updated bundles are only available in the currently running Karaf instance. To create a Opencast version that contains your changes permanently, you have to run `mvn install` in the assemblies directory again. 
+The updated bundles are only available in the currently running Karaf instance. To create a Opencast version that contains your changes permanently, you have to run `./mvnw install` in the assemblies directory again. 
 
 In several cases the `bundle:watch` can put Karaf in an unstable condition, as dependencies between bundles will not
 correctly be restored after the new bundle has been deployed.
@@ -133,8 +133,8 @@ correctly be restored after the new bundle has been deployed.
 Building with multiple threads decreases the build time significantly.
 If you want to enable multiple threads, you can use the following command:
 
-    $ mvn clean install -T 1.0C -DskipTests -Pnone 
-    && cd assemblies && mvn install -T 1.0C -Dskiptests -Pdev  
+    $ ./mvnw clean install -T 1.0C -DskipTests -Pnone 
+    && cd assemblies && ./mvnw install -T 1.0C -Dskiptests -Pdev  
     && cd ..
     $ ./build/opencast-dist-develop-*/start-opencast
 
@@ -146,12 +146,12 @@ We don't advise using this feature for production.
 For a quick build, you can use the following command to skip Opencast's tests.
 
     $ cd opencast
-    $ mvn clean install -Pdev -DskipTests
+    $ ./mvnw clean install -Pdev -DskipTests
 
 To see the whole `stacktrace` of the installation you can use the following command to disable the trimming.
 
     $ cd opencast
-    $ mvn clean install -DtrimStackTrace=false
+    $ ./mvnw clean install -DtrimStackTrace=false
 
 If you want to start opencast in debug mode, you could use the debug argument:
 

--- a/docs/guides/developer/docs/license.md
+++ b/docs/guides/developer/docs/license.md
@@ -50,10 +50,10 @@ Example:
 ### Java Libraries / Maven Dependencies
 
 Java dependencies are listed pre module. Maven provides some helpful tools to list dependencies and even report
-libraries. Have a look at the output of `mvn dependency:list` and `mvn dependency:tree` or generate a full report for a
+libraries. Have a look at the output of `./mvnw dependency:list` and `./mvnw dependency:tree` or generate a full report for a
 module using:
 
-    mvn -s settings.xml project-info-reports:dependencies
+    ./mvnw -s settings.xml project-info-reports:dependencies
 
 This will create a file `target/site/dependencies.html` containing a full report, including the library versions and
 licenses.

--- a/docs/guides/developer/docs/license.md
+++ b/docs/guides/developer/docs/license.md
@@ -50,8 +50,8 @@ Example:
 ### Java Libraries / Maven Dependencies
 
 Java dependencies are listed pre module. Maven provides some helpful tools to list dependencies and even report
-libraries. Have a look at the output of `./mvnw dependency:list` and `./mvnw dependency:tree` or generate a full report for a
-module using:
+libraries. Have a look at the output of `./mvnw dependency:list` and `./mvnw dependency:tree` or generate a full report
+for a module using:
 
     ./mvnw -s settings.xml project-info-reports:dependencies
 

--- a/docs/guides/developer/docs/participate/development-process.md
+++ b/docs/guides/developer/docs/participate/development-process.md
@@ -77,7 +77,7 @@ of what work has been done. To this end, there are a few expectations for all pu
 * Any actions that would be required for a version upgrade (e.g: from 3.x to 4.x) must be documented in
   `docs/guides/admin/docs/upgrade.md`
 * New features require a release note in `docs/guides/admin/releasenotes` of at least one line describing the change
-* The commands `mvn clean install`, `mvn javadoc:javadoc javadoc:aggregate`, and `mvn site` should all succeed
+* The commands `./mvnw clean install`, `./mvnw javadoc:javadoc javadoc:aggregate`, and `./mvnw site` should all succeed
 * The licenses of any external libraries used in the pull request comply with the [licensing rules](../license.md) both
   in terms of the license itself as well as its listing in NOTICES
 

--- a/docs/guides/developer/docs/participate/infrastructure/maven-repository.md
+++ b/docs/guides/developer/docs/participate/infrastructure/maven-repository.md
@@ -17,7 +17,7 @@ There is a preconfigured Docker image for a Nexus server set-up for Opencast. To
 follow these steps:
 
     docker run \
-        --name ./mvnwcache \
+        --name mvncache \
         -p 8000:8000 \
         docker.io/lkiesow/opencast-maven-repository
 

--- a/docs/guides/developer/docs/participate/infrastructure/maven-repository.md
+++ b/docs/guides/developer/docs/participate/infrastructure/maven-repository.md
@@ -17,7 +17,7 @@ There is a preconfigured Docker image for a Nexus server set-up for Opencast. To
 follow these steps:
 
     docker run \
-        --name mvncache \
+        --name ./mvnwcache \
         -p 8000:8000 \
         docker.io/lkiesow/opencast-maven-repository
 
@@ -58,7 +58,7 @@ Pushing artifacts to a Maven repository
 The following command will add a file to your local Maven repository.  This is useful for testing if your artifacts are
 correctly placed prior to pushing to the mainline Nexus repository.
 
-    mvn install:install-file \
+    ./mvnw install:install-file \
      -Dfile=$filename \
      -DgroupId=$groupId \
      -DartifactId=$artifactId \
@@ -118,7 +118,7 @@ Pushing Snapshots
 Snapshots are pushed automatically by the CI servers.  For historical purposes, this is accomplished by:
 
 ```bash
-mvn deploy
+./mvnw deploy
 ```
 
 To verify, your artifacts can be found [here](https://oss.sonatype.org/content/repositories/snapshots/org/opencastproject/)
@@ -140,27 +140,27 @@ Pushing releases is similar to snapshots, with the added requirements that you a
 This is automated with the `release` profile.  To push a release run
 
 ```bash
-mvn nexus-staging:deploy -P release
+./mvnw nexus-staging:deploy -P release
 ```
 
 This creates a staging repository (https://oss.sonatype.org/content/groups/staging/org/opencastproject/) for your
 artifacts.  This is always safe to do - you can still rollback all changes with
 
 ```bash
-mvn nexus-staging:drop
+./mvnw nexus-staging:drop
 ```
 
 If things do not look ok, fix the issue and redeploy.  Once you are confident that everything is ok, you can run
 
 ```bash
-mvn nexus-staging:close
+./mvnw nexus-staging:close
 ```
 
 This closes the staging repository, and runs the Sonatype-side tests for things like GPG signatures.  If this fails,
 correct the issue locally, and redeploy.  Once this succeeds, you have two options: drop (to destroy the release) or:
 
 ```bash
-mvn nexus-staging:release
+./mvnw nexus-staging:release
 ```
 
 to permanently release the binaries in their current states.
@@ -175,7 +175,7 @@ timeout and not something you have done use one of the following.
 To reattempt a deploy use
 
 ```bash
-mvn nexus-staging:deploy-staged
+./mvnw nexus-staging:deploy-staged
 ```
 
 This will avoid recompiling, retesting, and resigning all of the binaries.
@@ -184,5 +184,5 @@ This will avoid recompiling, retesting, and resigning all of the binaries.
 To reattempt a close use
 
 ```bash
-mvn nexus-staging:close
+./mvnw nexus-staging:close
 ```

--- a/docs/guides/developer/docs/participate/release-manager.md
+++ b/docs/guides/developer/docs/participate/release-manager.md
@@ -123,7 +123,7 @@ Example on how to create the Opencast 7 release branch:
 5. That is it for the release branch. Now update the versions in `develop` in preparation for the next release:
 
         git checkout develop
-        mvn versions:set -DnewVersion=8-SNAPSHOT versions:commit
+        ./mvnw versions:set -DnewVersion=8-SNAPSHOT versions:commit
 
 6. Have a look at the changes. Make sure that nothing else was modified:
 
@@ -353,7 +353,7 @@ The following steps outline the necessary steps for cutting the final release:
 
 4. Make the version changes for the release:
 
-        mvn versions:set -DnewVersion=6.0 versions:commit
+        ./mvnw versions:set -DnewVersion=6.0 versions:commit
 
 5. Have a look at the changes. Make sure that nothing else was modified:
 

--- a/mvnw
+++ b/mvnw
@@ -1,0 +1,308 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.2.0
+#
+# Required ENV vars:
+# ------------------
+#   JAVA_HOME - location of a JDK home dir
+#
+# Optional ENV vars
+# -----------------
+#   MAVEN_OPTS - parameters passed to the Java VM when running Maven
+#     e.g. to debug Maven itself, use
+#       set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+#   MAVEN_SKIP_RC - flag to disable loading of mavenrc files
+# ----------------------------------------------------------------------------
+
+if [ -z "$MAVEN_SKIP_RC" ] ; then
+
+  if [ -f /usr/local/etc/mavenrc ] ; then
+    . /usr/local/etc/mavenrc
+  fi
+
+  if [ -f /etc/mavenrc ] ; then
+    . /etc/mavenrc
+  fi
+
+  if [ -f "$HOME/.mavenrc" ] ; then
+    . "$HOME/.mavenrc"
+  fi
+
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+mingw=false
+case "$(uname)" in
+  CYGWIN*) cygwin=true ;;
+  MINGW*) mingw=true;;
+  Darwin*) darwin=true
+    # Use /usr/libexec/java_home if available, otherwise fall back to /Library/Java/Home
+    # See https://developer.apple.com/library/mac/qa/qa1170/_index.html
+    if [ -z "$JAVA_HOME" ]; then
+      if [ -x "/usr/libexec/java_home" ]; then
+        JAVA_HOME="$(/usr/libexec/java_home)"; export JAVA_HOME
+      else
+        JAVA_HOME="/Library/Java/Home"; export JAVA_HOME
+      fi
+    fi
+    ;;
+esac
+
+if [ -z "$JAVA_HOME" ] ; then
+  if [ -r /etc/gentoo-release ] ; then
+    JAVA_HOME=$(java-config --jre-home)
+  fi
+fi
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin ; then
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME=$(cygpath --unix "$JAVA_HOME")
+  [ -n "$CLASSPATH" ] &&
+    CLASSPATH=$(cygpath --path --unix "$CLASSPATH")
+fi
+
+# For Mingw, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$JAVA_HOME" ] && [ -d "$JAVA_HOME" ] &&
+    JAVA_HOME="$(cd "$JAVA_HOME" || (echo "cannot cd into $JAVA_HOME."; exit 1); pwd)"
+fi
+
+if [ -z "$JAVA_HOME" ]; then
+  javaExecutable="$(which javac)"
+  if [ -n "$javaExecutable" ] && ! [ "$(expr "\"$javaExecutable\"" : '\([^ ]*\)')" = "no" ]; then
+    # readlink(1) is not available as standard on Solaris 10.
+    readLink=$(which readlink)
+    if [ ! "$(expr "$readLink" : '\([^ ]*\)')" = "no" ]; then
+      if $darwin ; then
+        javaHome="$(dirname "\"$javaExecutable\"")"
+        javaExecutable="$(cd "\"$javaHome\"" && pwd -P)/javac"
+      else
+        javaExecutable="$(readlink -f "\"$javaExecutable\"")"
+      fi
+      javaHome="$(dirname "\"$javaExecutable\"")"
+      javaHome=$(expr "$javaHome" : '\(.*\)/bin')
+      JAVA_HOME="$javaHome"
+      export JAVA_HOME
+    fi
+  fi
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD="$(\unset -f command 2>/dev/null; \command -v java)"
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly." >&2
+  echo "  We cannot execute $JAVACMD" >&2
+  exit 1
+fi
+
+if [ -z "$JAVA_HOME" ] ; then
+  echo "Warning: JAVA_HOME environment variable is not set."
+fi
+
+# traverses directory structure from process work directory to filesystem root
+# first directory with .mvn subdirectory is considered project base directory
+find_maven_basedir() {
+  if [ -z "$1" ]
+  then
+    echo "Path not specified to find_maven_basedir"
+    return 1
+  fi
+
+  basedir="$1"
+  wdir="$1"
+  while [ "$wdir" != '/' ] ; do
+    if [ -d "$wdir"/.mvn ] ; then
+      basedir=$wdir
+      break
+    fi
+    # workaround for JBEAP-8937 (on Solaris 10/Sparc)
+    if [ -d "${wdir}" ]; then
+      wdir=$(cd "$wdir/.." || exit 1; pwd)
+    fi
+    # end of workaround
+  done
+  printf '%s' "$(cd "$basedir" || exit 1; pwd)"
+}
+
+# concatenates all lines of a file
+concat_lines() {
+  if [ -f "$1" ]; then
+    # Remove \r in case we run on Windows within Git Bash
+    # and check out the repository with auto CRLF management
+    # enabled. Otherwise, we may read lines that are delimited with
+    # \r\n and produce $'-Xarg\r' rather than -Xarg due to word
+    # splitting rules.
+    tr -s '\r\n' ' ' < "$1"
+  fi
+}
+
+log() {
+  if [ "$MVNW_VERBOSE" = true ]; then
+    printf '%s\n' "$1"
+  fi
+}
+
+BASE_DIR=$(find_maven_basedir "$(dirname "$0")")
+if [ -z "$BASE_DIR" ]; then
+  exit 1;
+fi
+
+MAVEN_PROJECTBASEDIR=${MAVEN_BASEDIR:-"$BASE_DIR"}; export MAVEN_PROJECTBASEDIR
+log "$MAVEN_PROJECTBASEDIR"
+
+##########################################################################################
+# Extension to allow automatically downloading the maven-wrapper.jar from Maven-central
+# This allows using the maven wrapper in projects that prohibit checking in binary data.
+##########################################################################################
+wrapperJarPath="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar"
+if [ -r "$wrapperJarPath" ]; then
+    log "Found $wrapperJarPath"
+else
+    log "Couldn't find $wrapperJarPath, downloading it ..."
+
+    if [ -n "$MVNW_REPOURL" ]; then
+      wrapperUrl="$MVNW_REPOURL/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar"
+    else
+      wrapperUrl="https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar"
+    fi
+    while IFS="=" read -r key value; do
+      # Remove '\r' from value to allow usage on windows as IFS does not consider '\r' as a separator ( considers space, tab, new line ('\n'), and custom '=' )
+      safeValue=$(echo "$value" | tr -d '\r')
+      case "$key" in (wrapperUrl) wrapperUrl="$safeValue"; break ;;
+      esac
+    done < "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.properties"
+    log "Downloading from: $wrapperUrl"
+
+    if $cygwin; then
+      wrapperJarPath=$(cygpath --path --windows "$wrapperJarPath")
+    fi
+
+    if command -v wget > /dev/null; then
+        log "Found wget ... using wget"
+        [ "$MVNW_VERBOSE" = true ] && QUIET="" || QUIET="--quiet"
+        if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
+            wget $QUIET "$wrapperUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
+        else
+            wget $QUIET --http-user="$MVNW_USERNAME" --http-password="$MVNW_PASSWORD" "$wrapperUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
+        fi
+    elif command -v curl > /dev/null; then
+        log "Found curl ... using curl"
+        [ "$MVNW_VERBOSE" = true ] && QUIET="" || QUIET="--silent"
+        if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
+            curl $QUIET -o "$wrapperJarPath" "$wrapperUrl" -f -L || rm -f "$wrapperJarPath"
+        else
+            curl $QUIET --user "$MVNW_USERNAME:$MVNW_PASSWORD" -o "$wrapperJarPath" "$wrapperUrl" -f -L || rm -f "$wrapperJarPath"
+        fi
+    else
+        log "Falling back to using Java to download"
+        javaSource="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/MavenWrapperDownloader.java"
+        javaClass="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/MavenWrapperDownloader.class"
+        # For Cygwin, switch paths to Windows format before running javac
+        if $cygwin; then
+          javaSource=$(cygpath --path --windows "$javaSource")
+          javaClass=$(cygpath --path --windows "$javaClass")
+        fi
+        if [ -e "$javaSource" ]; then
+            if [ ! -e "$javaClass" ]; then
+                log " - Compiling MavenWrapperDownloader.java ..."
+                ("$JAVA_HOME/bin/javac" "$javaSource")
+            fi
+            if [ -e "$javaClass" ]; then
+                log " - Running MavenWrapperDownloader.java ..."
+                ("$JAVA_HOME/bin/java" -cp .mvn/wrapper MavenWrapperDownloader "$wrapperUrl" "$wrapperJarPath") || rm -f "$wrapperJarPath"
+            fi
+        fi
+    fi
+fi
+##########################################################################################
+# End of extension
+##########################################################################################
+
+# If specified, validate the SHA-256 sum of the Maven wrapper jar file
+wrapperSha256Sum=""
+while IFS="=" read -r key value; do
+  case "$key" in (wrapperSha256Sum) wrapperSha256Sum=$value; break ;;
+  esac
+done < "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.properties"
+if [ -n "$wrapperSha256Sum" ]; then
+  wrapperSha256Result=false
+  if command -v sha256sum > /dev/null; then
+    if echo "$wrapperSha256Sum  $wrapperJarPath" | sha256sum -c > /dev/null 2>&1; then
+      wrapperSha256Result=true
+    fi
+  elif command -v shasum > /dev/null; then
+    if echo "$wrapperSha256Sum  $wrapperJarPath" | shasum -a 256 -c > /dev/null 2>&1; then
+      wrapperSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available."
+    echo "Please install either command, or disable validation by removing 'wrapperSha256Sum' from your maven-wrapper.properties."
+    exit 1
+  fi
+  if [ $wrapperSha256Result = false ]; then
+    echo "Error: Failed to validate Maven wrapper SHA-256, your Maven wrapper might be compromised." >&2
+    echo "Investigate or delete $wrapperJarPath to attempt a clean download." >&2
+    echo "If you updated your Maven version, you need to update the specified wrapperSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+MAVEN_OPTS="$(concat_lines "$MAVEN_PROJECTBASEDIR/.mvn/jvm.config") $MAVEN_OPTS"
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME=$(cygpath --path --windows "$JAVA_HOME")
+  [ -n "$CLASSPATH" ] &&
+    CLASSPATH=$(cygpath --path --windows "$CLASSPATH")
+  [ -n "$MAVEN_PROJECTBASEDIR" ] &&
+    MAVEN_PROJECTBASEDIR=$(cygpath --path --windows "$MAVEN_PROJECTBASEDIR")
+fi
+
+# Provide a "standardized" way to retrieve the CLI args that will
+# work with both Windows and non-Windows executions.
+MAVEN_CMD_LINE_ARGS="$MAVEN_CONFIG $*"
+export MAVEN_CMD_LINE_ARGS
+
+WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+
+# shellcheck disable=SC2086 # safe args
+exec "$JAVACMD" \
+  $MAVEN_OPTS \
+  $MAVEN_DEBUG_OPTS \
+  -classpath "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar" \
+  "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
+  ${WRAPPER_LAUNCHER} $MAVEN_CONFIG "$@"


### PR DESCRIPTION
The Maven wrapper is handy if you need to install the necessary Maven version but cannot upgrade/downgrade or don't want to install Maven at all.

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
