### PR TITLE
Disable running Firefox from Karma on Macs

### DIFF
--- a/modules/admin-ui-frontend/test/karma.conf.js
+++ b/modules/admin-ui-frontend/test/karma.conf.js
@@ -23,28 +23,38 @@ module.exports = function (config) {
             '../bower_components/angular-chart.js/dist/angular-chart.js',
             '../bower_components/angular-mocks/angular-mocks.js',
             // endbower
-      '../app/scripts/lib/chosen.jquery.js',
-      '../app/scripts/lib/angular-chosen.js',
-      '../app/scripts/lib/underscore-1.5.2.js',
-      '../app/scripts/lib/video-js/video.js',
-      '../app/scripts/lib/moment-with-locales.js',
+            '../app/scripts/lib/chosen.jquery.js',
+            '../app/scripts/lib/angular-chosen.js',
+            '../app/scripts/lib/underscore-1.5.2.js',
+            '../app/scripts/lib/video-js/video.js',
+            '../app/scripts/lib/moment-with-locales.js',
 
-      '../app/scripts/app.js',
-      '../app/scripts/shared/filters/filters.js',
-      '../app/scripts/shared/resources/resources.js',
-      '../app/scripts/shared/directives/directives.js',
-      '../app/scripts/shared/controllers/controllers.js',
-      '../app/scripts/shared/services/services.js',
-      '../app/scripts/modules/**/*.js',
-      '../app/scripts/shared/**/*.js',
-      '../app/**/*.html',
+            '../app/scripts/app.js',
+            '../app/scripts/shared/filters/filters.js',
+            '../app/scripts/shared/resources/resources.js',
+            '../app/scripts/shared/directives/directives.js',
+            '../app/scripts/shared/controllers/controllers.js',
+            '../app/scripts/shared/services/services.js',
+            '../app/scripts/modules/**/*.js',
+            '../app/scripts/shared/**/*.js',
+            '../app/**/*.html',
 
             'test/lib/jasmine-jquery.js',
             'test/lib/jquery-deparam.js',
 
             // fixtures
-      {pattern: '../resources/public/**/*.json', watched: true, served: true, included: false},
-      {pattern: 'app/GET/**/*', watched: true, served: true, included: false},
+            {
+                pattern: '../resources/public/**/*.json',
+                watched: true,
+                served: true,
+                included: false
+            },
+            {
+                pattern: 'app/GET/**/*',
+                watched: true,
+                served: true,
+                included: false
+            },
 
             'test/unit/setup.js',
             'test/unit/**/*Helper.js',
@@ -61,14 +71,14 @@ module.exports = function (config) {
             preferHeadless: true,
             // limit the list of browsers used by karma
             postDetection: (browsers) => {
-                const allowed = new Set(['ChromeHeadless', 'FirefoxHeadless'])
+                const allowed = new Set(['ChromeHeadless', 'FirefoxHeadless']);
                 console.info('Detected browsers: ' + browsers);
                 browsers = browsers.filter(browser => allowed.has(browser));
                 console.info('Usable browsers: ' + browsers);
                 if (browsers.length < 1) {
-                    console.error("No browsers detected");
-                    console.error("Suggest installing Firefox or other FOSS browser");
-                    throw "No browsers detected";
+                    console.error('No browsers detected');
+                    console.error('Suggest installing Firefox or other FOSS browser');
+                    throw 'No browsers detected';
                 }
                 return browsers;
             }
@@ -80,21 +90,21 @@ module.exports = function (config) {
         browserNoActivityTimeout : 60000, // by default 10000
 
         preprocessors: {
-      '../app/scripts/shared/**/*.js': ['coverage'],
-      '../app/scripts/modules/**/*.js': ['coverage'],
-      '../app/**/*.html': ['ng-html2js']
+            '../app/scripts/shared/**/*.js': ['coverage'],
+            '../app/scripts/modules/**/*.js': ['coverage'],
+            '../app/**/*.html': ['ng-html2js']
         },
 
         reporters: ['progress'],
 
         coverageReporter: {
             type : 'html',
-      dir : '../target/grunt/coverage/'
+            dir : '../target/grunt/coverage/'
         },
 
         ngHtml2JsPreprocessor: {
             cacheIdFromPath: function (filepath) {
-        var match = filepath.match(/.*app\/scripts\/(.*)/);
+                var match = filepath.match(/.*app\/scripts\/(.*)/);
                 if (match !== null) {
                     return match[1];
                 } else {

--- a/modules/admin-ui-frontend/test/karma.conf.js
+++ b/modules/admin-ui-frontend/test/karma.conf.js
@@ -1,3 +1,5 @@
+const os = require('os');
+
 module.exports = function (config) {
     config.set({
         basePath : './',
@@ -71,13 +73,20 @@ module.exports = function (config) {
             preferHeadless: true,
             // limit the list of browsers used by karma
             postDetection: (browsers) => {
-                const allowed = new Set(['ChromeHeadless', 'FirefoxHeadless']);
+                const allowed = ['Chrome'];
+                // Karma can't start FirefoxHeadless on M1 Macs
+                // See https://github.com/opencast/opencast/issues/3894
+                const isM1Mac = os.platform() === 'darwin' && os.arch() === 'arm64';
+                if (!isM1Mac) {
+                    allowed.push('Firefox');
+                }
+                const allowedSet = new Set(allowed.map(browser => browser + 'Headless'));
                 console.info('Detected browsers: ' + browsers);
-                browsers = browsers.filter(browser => allowed.has(browser));
+                browsers = browsers.filter(browser => allowedSet.has(browser));
                 console.info('Usable browsers: ' + browsers);
                 if (browsers.length < 1) {
                     console.error('No browsers detected');
-                    console.error('Suggest installing Firefox or other FOSS browser');
+                    console.error('Install one of ' + allowed.join(', '));
                     throw 'No browsers detected';
                 }
                 return browsers;

--- a/modules/admin-ui-frontend/test/karma.conf.js
+++ b/modules/admin-ui-frontend/test/karma.conf.js
@@ -74,10 +74,9 @@ module.exports = function (config) {
             // limit the list of browsers used by karma
             postDetection: (browsers) => {
                 const allowed = ['Chrome'];
-                // Karma can't start FirefoxHeadless on M1 Macs
+                // Karma can't start FirefoxHeadless on Macs
                 // See https://github.com/opencast/opencast/issues/3894
-                const isM1Mac = os.platform() === 'darwin' && os.arch() === 'arm64';
-                if (!isM1Mac) {
+                if (os.platform() !== 'darwin') {
                     allowed.push('Firefox');
                 }
                 const allowedSet = new Set(allowed.map(browser => browser + 'Headless'));


### PR DESCRIPTION
The old admin UI is on its way out anyway, so it should be fine to close #3894 with this. Karma is deprecated anyway, so if we want to fix it properly, we would need to get a new (frontend) test runner in there, which I don't see happening.

Note for reviewers: There are two commits here, which are best viewed individually. The first just fixes some formatting issues in the Karma config. Or you view the the changes with whitespace ignored, that should also hide most (not all) of those "irrelevant" changes.