### PR TITLE
Add support for custom actions in ACL to Tobira harvest API

### DIFF
--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Harvest.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Harvest.java
@@ -23,6 +23,7 @@ package org.opencastproject.tobira.impl;
 
 import org.opencastproject.search.api.SearchQuery;
 import org.opencastproject.search.api.SearchService;
+import org.opencastproject.security.api.AuthorizationService;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.series.api.SeriesException;
 import org.opencastproject.series.api.SeriesService;
@@ -71,6 +72,7 @@ final class Harvest {
       Date since,
       SearchService searchService,
       SeriesService seriesService,
+      AuthorizationService authorizationService,
       Workspace workspace
   ) throws UnauthorizedException, SeriesException {
     // Retrieve episodes from index.
@@ -137,7 +139,7 @@ final class Harvest {
         })
         .map(event -> {
           try {
-            return new Item(event, workspace);
+            return new Item(event, authorizationService, workspace);
           } catch (Exception e) {
             var id = event == null ? null : event.getId();
             logger.error("Error reading event '{}' (skipping...)", id, e);

--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/TobiraEndpoint.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/TobiraEndpoint.java
@@ -26,6 +26,7 @@ import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static org.opencastproject.util.doc.rest.RestParameter.Type;
 
 import org.opencastproject.search.api.SearchService;
+import org.opencastproject.security.api.AuthorizationService;
 import org.opencastproject.series.api.SeriesService;
 import org.opencastproject.util.Jsons;
 import org.opencastproject.util.doc.rest.RestParameter;
@@ -94,11 +95,12 @@ public class TobiraEndpoint {
   // adding new JSON fields is a non-breaking change. You should also consider whether Tobira needs
   // to resynchronize, i.e. to get new data.
   private static final int VERSION_MAJOR = 1;
-  private static final int VERSION_MINOR = 3;
+  private static final int VERSION_MINOR = 4;
   private static final String VERSION = VERSION_MAJOR + "." + VERSION_MINOR;
 
   private SearchService searchService;
   private SeriesService seriesService;
+  private AuthorizationService authorizationService;
   private Workspace workspace;
 
   @Activate
@@ -114,6 +116,11 @@ public class TobiraEndpoint {
   @Reference
   public void setSeriesService(SeriesService service) {
     this.seriesService = service;
+  }
+
+  @Reference
+  public void setAuthorizationService(AuthorizationService service) {
+    this.authorizationService = service;
   }
 
   @Reference
@@ -190,7 +197,9 @@ public class TobiraEndpoint {
 
     try {
       var json = Harvest.harvest(
-          preferredAmount, new Date(since), searchService, seriesService, workspace);
+          preferredAmount,
+          new Date(since),
+          searchService, seriesService, authorizationService, workspace);
 
       // TODO: encoding
       return Response.ok(json.toJson()).build();


### PR DESCRIPTION
Previously, only read and write roles were transmitted.

This can go into 14 as it is not a breaking change. Well, one thing changes: `ROLE_ADMIN` is not explicitly included in the event ACL anymore. But since this is not a public free-for-all API, but only used by Tobira, and since Tobira has implicit `ROLE_ADMIN` checks everywhere, this is no problem. In fact, Tobira even removes `ROLE_ADMIN` in the incoming ACL before storing it in the DB.

Related issue: https://github.com/elan-ev/tobira/issues/1004

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
