### PR TITLE
Fix broken link in markdown documentation

### DIFF
--- a/docs/guides/admin/docs/configuration/youtubepublication.md
+++ b/docs/guides/admin/docs/configuration/youtubepublication.md
@@ -85,7 +85,7 @@ With the JSON file created and saved previously, you have to proceed as describe
 ## Add YouTube publication to your Opencast workflows
 
 Opencast can now publish to YouTube. To make use of this, add the [Publish YouTube workflow operation](../workflowoperationhandlers/publish-youtube-woh.md)
-to your Opencast workflows. You can find more details on how to use the operation on its [own page]((../workflowoperationhandlers/publish-youtube-woh.md)).
+to your Opencast workflows. You can find more details on how to use the operation on its [own page](../workflowoperationhandlers/publish-youtube-woh.md).
 In general, it should be placed near your other `publish` operations.
 
 You may also want to add the [Retract YouTube workflow operation](../workflowoperationhandlers/retract-youtube-woh.md) 


### PR DESCRIPTION
This PR fixes a bug in the markdown docs which didn't cause them to fail, but did throw a warning on every build.


### Your pull request should…

* [x] have a concise title
* [x] ~[close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
