### PR TITLE
Debian installation documentation fixed

### DIFF
--- a/docs/guides/admin/docs/installation/debs.md
+++ b/docs/guides/admin/docs/installation/debs.md
@@ -53,6 +53,10 @@ First you have to install the necessary repositories so that your package manage
 
         wget -qO - https://pkg.opencast.org/gpgkeys/opencast-deb.key | sudo apt-key add -
 
+    On latest Debian based systems (Debian 11+, Ubuntu 22.04+) importing gpg keys with `apt-key` is deprecated. You can use an alternative step:
+
+        wget -qO - https://pkg.opencast.org/gpgkeys/opencast-deb.key | gpg --dearmor | sudo dd of=/etc/apt/trusted.gpg.d/opencast-deb.gpg
+
 * Update your package listing
 
         apt-get update


### PR DESCRIPTION
On latest Dabian based systems you will see a deprecation warning on importing opencast gpg key with apt-key as documented. The warning looks like this:

    $ wget -qO - https://pkg.opencast.org/gpgkeys/opencast-deb.key | sudo apt-key add -
    Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
    OK

The new way importing gpg keys for apt ist to put the binary form of the key in the `apt/trusted.gpg.d` directory, see [Debian documentation](https://manpages.debian.org/stretch/apt/apt-key.8.en.html#COMMANDS) . We can improve it further on placing the binary version of the same gpg key on the Opencast Debian packages server/S3 for download. This can be done with

    cat opencast-deb.key | gpg --dearmor --output opencast-deb.gpg

then we do not need to convert it on each installation.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
