### PR TITLE
Fix Paella 7 with no segments

### DIFF
--- a/modules/engage-paella-player-7/package-lock.json
+++ b/modules/engage-paella-player-7/package-lock.json
@@ -9,7 +9,7 @@
         "paella-basic-plugins": "^1.44.0",
         "paella-core": "^1.46.1",
         "paella-skins": "^1.32.3",
-        "paella-slide-plugins": "^1.41.1",
+        "paella-slide-plugins": "^1.41.4",
         "paella-user-tracking": "^1.42.0",
         "paella-zoom-plugin": "^1.41.1"
       },
@@ -1828,19 +1828,6 @@
         "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
-    "node_modules/@jridgewell/source-map/node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "dev": true,
@@ -3046,9 +3033,10 @@
       }
     },
     "node_modules/css-loader/node_modules/semver": {
-      "version": "7.5.0",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -4315,9 +4303,10 @@
       }
     },
     "node_modules/html-validate/node_modules/semver": {
-      "version": "7.5.0",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -4996,7 +4985,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "dev": true,
       "funding": [
         {
@@ -5004,7 +4995,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -5226,11 +5216,11 @@
       "integrity": "sha512-u0kJnnAqTUI36bEuLSjHXdqX8fahXgUj4kbjxkOQ3rQ4t/X5eVHX2wX6P6kcIyGmyBjCL5XNJte8vyJMmMiX5A=="
     },
     "node_modules/paella-slide-plugins": {
-      "version": "1.41.1",
-      "resolved": "https://registry.npmjs.org/paella-slide-plugins/-/paella-slide-plugins-1.41.1.tgz",
-      "integrity": "sha512-/lpzn4eor7ESdFWC5oYVALLpMzKlFsX4wvlO3xfJbon0RV1lUm6IlmBuzt98itKq5T8wUrax34tXEUBmibotAA==",
+      "version": "1.41.4",
+      "resolved": "https://registry.npmjs.org/paella-slide-plugins/-/paella-slide-plugins-1.41.4.tgz",
+      "integrity": "sha512-HdXsY6+X6vOlktQexb2TF36Lt0RGWCKapM/58ObN7bwb+mn7AMrCUoTHtVYJThMTzgkzX0JhpfEvZV2o9HZMMw==",
       "dependencies": {
-        "paella-core": "^1.44.1"
+        "paella-core": "^1.44.2"
       }
     },
     "node_modules/paella-user-tracking": {
@@ -5438,7 +5428,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.23",
+      "version": "8.4.32",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
+      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
       "dev": true,
       "funding": [
         {
@@ -5454,9 +5446,8 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -8256,17 +8247,6 @@
       "requires": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
-      },
-      "dependencies": {
-        "@jridgewell/gen-mapping": {
-          "version": "0.3.3",
-          "dev": true,
-          "requires": {
-            "@jridgewell/set-array": "^1.0.1",
-            "@jridgewell/sourcemap-codec": "^1.4.10",
-            "@jridgewell/trace-mapping": "^0.3.9"
-          }
-        }
       }
     },
     "@jridgewell/sourcemap-codec": {
@@ -9100,7 +9080,9 @@
           }
         },
         "semver": {
-          "version": "7.5.0",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -9893,7 +9875,9 @@
           }
         },
         "semver": {
-          "version": "7.5.0",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -10296,7 +10280,9 @@
       }
     },
     "nanoid": {
-      "version": "3.3.6",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "dev": true
     },
     "natural-compare": {
@@ -10435,11 +10421,11 @@
       "integrity": "sha512-u0kJnnAqTUI36bEuLSjHXdqX8fahXgUj4kbjxkOQ3rQ4t/X5eVHX2wX6P6kcIyGmyBjCL5XNJte8vyJMmMiX5A=="
     },
     "paella-slide-plugins": {
-      "version": "1.41.1",
-      "resolved": "https://registry.npmjs.org/paella-slide-plugins/-/paella-slide-plugins-1.41.1.tgz",
-      "integrity": "sha512-/lpzn4eor7ESdFWC5oYVALLpMzKlFsX4wvlO3xfJbon0RV1lUm6IlmBuzt98itKq5T8wUrax34tXEUBmibotAA==",
+      "version": "1.41.4",
+      "resolved": "https://registry.npmjs.org/paella-slide-plugins/-/paella-slide-plugins-1.41.4.tgz",
+      "integrity": "sha512-HdXsY6+X6vOlktQexb2TF36Lt0RGWCKapM/58ObN7bwb+mn7AMrCUoTHtVYJThMTzgkzX0JhpfEvZV2o9HZMMw==",
       "requires": {
-        "paella-core": "^1.44.1"
+        "paella-core": "^1.44.2"
       }
     },
     "paella-user-tracking": {
@@ -10568,10 +10554,12 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.4.23",
+      "version": "8.4.32",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
+      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
       "dev": true,
       "requires": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       }

--- a/modules/engage-paella-player-7/package.json
+++ b/modules/engage-paella-player-7/package.json
@@ -39,7 +39,7 @@
     "paella-basic-plugins": "^1.44.0",
     "paella-core": "^1.46.1",
     "paella-skins": "^1.32.3",
-    "paella-slide-plugins": "^1.41.1",
+    "paella-slide-plugins": "^1.41.4",
     "paella-user-tracking": "^1.42.0",
     "paella-zoom-plugin": "^1.41.1"
   }


### PR DESCRIPTION
This patch fixes the issue that Paella player 7 will run into an error if a video has no segments, for example, because the slide detection did not run.

![Screenshot from 2023-12-17 21-42-49](https://github.com/opencast/opencast/assets/1008395/689f8df6-b33f-4783-9735-3611bc916d45)


Fixed in paella-slide-plugins in:
https://github.com/polimediaupv/paella-slide-plugins/pull/4

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
