### PR TITLE
Don't log internal AmberScript service state

### DIFF
--- a/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/AmberscriptTranscriptionService.java
+++ b/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/AmberscriptTranscriptionService.java
@@ -1062,7 +1062,7 @@ public class AmberscriptTranscriptionService extends AbstractJobProducer impleme
             final AResult r = q.select(q.snapshot()).where(q.mediaPackageId(mpId).and(q.version().isLatest())).run();
             if (r.getSize() == 0) {
               // Media package not archived yet? Skip until next time.
-              logger.warn("Media package {} has not been archived yet. Skipped.", mpId);
+              logger.debug("Media package {} has not been archived yet. Skipped.", mpId);
               continue;
             }
 


### PR DESCRIPTION
This patch reduces the log level for the AmberScript service informing us about a running workflow (which happens all the time and is usually of no interest to admins) to a debug log level. We use AmberScript a lot and our logs are full of these statements.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
