### PR TITLE
Fix ACL Template Display for Series in old Admin UI

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
@@ -484,7 +484,7 @@ angular.module('adminNg.controllers')
           $scope.access = EventAccessResource.get({ id: id }, function (data) {
             if (angular.isDefined(data.episode_access)) {
               $scope.baseAclId = data.episode_access.current_acl.toString();
-              $scope.baseAclId = $scope.baseAclId === 0 ? $scope.baseAclId : undefined;
+              $scope.baseAclId = $scope.baseAclId === '0' ? undefined : $scope.baseAclId;
               var json = angular.fromJson(data.episode_access.acl);
               $scope.aclCreateDefaults.$promise.then(function () { // needed for roleUserPrefix
                 changePolicies(json.acl.ace, true);
@@ -1039,7 +1039,7 @@ angular.module('adminNg.controllers')
       $scope.access = EventAccessResource.get({ id: $scope.resourceId }, function (data) {
         if (angular.isDefined(data.episode_access)) {
           $scope.baseAclId = data.episode_access.current_acl.toString();
-          $scope.baseAclId = $scope.baseAclId === 0 ? $scope.baseAclId : undefined;
+          $scope.baseAclId = $scope.baseAclId === '0' ? undefined : $scope.baseAclId;
           var json = angular.fromJson(data.episode_access.acl);
           $scope.aclCreateDefaults.$promise.then(function () { // needed for roleUserPrefix
             changePolicies(json.acl.ace, true);

--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/serieController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/serieController.js
@@ -425,7 +425,7 @@ angular.module('adminNg.controllers')
             changePolicies(json.acl.ace, true);
             getCurrentPolicies();
             $scope.baseAclId = data.series_access.current_acl.toString();
-            $scope.baseAclId = $scope.baseAclId === 0 ? $scope.baseAclId : undefined;
+            $scope.baseAclId = $scope.baseAclId === '0' ? undefined : $scope.baseAclId;
 
             $scope.aclLocked = data.series_access.locked;
 

--- a/modules/admin-ui-frontend/app/scripts/modules/users/controllers/aclController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/users/controllers/aclController.js
@@ -251,7 +251,7 @@ angular.module('adminNg.controllers')
             var json = angular.fromJson(data.acl);
             changePolicies(json.ace, true);
             $scope.baseAclId = data.acl.id.toString();
-            $scope.baseAclId = $scope.baseAclId === 0 ? $scope.baseAclId : undefined;
+            $scope.baseAclId = $scope.baseAclId === '0' ? undefined : $scope.baseAclId;
           }
 
           angular.forEach(angular.fromJson(data.acl.ace), function(value, key) {


### PR DESCRIPTION
PR #5537 fixed the template selection, but accidentally broke the display of already selected templates because `baseAclId` was always set to `undefined`. This fixes that (at least for series, events might be broken in a different way as well).