### PR TITLE
Fix ACL template selection breaking after first selection

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
@@ -484,6 +484,7 @@ angular.module('adminNg.controllers')
           $scope.access = EventAccessResource.get({ id: id }, function (data) {
             if (angular.isDefined(data.episode_access)) {
               $scope.baseAclId = data.episode_access.current_acl.toString();
+              $scope.baseAclId = $scope.baseAclId === 0 ? $scope.baseAclId : undefined;
               var json = angular.fromJson(data.episode_access.acl);
               $scope.aclCreateDefaults.$promise.then(function () { // needed for roleUserPrefix
                 changePolicies(json.acl.ace, true);
@@ -704,7 +705,7 @@ angular.module('adminNg.controllers')
     $scope.policies = [];
     $scope.policiesUser = [];
     $scope.baseAcl = {};
-    $scope.baseAclId = '';
+    $scope.baseAclId = undefined;
 
     $scope.not = function(func) {
       return function (item) {
@@ -1038,6 +1039,7 @@ angular.module('adminNg.controllers')
       $scope.access = EventAccessResource.get({ id: $scope.resourceId }, function (data) {
         if (angular.isDefined(data.episode_access)) {
           $scope.baseAclId = data.episode_access.current_acl.toString();
+          $scope.baseAclId = $scope.baseAclId === 0 ? $scope.baseAclId : undefined;
           var json = angular.fromJson(data.episode_access.acl);
           $scope.aclCreateDefaults.$promise.then(function () { // needed for roleUserPrefix
             changePolicies(json.acl.ace, true);

--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/serieController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/serieController.js
@@ -109,7 +109,7 @@ angular.module('adminNg.controllers')
     $scope.policies = [];
     $scope.policiesUser = [];
     $scope.baseAcl = {};
-    $scope.baseAclId = '';
+    $scope.baseAclId = undefined;
 
     AuthService.getUser().$promise.then(function (user) {
       var mode = user.org.properties['admin.series.acl.event.update.mode'];
@@ -425,6 +425,7 @@ angular.module('adminNg.controllers')
             changePolicies(json.acl.ace, true);
             getCurrentPolicies();
             $scope.baseAclId = data.series_access.current_acl.toString();
+            $scope.baseAclId = $scope.baseAclId === 0 ? $scope.baseAclId : undefined;
 
             $scope.aclLocked = data.series_access.locked;
 

--- a/modules/admin-ui-frontend/app/scripts/modules/users/controllers/aclController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/users/controllers/aclController.js
@@ -101,7 +101,7 @@ angular.module('adminNg.controllers')
     $scope.policies = [];
     $scope.policiesUser = [];
     $scope.baseAcl = {};
-    $scope.baseAclId = '';
+    $scope.baseAclId = undefined;
     $scope.metadata = {};
 
     $scope.changeBaseAcl = function (id) {
@@ -251,6 +251,7 @@ angular.module('adminNg.controllers')
             var json = angular.fromJson(data.acl);
             changePolicies(json.ace, true);
             $scope.baseAclId = data.acl.id.toString();
+            $scope.baseAclId = $scope.baseAclId === 0 ? $scope.baseAclId : undefined;
           }
 
           angular.forEach(angular.fromJson(data.acl.ace), function(value, key) {

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/acl-details.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/acl-details.html
@@ -86,7 +86,9 @@
                                     ng-options="id as name for (id, name) in acls"
                                     placeholder-text-single="'{{ 'USERS.ACLS.DETAILS.ACCESS.ACCESS_POLICY.LABEL' | translate }}'"
                                     no-results-text="'{{ 'USERS.ACLS.DETAILS.ACCESS.ACCESS_POLICY.EMPTY' | translate }}'"
-                                    ></select>
+                                    >
+                                    <option value=""></option>
+                            </select>
                           </div>
                         </td>
                       </tr>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/event-details.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/event-details.html
@@ -579,7 +579,9 @@
                                       ng-options="id as name for (id, name) in acls"
                                       placeholder-text-single="'{{ 'EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.LABEL' | translate }}'"
                                       no-results-text="'{{ 'EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.EMPTY' | translate }}'"
-                                      ></select>
+                                      >
+                                      <option value=""></option>
+                              </select>
                             </div>
                             <p ng-show="transactions.read_only">{{baseAclId}}</p>
                           </div>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/series-details.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/series-details.html
@@ -189,7 +189,9 @@
                                     ng-options="id as name for (id, name) in acls"
                                     placeholder-text-single="'{{ 'EVENTS.SERIES.DETAILS.ACCESS.ACCESS_POLICY.LABEL' | translate }}'"
                                     no-results-text="'{{ 'EVENTS.SERIES.DETAILS.ACCESS.ACCESS_POLICY.EMPTY' | translate }}'"
-                                    ></select>
+                                    >
+                                    <option value=""></option>
+                            </select>
                           </div>
                         </td>
                       </tr>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-acl.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-acl.html
@@ -62,7 +62,9 @@
                                          ng-options="id as name for (id, name) in wizard.step.acls"
                                          placeholder-text-single="'{{ 'USERS.ACLS.NEW.ACCESS.ACCESS_POLICY.LABEL' | translate }}'"
                                          no-results-text="'{{ 'USERS.ACLS.NEW.ACCESS.ACCESS_POLICY.EMPTY' | translate }}'"
-                                         ></select>
+                                         >
+                                         <option value=""></option>
+                          </select>
                         </div>
                       </td>
                     </tr>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-event.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-event.html
@@ -522,7 +522,9 @@
                                   ng-options="id as name for (id, name) in wizard.step.acls"
                                   placeholder-text-single="'{{ 'EVENTS.SERIES.NEW.ACCESS.ACCESS_POLICY.LABEL' | translate }}'"
                                   no-results-text="'{{ 'EVENTS.SERIES.NEW.ACCESS.ACCESS_POLICY.EMPTY' | translate }}'"
-                                  ></select>
+                                  >
+                                  <option value=""></option>
+                          </select>
                         </div>
                       </td>
                     </tr>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-series.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-series.html
@@ -88,7 +88,9 @@
                                   ng-options="id as name for (id, name) in wizard.step.acls"
                                   placeholder-text-single="'{{ 'EVENTS.SERIES.NEW.ACCESS.ACCESS_POLICY.LABEL' | translate }}'"
                                   no-results-text="'{{ 'EVENTS.SERIES.NEW.ACCESS.ACCESS_POLICY.EMPTY' | translate }}'"
-                                  ></select>
+                                  >
+                                  <option value=""></option>
+                          </select>
                         </div>
                       </td>
                     </tr>

--- a/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-acl/access.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-acl/access.js
@@ -41,7 +41,7 @@ angular.module('adminNg.services')
 
       me.isAccessState = true;
       me.ud = {};
-      me.ud.id = {};
+      me.ud.id = undefined;
       me.ud.policies = [];
       me.ud.policiesUser = [];
       me.ud.baseAcl = {};

--- a/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-event/access.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-event/access.js
@@ -150,7 +150,7 @@ angular.module('adminNg.services')
 
       me.isAccessState = true;
       me.ud = {};
-      me.ud.id = {};
+      me.ud.id = undefined;
       me.ud.policies = [];
       me.ud.policiesUser = [];
       me.ud.baseAcl = {};

--- a/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-series/access.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-series/access.js
@@ -78,7 +78,7 @@ angular.module('adminNg.services')
           };
 
       me.ud = {};
-      me.ud.id = {};
+      me.ud.id = undefined;
       me.ud.policies = [];
       me.ud.policiesUser = [];
       me.ud.baseAcl = {};


### PR DESCRIPTION
The template selection dropdown for access policies in e.g. the event details is broken. After selecting an access policy, when trying to select another access policy, the rules from the access policy above the selected access policy will be selected.
For example, if you have `public, authenticated, private` and select `public`, you get the aces for `public`. If you then select `authenticated` you get the aces for `public`. Then selecting `private` will lead to an error.

This fixes that. Apparently the angularjs select thingy breaks if you set ng-model to a value that is not in ng-options (e.g. setting it ng-model to `0`, but ng-options only contains `951, 952, 953`). This commit sets it to `undefined` instead, which angularjs seems to be able to handle.
