### PR TITLE
Paella 7: Download audio trancripts (without timestamps)

### DIFF
--- a/modules/engage-paella-player-7/src/css/DownloadsPlugin.css
+++ b/modules/engage-paella-player-7/src/css/DownloadsPlugin.css
@@ -30,6 +30,10 @@
     color: lightsalmon;
 }
 
+.downloads-plugin .downloadStream .transcript {
+    color: coral;
+}
+
 
 .downloads-plugin a {
     color: lightsalmon;


### PR DESCRIPTION
This PR adds the  ability to download the captions files without the timestamps.

![Captura de pantalla 2024-01-08 a las 12 01 18](https://github.com/opencast/opencast/assets/2735202/e82ee3db-0ad1-4645-9456-b06a5525aba2)

- Click on `text\vtt` to download the vtt file (with timestamps)
- Click on `transcript` to download only the text (without timestamps).

### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
