### PR TITLE
Paella7: Add support for text/vtt captions in DownloadsPlugin

### DIFF
--- a/etc/ui-config/mh_default_org/paella7/config.json
+++ b/etc/ui-config/mh_default_org/paella7/config.json
@@ -413,7 +413,7 @@
 
             "downloadFlavors": false,
             "downloadTags": false,
-            "downloadMimeTypes": ["audio/m4a", "video/mp4"],
+            "downloadMimeTypes": ["audio/m4a", "video/mp4", "text/vtt"],
 
             "enableOnLicenses": [
                 "CC-BY",

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.downloadsPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.downloadsPlugin.js
@@ -103,6 +103,7 @@ export default class DownloadsPlugin extends PopUpButtonPlugin {
         type: track.type,
         mimetype: track.mimetype,
         url: track.url,
+        tags: track?.tags?.tag ?? [],
         metadata: {
           video: vmeta,
           audio: ameta
@@ -133,11 +134,20 @@ export default class DownloadsPlugin extends PopUpButtonPlugin {
       streamDownloads.forEach(d => {
         const vmeta = d?.metadata?.video?.res;
         const ameta = d?.metadata?.audio?.samplingrate ? `${d?.metadata?.audio?.samplingrate} Hz` : null;
-        const meta = vmeta ?? ameta ?? '';
+        let cmeta = '';
+        if (d.mimetype == 'text/vtt') {
+          const lang_tag = d?.tags?.filter(x => x.startsWith('lang:'));
+          if (lang_tag.length > 0) {
+            const captions_lang = lang_tag[0].split(':')[1];
+            const languageNames = new Intl.DisplayNames([window.navigator.language], {type: 'language'});
+            cmeta = languageNames.of(captions_lang) || translate('Unknown language');
+          }
+        }
+        const meta = vmeta ?? ameta ?? cmeta ?? '';
 
         createElementWithHtmlText(`
                 <li>
-                  <a href="${d.url}" target="_blank">
+                  <a href="${d.url}" download target="_blank">
                     <span class="mimetype">[${d.mimetype}]</span><span class="res">${meta}</span>
                   </a>
                 </li>


### PR DESCRIPTION
This PR adds the captions files to the paella7 downloads plugin
![Captura de pantalla 2023-12-20 a las 9 51 53](https://github.com/opencast/opencast/assets/2735202/2cf3e4d7-ec83-4945-be7c-d7e15a6a2155)

### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
