### PR TITLE
PoC: DOSGi Cellar

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="opencast-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0">
 
+  <repository>mvn:org.apache.karaf.cellar/apache-karaf-cellar/${karaf.cellar.version}/xml/features</repository>
+
   <feature name="query-dsl" version="${project.version}">
     <bundle>mvn:com.google.guava/guava/${guava.version}</bundle>
     <bundle>mvn:com.google.guava/failureaccess/${failureaccess.version}</bundle>
@@ -19,6 +21,8 @@
     <feature>scr</feature>
     <feature>cxf-jaxrs</feature>
     <feature>cxf-http-jetty</feature>
+    <feature>cellar</feature>
+    <feature>cellar-dosgi</feature>
 
     <!-- httpclient needs to start before common so that it can get org.apache.commons.logging -->
     <bundle start-level="55">mvn:org.apache.httpcomponents/httpclient-osgi/${httpcomponents-httpclient.version}</bundle>
@@ -147,7 +151,6 @@
     <feature>opencast-core</feature>
     <feature>opencast-services-processing-heavy-load</feature>
     <feature>opencast-services-processing-light-load</feature>
-
     <bundle start-level="82">mvn:org.opencastproject/opencast-admin-ui/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-admin-ui-frontend/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-admin-ui-interface/${project.version}</bundle>

--- a/etc/hazelcast.xml
+++ b/etc/hazelcast.xml
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-3.12.xsd">
+    <group>
+        <name>cellar</name>
+        <password>pass</password>
+    </group>
+    <management-center enabled="false">http://localhost:8080/mancenter</management-center>
+    <network>
+        <port auto-increment="true" port-count="100">5701</port>
+        <outbound-ports>
+            <!--
+                Allowed port range when connecting to other nodes.
+                0 or * means use system provided port.
+            -->
+            <ports>0</ports>
+        </outbound-ports>
+        <join>
+            <multicast enabled="true">
+                <multicast-group>224.2.2.3</multicast-group>
+                <multicast-port>54327</multicast-port>
+            </multicast>
+            <tcp-ip enabled="false">
+                <interface>127.0.0.1</interface>
+            </tcp-ip>
+            <aws enabled="false">
+                <access-key>my-access-key</access-key>
+                <secret-key>my-secret-key</secret-key>
+                <!--optional, default is us-east-1 -->
+                <region>us-west-1</region>
+                <!--optional, default is ec2.amazonaws.com. If set, region shouldn't be set as it will override this property -->
+                <host-header>ec2.amazonaws.com</host-header>
+                <!-- optional, only instances belonging to this group will be discovered, default will try all running instances -->
+                <security-group-name>hazelcast-sg</security-group-name>
+                <tag-key>type</tag-key>
+                <tag-value>hz-nodes</tag-value>
+            </aws>
+        </join>
+        <interfaces enabled="false">
+            <interface>10.10.1.*</interface>
+        </interfaces>
+        <ssl enabled="false"/>
+        <socket-interceptor enabled="false"/>
+        <symmetric-encryption enabled="false">
+            <!--
+               encryption algorithm such as
+               DES/ECB/PKCS5Padding,
+               PBEWithMD5AndDES,
+               AES/CBC/PKCS5Padding,
+               Blowfish,
+               DESede
+            -->
+            <algorithm>PBEWithMD5AndDES</algorithm>
+            <!-- salt value to use when generating the secret key -->
+            <salt>thesalt</salt>
+            <!-- pass phrase to use when generating the secret key -->
+            <password>thepass</password>
+            <!-- iteration count to use when generating the secret key -->
+            <iteration-count>19</iteration-count>
+        </symmetric-encryption>
+    </network>
+    <partition-group enabled="false"/>
+    <executor-service>
+        <pool-size>16</pool-size>
+        <!-- Queue capacity. 0 means Integer.MAX_VALUE -->
+        <queue-capacity>0</queue-capacity>
+    </executor-service>
+    <queue name="default">
+        <!--
+            Maximum size of the queue. When a JVM's local queue size reaches the maximum,
+            all put/offer operations will get blocked until the queue size
+            of the JVM goes down below the maximum.
+            Any integer between 0 and Integer.MAX_VALUE. 0 means
+            Integer.MAX_VALUE. Default is 0.
+        -->
+        <max-size>0</max-size>
+        <!--
+            Number of backups. If 1 is set as the backup-count for example,
+            then all entries of the map will be copied to another JVM for
+            fail-safety. 0 means no backup.
+        -->
+        <backup-count>1</backup-count>
+        <!--
+            Number of async backups. 0 means no backup.
+        -->
+        <async-backup-count>0</async-backup-count>
+        <empty-queue-ttl>-1</empty-queue-ttl>
+    </queue>
+
+    <map name="default">
+        <!--
+            Data type that will be used for storing recordMap.
+            Possible values:
+                BINARY (default): keys and values will be stored as binary data
+                OBJECT : values will be stored in their object forms
+                OFFHEAP : values will be stored in non-heap region of JVM
+        -->
+        <in-memory-format>BINARY</in-memory-format>
+        <!--
+            Number of backups. If 1 is set as the backup-count for example,
+            then all entries of the map will be copied to another JVM for
+            fail-safety. 0 means no backup.
+        -->
+        <backup-count>1</backup-count>
+        <!--
+            Number of async backups. 0 means no backup.
+        -->
+        <async-backup-count>0</async-backup-count>
+        <!--
+            Maximum number of seconds for each entry to stay in the map. Entries that are
+            older than <time-to-live-seconds> and not updated for <time-to-live-seconds>
+            will get automatically evicted from the map.
+            Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+        -->
+        <time-to-live-seconds>0</time-to-live-seconds>
+        <!--
+            Maximum number of seconds for each entry to stay idle in the map. Entries that are
+            idle(not touched) for more than <max-idle-seconds> will get
+            automatically evicted from the map. Entry is touched if get, put or containsKey is called.
+            Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+        -->
+        <max-idle-seconds>0</max-idle-seconds>
+        <!--
+            Valid values are:
+            NONE (no eviction),
+            LRU (Least Recently Used),
+            LFU (Least Frequently Used).
+            NONE is the default.
+        -->
+        <eviction-policy>NONE</eviction-policy>
+        <!--
+            Maximum size of the map. When max size is reached,
+            map is evicted based on the policy defined.
+            Any integer between 0 and Integer.MAX_VALUE. 0 means
+            Integer.MAX_VALUE. Default is 0.
+        -->
+        <max-size policy="PER_NODE">0</max-size>
+        <!--
+            When max. size is reached, specified percentage of
+            the map will be evicted. Any integer between 0 and 100.
+            If 25 is set for example, 25% of the entries will
+            get evicted.
+        -->
+        <eviction-percentage>25</eviction-percentage>
+        <!--
+            While recovering from split-brain (network partitioning),
+            map entries in the small cluster will merge into the bigger cluster
+            based on the policy set here. When an entry merge into the
+            cluster, there might an existing entry with the same key already.
+            Values of these entries might be different for that same key.
+            Which value should be set for the key? Conflict is resolved by
+            the policy set here. Default policy is PutIfAbsentMapMergePolicy
+
+            There are built-in merge policies such as
+            com.hazelcast.map.merge.PassThroughMergePolicy; entry will be added if there is no existing entry for the key.
+            com.hazelcast.map.merge.PutIfAbsentMapMergePolicy ; entry will be added if the merging entry doesn't exist in the cluster.
+            com.hazelcast.map.merge.HigherHitsMapMergePolicy ; entry with the higher hits wins.
+            com.hazelcast.map.merge.LatestUpdateMapMergePolicy ; entry with the latest update wins.
+        -->
+        <merge-policy>com.hazelcast.map.merge.PassThroughMergePolicy</merge-policy>
+    </map>
+    <map name="org.apache.karaf.cellar.log">
+        <time-to-live-seconds>0</time-to-live-seconds>
+        <max-idle-seconds>0</max-idle-seconds>
+        <eviction-policy>LRU</eviction-policy>
+        <max-size policy="PER_PARTITION">5000</max-size>
+        <eviction-percentage>25</eviction-percentage>
+        <backup-count>0</backup-count>
+    </map>
+
+    <multimap name="default">
+        <backup-count>1</backup-count>
+        <value-collection-type>SET</value-collection-type>
+    </multimap>
+
+    <multimap name="default">
+        <backup-count>1</backup-count>
+        <value-collection-type>SET</value-collection-type>
+    </multimap>
+
+    <list name="default">
+        <backup-count>1</backup-count>
+    </list>
+
+    <set name="default">
+        <backup-count>1</backup-count>
+    </set>
+
+    <jobtracker name="default">
+        <max-thread-size>0</max-thread-size>
+        <!-- Queue size 0 means number of partitions * 2 -->
+        <queue-size>0</queue-size>
+        <retry-count>0</retry-count>
+        <chunk-size>1000</chunk-size>
+        <communicate-stats>true</communicate-stats>
+        <topology-changed-strategy>CANCEL_RUNNING_OPERATION</topology-changed-strategy>
+    </jobtracker>
+
+    <semaphore name="default">
+        <initial-permits>0</initial-permits>
+        <backup-count>1</backup-count>
+        <async-backup-count>0</async-backup-count>
+    </semaphore>
+
+    <serialization>
+        <portable-version>0</portable-version>
+    </serialization>
+
+    <services enable-defaults="true" />
+    
+    <properties>
+        <property name="hazelcast.max.no.heartbeat.seconds">60</property>
+        <property name="hazelcast.max.no.master.confirmation.seconds">120</property>
+    </properties>
+</hazelcast>

--- a/etc/org.apache.karaf.cellar.groups.cfg
+++ b/etc/org.apache.karaf.cellar.groups.cfg
@@ -1,0 +1,62 @@
+#
+# This property stores the cluster groups for which the local node is member
+#
+groups = default
+
+#
+# Filtering of the bundles in the default cluster group
+#
+default.bundle.whitelist.inbound=*
+default.bundle.whitelist.outbound=*
+default.bundle.blacklist.inbound=*.xml
+default.bundle.blacklist.outbound=*.xml
+
+#
+# Filtering of the configurations in the default cluster group
+#
+default.config.whitelist.inbound=*
+default.config.whitelist.outbound=*
+default.config.blacklist.inbound=org.apache.felix.fileinstall*, \
+                                   org.apache.karaf.management, \
+                                   org.apache.karaf.shell, \
+                                   org.ops4j.pax.web, \
+                                   org.apache.aries.transaction, \
+                                   org.ops4j.pax.logging, \
+                                   org.apache.karaf.cellar.node, \
+                                   org.apache.karaf.cellar.groups
+default.config.blacklist.outbound=org.apache.felix.fileinstall*, \
+                                    org.apache.karaf.management, \
+                                    org.apache.karaf.shell, \
+                                    org.ops4j.pax.web, \
+                                    org.apache.aries.transaction, \
+                                    org.ops4j.pax.logging, \
+                                    org.apache.karaf.cellar.node, \
+                                    org.apache.karaf.cellar.groups
+
+#
+# Filtering of the features in the default cluster group
+#
+default.feature.whitelist.inbound=*
+default.feature.whitelist.outbound=*
+default.feature.blacklist.inbound=none
+default.feature.blacklist.outbound=none
+
+#
+# The following properties define the behavior to use when the node joins the cluster (the usage of the bootstrap
+# synchronizer), per cluster group and per resource.
+# The following values are accepted:
+# disabled: means that the synchronizer doesn't sync cluster group and node states
+# cluster: the synchronizer retrieves the state from the cluster group first (pull first), and push the node the state
+#          to the cluster group after (push after)
+# node: the synchronizer push the node state to the cluster group (push first), and pull the state from the cluster group
+#        after (pull after)
+# clusterOnly: the cluster is the "master", the node only retrieves and applies the cluster group state, nothing is
+#              pushed to the cluster group
+# nodeOnly: the node is the "master", the node pushes his state to the cluster group, nothing is pulled from the
+#           cluster group
+#
+default.bundle.sync=disabled
+default.config.sync=disabled
+default.feature.sync=disabled
+default.obr.urls.sync=disabled
+default.balanced.servlet.sync=disabled

--- a/etc/org.apache.karaf.cellar.node.cfg
+++ b/etc/org.apache.karaf.cellar.node.cfg
@@ -1,0 +1,47 @@
+#
+# This node is member of the following cluster groups
+#
+groups = default
+
+#
+# The following properties define if the local event listeners (per resource)
+# A local listener listens for local events (like bundle install, etc) and broadcast this state change to the cluster
+#
+bundle.listener = false
+config.listener = false
+feature.listener = false
+
+#
+# Cluster event producer
+#
+producer = true
+
+#
+# Cluster event consumer
+#
+consumer = true
+
+#
+# Cluster event handlers
+#
+# bundle event handler
+handler.org.apache.karaf.cellar.bundle.BundleEventHandler = true
+# config event handler
+handler.org.apache.karaf.cellar.config.ConfigurationEventHandler = true
+# feature event handler
+handler.org.apache.karaf.cellar.features.FeaturesEventHandler = true
+# DOSGi event handler
+handler.org.apache.karaf.cellar.dosgi.RemoteServiceCallHandler = true
+# OSGi event handler
+handler.org.apache.karaf.cellar.event.ClusterEventHandler = true
+# OBR event handler
+handler.org.apache.karaf.cellar.obr.ObrBundleEventHandler = true
+handler.org.apache.karaf.cellar.obr.ObrUrlEventHandler = true
+# HTTP balancer event handler
+handler.org.apache.karaf.cellar.http.balancer.BalancerEventHandler = true
+
+#
+# Excluded config properties from the sync
+# Some config properties can be considered as local to a node, and should not be sync on the cluster.
+#
+config.excluded.properties = felix.fileinstall.filename, felix.fileinstall.dir, felix.fileinstall.tmpdir, org.ops4j.pax.url.mvn.defaultRepositories

--- a/modules/hello-world-endpoint-dosgi/pom.xml
+++ b/modules/hello-world-endpoint-dosgi/pom.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>opencast-hello-world-impl</artifactId>
+  <artifactId>opencast-hello-world-endpoint-dosgi</artifactId>
   <packaging>bundle</packaging>
-  <name>Opencast :: hello-world-impl</name>
+  <name>Opencast :: hello-world-endpoint-dosgi</name>
   <parent>
     <groupId>org.opencastproject</groupId>
     <artifactId>base</artifactId>
@@ -45,15 +45,6 @@
       <artifactId>jersey-server</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <!--dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.service.component</artifactId>
-    </dependency-->
   </dependencies>
   <build>
     <plugins>

--- a/modules/hello-world-endpoint-dosgi/src/main/java/org/opencastproject/helloworld/impl/endpoint/HelloWorldRestEndpoint.java
+++ b/modules/hello-world-endpoint-dosgi/src/main/java/org/opencastproject/helloworld/impl/endpoint/HelloWorldRestEndpoint.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.helloworld.impl.endpoint;
+
+import org.opencastproject.helloworld.api.HelloWorldService;
+import org.opencastproject.util.doc.rest.RestParameter;
+import org.opencastproject.util.doc.rest.RestQuery;
+import org.opencastproject.util.doc.rest.RestResponse;
+import org.opencastproject.util.doc.rest.RestService;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ * The REST endpoint for the {@link HelloWorldService} service
+ */
+@Component(
+    property = {
+        "service.description=Hello World REST Endpoint",
+        "opencast.service.type=org.opencastproject.helloworld",
+        "opencast.service.path=/helloworld-dosgi",
+        "opencast.service.jobproducer=false"
+    },
+    immediate = true,
+    service = HelloWorldRestEndpoint.class
+)
+@Path("/")
+@RestService(
+    name = "HelloWorldServiceEndpoint",
+    title = "Hello World Service Endpoint",
+    abstractText = "This is a tutorial service.",
+    notes = {
+        "All paths above are relative to the REST endpoint base (something like http://your.server/files)",
+        "If the service is down or not working it will return a status 503, this means the the "
+            + "underlying service is not working and is either restarting or has failed",
+        "A status code 500 means a general failure has occurred which is not recoverable and was "
+            + "not anticipated. In other words, there is a bug! You should file an error report "
+            + "with your server logs from the time when the error occurred: "
+            + "<a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>"
+    }
+)
+public class HelloWorldRestEndpoint {
+  /** The logger */
+  private static final Logger logger = LoggerFactory.getLogger(HelloWorldRestEndpoint.class);
+
+  /** The rest docs */
+  protected String docs;
+
+  /** The service */
+  protected HelloWorldService helloWorldService;
+
+  /**
+   * Simple example service call
+   *
+   * @return The Hello World statement
+   * @throws Exception
+   */
+  @GET
+  @Path("helloworld")
+  @Produces(MediaType.TEXT_PLAIN)
+  @RestQuery(
+      name = "helloworld",
+      description = "example service call",
+      responses = {
+          @RestResponse(
+              responseCode = HttpServletResponse.SC_OK,
+              description = "Hello World"
+          ),
+          @RestResponse(
+              responseCode = HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+              description = "The underlying service could not output something."
+          )
+      },
+      returnDescription = "The text that the service returns."
+  )
+  public Response helloWorld() throws Exception {
+    logger.info("REST call for Hello World");
+    return Response.ok().entity(helloWorldService.helloWorld()).build();
+  }
+
+  /**
+   * Simple example service call with parameter
+   *
+   * @param name
+   *          the optional name of the Person to greet
+   * @return A Hello statement with optional name
+   * @throws Exception
+   */
+  @GET
+  @Path("helloname")
+  @Produces(MediaType.TEXT_PLAIN)
+  @RestQuery(
+      name = "helloname",
+      description = "example service call with parameter",
+      restParameters = {
+          @RestParameter(
+              name = "name",
+              description = "name to output",
+              isRequired = false,
+              type = RestParameter.Type.TEXT
+          )
+      },
+      responses = {
+          @RestResponse(
+              responseCode = HttpServletResponse.SC_OK,
+              description = "Hello or Hello Name"
+          ),
+          @RestResponse(
+              responseCode = HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+              description = "The underlying service could not output something."
+          )
+      },
+      returnDescription = "The text that the service returns."
+  )
+  public Response helloName(@FormParam("name") String name) throws Exception {
+    logger.info("REST call for Hello Name");
+    return Response.ok().entity(helloWorldService.helloName(name)).build();
+  }
+
+  @GET
+  @Produces(MediaType.TEXT_HTML)
+  @Path("docs")
+  public String getDocs() {
+    return docs;
+  }
+
+  @Reference
+  public void setHelloWorldService(HelloWorldService service) {
+    this.helloWorldService = service;
+  }
+}

--- a/modules/hello-world-impl/src/main/java/org/opencastproject/helloworld/impl/HelloWorldServiceImpl.java
+++ b/modules/hello-world-impl/src/main/java/org/opencastproject/helloworld/impl/HelloWorldServiceImpl.java
@@ -37,7 +37,8 @@ import java.util.Objects;
  */
 @Component(
     property = {
-        "service.description=Hello World Service"
+        "service.description=Hello World Service",
+        "service.exported.interfaces=*"
     },
     immediate = true,
     service = HelloWorldService.class

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <joda-time.version>2.12.5</joda-time.version>
     <json-simple.version>1.1.1</json-simple.version>
     <karaf.version>4.4.4</karaf.version>
+    <karaf.cellar.version>4.2.1</karaf.cellar.version>
     <node.version>v18.16.0</node.version>
     <osgi.core.version>8.0.0</osgi.core.version>
     <osgi.annotation.version>8.1.0</osgi.annotation.version>
@@ -138,6 +139,7 @@
     <module>modules/fileupload</module>
     <module>modules/hello-world-api</module>
     <module>modules/hello-world-impl</module>
+    <module>modules/hello-world-endpoint-dosgi</module>
     <module>modules/hello-world-workflowoperation</module>
     <module>modules/incident-workflowoperation</module>
     <module>modules/index-service</module>


### PR DESCRIPTION
Implementing DOSGi without Cellar can be implemented via CXF DOSGi, and if service discovery is required, ZooKepper is supported.

### Testing instructions:

Launch two opencast allinone nodes on the same machine and verify they joined the cluster.

```
karaf@root()> cluster:node-list
  │ Id                 │ Alias │ Host Name     │ Port
──┼────────────────────┼───────┼───────────────┼─────
x │ 192.168.0.100:5701 │       │ 192.168.0.100 │ 5701
  │ 192.168.0.100:5702 │       │ 192.168.0.100 │ 5702

```

### Node A:

Copy the `hello-world-api` and `hello-world-impl` bundles to the deploy folder and verify the bundle is loaded correctly.
Check if the API Endpoint `/helloworld` is available.

### Node B:

Copy the `hello-world-api` and `hello-world-endpoint-dosgi` bundles to the deploy folder and verify the bundle is loaded correctly.

Check if the API Endpoint `/helloworld-dosgi` is available and the clusters service list contains a HellWorldService entry.

```
karaf@root()> cluster:service-list 
Service Class                                        │ Provider Node
─────────────────────────────────────────────────────┼───────────────────
org.opencastproject.helloworld.api.HelloWorldService │ 192.168.0.100:5702
```

Calling the `/helloworld-dosgi/helloname?name=DOSGi` endpoint on node B should result in the following log entries:

Node B: `(HelloWorldRestEndpoint:145) - REST call for Hello Name`
Node A: `(HelloWorldServiceImpl:76) - Name is DOSGi.`

### Links:
https://karaf.apache.org/manual/cellar/latest-4/
https://cwiki.apache.org/confluence/display/CXF/Distributed+OSGi