### PR TITLE
Encoding profile fix for portrait videos

### DIFF
--- a/etc/encoding/opencast.properties
+++ b/etc/encoding/opencast.properties
@@ -36,21 +36,21 @@ profile.adaptive-parallel.http.suffix.720p-quality = -720p.mp4
 profile.adaptive-parallel.http.suffix.1080p-quality = -1080p.mp4
 profile.adaptive-parallel.http.suffix.1440p-quality = -1440p.mp4
 profile.adaptive-parallel.http.suffix.2160p-quality = -2160p.mp4
-profile.adaptive-parallel.http.ffmpeg.command.if-width-or-height-geq-1600-900 = \
+profile.adaptive-parallel.http.ffmpeg.command.if-width-or-height-geq-1600-1600 = \
   -filter:v scale=1920:1920:force_original_aspect_ratio=decrease:force_divisible_by=2,fps=25 \
     -pix_fmt yuv420p \
     -c:v libx264 -profile:v high -level 4.0 -crf 23 \
     -x264opts keyint=25:min-keyint=25:no-scenecut -maxrate 4000k -bufsize 8000k \
     -c:a aac -b:a 96k -ac 2 \
     -movflags faststart #{out.dir}/#{out.name}#{out.suffix.1080p-quality}
-profile.studio.adaptive-parallel.http.ffmpeg.command.if-width-or-height-geq-2440-1260 = \
+profile.studio.adaptive-parallel.http.ffmpeg.command.if-width-or-height-geq-2440-2440 = \
   -filter:v scale=2560:2560:force_original_aspect_ratio=decrease:force_divisible_by=2,fps=25 \
     -pix_fmt yuv420p \
     -c:v libx264 -profile:v high -level 5.0 -crf 23 \
     -x264opts keyint=25:min-keyint=25:no-scenecut -maxrate 9800k -bufsize 19600k \
     -c:a aac -b:a 96k -ac 2 \
     -movflags faststart #{out.dir}/#{out.name}#{out.suffix.1440p-quality}
-profile.adaptive-parallel.http.ffmpeg.command.if-width-or-height-geq-3200-1800 = \
+profile.adaptive-parallel.http.ffmpeg.command.if-width-or-height-geq-3200-3200 = \
   -filter:v scale=3840:3840:force_original_aspect_ratio=decrease:force_divisible_by=2,fps=25 \
     -pix_fmt yuv420p \
     -c:v libx264 -profile:v high -level 5.1 -crf 23 \
@@ -70,9 +70,9 @@ profile.adaptive-parallel.http.ffmpeg.command = -i #{in.video.path} \
     -x264opts keyint=25:min-keyint=25:no-scenecut -maxrate 1200k -bufsize 2400k \
     -c:a aac -b:a 96k -ac 2 \
     -movflags faststart #{out.dir}/#{out.name}#{out.suffix.720p-quality} \
-  #{if-width-or-height-geq-1600-900} \
-  #{if-width-or-height-geq-2440-1260} \
-  #{if-width-or-height-geq-3200-1800}
+  #{if-width-or-height-geq-1600-1600} \
+  #{if-width-or-height-geq-2440-2440} \
+  #{if-width-or-height-geq-3200-3200}
 
 # Preview image for the player, shown before the movie is started
 profile.player-preview.http.name = cover image for engage


### PR DESCRIPTION
Resolution based encoding for delivery videos in portrait format is broken. Example given

Input video resolution | Maximum output video resolution
-----------------------|--------------------------------
1920x1080 | 1920x1080
1080x1920 | 2160x3840

We want not upscale videos per default. This patch fixes this.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
