### PR TITLE
Update xmlsec version (CAS fix)

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -658,7 +658,7 @@
   <feature name="opencast-security-cas" version="${project.version}">
     <bundle start-level="82">mvn:commons-collections/commons-collections/3.2.1</bundle>
     <bundle start-level="82">mvn:org.apache.velocity/velocity/1.7</bundle>
-    <bundle start-level="82">mvn:org.apache.santuario/xmlsec/2.1.2</bundle>
+    <bundle start-level="82">mvn:org.apache.santuario/xmlsec/${xmlsec.version}</bundle>
     <bundle start-level="82">mvn:org.bouncycastle/bcprov-jdk15on/1.51</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-security-cas-client-wrapper/${project.version}</bundle>
     <bundle start-level="82">mvn:org.springframework.security/spring-security-core/3.1.7.RELEASE</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
     <rest-assured.version>4.4.0</rest-assured.version>
     <spring.version>3.1.4.RELEASE</spring.version>
     <spring-security.version>3.1.7.RELEASE</spring-security.version>
+    <xmlsec.version>2.2.6</xmlsec.version>
   </properties>
   <modules>
     <module>modules/admin-ui</module>
@@ -1106,7 +1107,7 @@
       <dependency>
         <groupId>org.apache.santuario</groupId>
         <artifactId>xmlsec</artifactId>
-        <version>2.2.6</version>
+        <version>${xmlsec.version}</version>
       </dependency>
       <dependency>
         <groupId>org.owasp.esapi</groupId>


### PR DESCRIPTION
The `xmlsec` dependency version did not match the version included in the `opencast-security-cas` feature.

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
