### PR TITLE
Fix ltitools Upload crashing if extendedMetadata exists

### DIFF
--- a/modules/lti/src/components/EditForm.tsx
+++ b/modules/lti/src/components/EditForm.tsx
@@ -4,7 +4,8 @@ import {
     EventMetadataField,
     EventMetadataContainer,
     EventMetadataCollection,
-    collectionToPairs
+    collectionToPairs,
+    findField
 } from "../OpencastRest";
 import Select, { OnChangeValue } from "react-select";
 import CreatableSelect from "react-select/creatable";
@@ -161,9 +162,9 @@ class TranslatedEditForm extends React.Component<EditFormProps> {
     }
 
     render() {
-        const languageField = this.props.data.fields.filter((field) => field.id === "language")[0];
+        const languageField = findField("language", this.props.data);
         let languageOptions: OptionType[] = [];
-        if(languageField.collection !== undefined){
+        if(languageField && languageField.collection !== undefined){
             languageOptions = collectionToOptions(languageField.collection, languageField.translatable, this.props.t);
         }
         return <form>

--- a/modules/lti/src/components/Upload.tsx
+++ b/modules/lti/src/components/Upload.tsx
@@ -86,7 +86,8 @@ class TranslatedUpload extends React.Component<UploadProps, UploadState> {
     componentDidMount() {
         getEventMetadata(this.state.eventId).then((metadataCollection) => {
             if (metadataCollection.length > 0) {
-                const metadata = metadataCollection[0];
+                const metadata = metadataCollection.find(col => col.flavor === "dublincore/episode");
+                if (metadata === undefined) { throw Error("Could not find episode metadata catalog")}
                 const seriesId = this.resolveSeries(metadata)
                 if (seriesId === undefined) {
                     this.setState({


### PR DESCRIPTION
The ltitools Upload page can crash on loading, if the series specified for the upload is attached to an event which has at least one extendedMetadata dublincore catalog attached to it (or any other dublincore catalog beside the default one really).

This fixes that, although the fix relies on hardcoding the default flavor of the event dublincore catalogs, which is technically configurable. I have not found a way to easily access whether a dublincore catalog is the common one, and don't currently feel motivated to implement one :').