### PR TITLE
Don't create composites for new editor

### DIFF
--- a/docs/guides/admin/docs/releasenotes/workflow-changes-editor
+++ b/docs/guides/admin/docs/releasenotes/workflow-changes-editor
@@ -1,0 +1,1 @@
+Creating composites for the editor was removed from the `schedule-and-upload` workflow since the new editor can display multiple tracks. If you still use the old one, you can comment the necessary operations back in.

--- a/etc/workflows/partial-preview.xml
+++ b/etc/workflows/partial-preview.xml
@@ -21,6 +21,8 @@
 
     <!-- Analyze media assets -->
 
+    <!-- CHANGEME: Activate this if you use the old editor -->
+    <!--
     <operation
       id="analyze-tracks"
       exception-handler-workflow="partial-error"
@@ -29,12 +31,15 @@
         <configuration key="source-flavor">*/source</configuration>
       </configurations>
     </operation>
+    -->
 
     <!-- Transcode video previews -->
 
+    <!-- CHANGEME: Add
+        if="NOT (${presenter_source_video} AND ${presentation_source_video})"
+    to this operation if you use the old editor -->
     <operation
       id="encode"
-      if="NOT (${presenter_source_video} AND ${presentation_source_video})"
       exception-handler-workflow="partial-error"
       description="Create single-stream video preview">
       <configurations>
@@ -45,6 +50,8 @@
       </configurations>
     </operation>
 
+    <!-- CHANGEME: Activate this if you use the old editor -->
+    <!--
     <operation
       id="composite"
       if="${presenter_source_video} AND ${presentation_source_video}"
@@ -66,6 +73,7 @@
         </configuration>
       </configurations>
     </operation>
+    -->
 
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
     <!-- Audio waveform                                                    -->


### PR DESCRIPTION
The new editor can display more than one track and it's default in OC 14, so there's no need to create composites for the internal publication anymore. But since lots of people still use the old one, I simply commented out the other operations. This might be debatable. I'm also unsure if this can go into a minor release - but config isn't updated automatically, right?