### PR TITLE
Don't duplicate user roles when switching ACL templates in old Admin UI

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-acl/access.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-acl/access.js
@@ -102,7 +102,6 @@ angular.module('adminNg.services')
 
               UserResource.get({ username: id }).$promise.then(function (data) {
                 policy.user = data;
-                me.ud.policiesUser.push(policy);
                 // Did we get a user not present in Opencast (e.g. LDAP)? Add it to the list!
                 if (me.users.map(user => user.id).indexOf(id) == -1) {
                   if (me.aclCreateDefaults['sanitize']) {

--- a/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-event/access.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-event/access.js
@@ -271,7 +271,6 @@ angular.module('adminNg.services')
 
               UserResource.get({ username: id }).$promise.then(function (data) {
                 policy.user = data;
-                me.ud.policiesUser.push(policy);
                 // Did we get a user not present in Opencast (e.g. LDAP)? Add it to the list!
                 if (me.users.map(user => user.id).indexOf(id) == -1) {
                   if (me.aclCreateDefaults['sanitize']) {

--- a/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-series/access.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-series/access.js
@@ -148,7 +148,6 @@ angular.module('adminNg.services')
 
               UserResource.get({ username: id }).$promise.then(function (data) {
                 policy.user = data;
-                me.ud.policiesUser.push(policy);
                 // Did we get a user not present in Opencast (e.g. LDAP)? Add it to the list!
                 if (me.users.map(user => user.id).indexOf(id) == -1) {
                   if (me.aclCreateDefaults['sanitize']) {


### PR DESCRIPTION
When switching templates in the ACL view of the old Admin UI of _new_ events, series or ACL templates, the user roles are accidentally pushed twice. This is not visible in the UI, except if you have custom actions, which will result in them seeming to mysteriously multiply each time you select a different template:

![grafik](https://github.com/opencast/opencast/assets/11960278/000d0f70-5db2-4b43-b976-b85563d098f0)

This was initially broken by #5269.