### PR TITLE
Avoid unnecessary FFmpeg logs

### DIFF
--- a/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/ffmpeg/FFmpegEdit.java
+++ b/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/ffmpeg/FFmpegEdit.java
@@ -111,6 +111,9 @@ public class FFmpegEdit {
     BufferedReader in = null;
     Process encoderProcess = null;
     try {
+      params.add(0, "-nostats");
+      params.add(0, "-nostdin");
+      params.add(0, "-hide_banner");
       params.add(0, binary);
       logger.info("executing command: " + StringUtils.join(params, " "));
       ProcessBuilder pbuilder = new ProcessBuilder(params);


### PR DESCRIPTION
This patch adds a few flags to the FFmpeg command used by the editor to reduce the amount of unnecessary logs.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
