### PR TITLE
Editor shouldn't just overwrite existing files

### DIFF
--- a/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/ffmpeg/FFmpegEdit.java
+++ b/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/ffmpeg/FFmpegEdit.java
@@ -238,7 +238,6 @@ public class FFmpegEdit {
       }
       outmap = "o";                 // if more than one clip
     }
-    command.add("-y");      // overwrite old pathname
     for (String o : inputfiles) {
       command.add("-i");   // Add inputfile in the order of entry
       command.add(o);


### PR DESCRIPTION
The video editor of Opencast starts FFmpeg with the flag `-y`, meaning that existing files will just be overwritten if they exist. That is dangerous. Target files should never exist or there is something seriously wrong. In that case, just overwriting stuff could potentially lead to data loss. Better take the error and make sure users know about the problem.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
