### PR TITLE
Use edited thumbnails in partial-publish.xml

### DIFF
--- a/etc/workflows/partial-publish.xml
+++ b/etc/workflows/partial-publish.xml
@@ -136,6 +136,7 @@
 
     <operation
       id="image"
+      if="NOT ${presentation/thumbnail_edited}"
       exception-handler-workflow="partial-error"
       description="Creating player preview image for presentation video">
       <configurations>
@@ -144,6 +145,17 @@
         <configuration key="target-tags">engage-download</configuration>
         <configuration key="encoding-profile">player-preview.http</configuration>
         <configuration key="time">3</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+        id="tag"
+        if="${presentation/thumbnail_edited}"
+        exception-handler-workflow="partial-error"
+        description="Prepare thumbnail for publication">
+      <configurations>
+        <configuration key="source-flavor">presentation/player+preview</configuration>
+        <configuration key="target-tags">+engage-download</configuration>
       </configurations>
     </operation>
 
@@ -167,6 +179,7 @@
 
     <operation
         id="image"
+        if="NOT ${presenter/thumbnail_edited}"
         exception-handler-workflow="partial-error"
         description="Creating player preview image for presenter video">
       <configurations>
@@ -175,6 +188,18 @@
         <configuration key="target-tags">engage-download</configuration>
         <configuration key="encoding-profile">player-preview.http</configuration>
         <configuration key="time">3</configuration>
+      </configurations>
+    </operation>
+
+
+    <operation
+        id="tag"
+        if="${presenter/thumbnail_edited}"
+        exception-handler-workflow="partial-error"
+        description="Prepare thumbnail for publication">
+      <configurations>
+        <configuration key="source-flavor">presenter/player+preview</configuration>
+        <configuration key="target-tags">+engage-download</configuration>
       </configurations>
     </operation>
 


### PR DESCRIPTION
Intended to resolve #5541.

While thumbnails created in the (new) editor are stored in Opencast, they currently go unused. This changes partial-publish.xml (aka the default editor workflow) to use thumbnails created in the editor for publication.

Discussion points:
- Currently this uses the thumbnails from the editor as is. Maybe they should be encoded in some way?
- This only touches upon the thumbnails for the engage player. Other thumbnails (for search, feed cover) are ignored. Should they also be changed?
