### PR TITLE
Don't warn about using the default tool

### DIFF
--- a/modules/lti/src/main/java/org/opencastproject/lti/LtiServlet.java
+++ b/modules/lti/src/main/java/org/opencastproject/lti/LtiServlet.java
@@ -241,7 +241,7 @@ public class LtiServlet extends HttpServlet {
         builder = UriBuilder.fromUri(toolUri).scheme(null).host(null).userInfo(null).port(-1);
       }
     } catch (URISyntaxException ex) {
-      logger.warn("The 'custom_tool' parameter was invalid: '{}'. Reverting to default: '{}'",
+      logger.debug("The 'custom_tool' parameter was invalid: '{}'. Reverting to default: '{}'",
               Arrays.toString(req.getParameterValues(LTI_CUSTOM_TOOL)), TOOLS_URL);
       builder = UriBuilder.fromPath(TOOLS_URL);
     }


### PR DESCRIPTION
If an LTI consumer does not specify a tool to use, Opencast will use the default tool. That's just fine and expected in some cases.

However, Opencast will log a warning every time this is being used, causing an excessive amount of unnecessary logs like these:

```
2024-01-07T09:32:50,808 | WARN  | (LtiServlet:244) - The 'custom_tool' parameter was invalid: 'null'. Reverting to default: '/ltitools'
2024-01-07T09:54:18,405 | WARN  | (LtiServlet:244) - The 'custom_tool' parameter was invalid: 'null'. Reverting to default: '/ltitools'
2024-01-07T10:04:31,447 | WARN  | (LtiServlet:244) - The 'custom_tool' parameter was invalid: 'null'. Reverting to default: '/ltitools'
2024-01-07T10:05:06,044 | WARN  | (LtiServlet:244) - The 'custom_tool' parameter was invalid: 'null'. Reverting to default: '/ltitools'
2024-01-07T10:06:01,375 | WARN  | (LtiServlet:244) - The 'custom_tool' parameter was invalid: 'null'. Reverting to default: '/ltitools'
2024-01-07T10:11:49,238 | WARN  | (LtiServlet:244) - The 'custom_tool' parameter was invalid: 'null'. Reverting to default: '/ltitools'
2024-01-07T10:15:01,609 | WARN  | (LtiServlet:244) - The 'custom_tool' parameter was invalid: 'null'. Reverting to default: '/ltitools'
2024-01-07T10:15:12,961 | WARN  | (LtiServlet:244) - The 'custom_tool' parameter was invalid: 'null'. Reverting to default: '/ltitools'
2024-01-07T10:15:40,276 | WARN  | (LtiServlet:244) - The 'custom_tool' parameter was invalid: 'null'. Reverting to default: '/ltitools'
```

This patch reduces the log level for this type of message to debug.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
