### PR TITLE
Fix Paella Player 7 for single stream videos

### DIFF
--- a/modules/engage-paella-player-7/src/js/EpisodeConversor.js
+++ b/modules/engage-paella-player-7/src/js/EpisodeConversor.js
@@ -120,7 +120,13 @@ function getMetadata(episode, config) {
       : [episode.mediapackage.contributors.contributor])
     : [];
 
-  const isLive = episode?.mediapackage?.media?.track?.some((track) => track.live === true);
+  const tracks = episode?.mediapackage?.media?.track
+    ? (Array.isArray(episode.mediapackage.media.track)
+      ? episode.mediapackage.media.track
+      : [episode.mediapackage.media.track])
+    : [];
+
+  const isLive = tracks.some((track) => track.live === true);
   const visibleTimeLine = !(isLive && config?.hideTimeLineOnLive);
 
   const result = {


### PR DESCRIPTION
Currently if we open the Paella Player 7 for an event that has only one track (careful: captions count as tracks!), we get an error "s.some is not a track". This was broken by the isLive check from #5420 and happens because a single track is not wrapped in an array when the episode is returned by the search service. This fixes that by doing that first. It won't win any awards for being pretty, but it works. ;)

