### PR TITLE
Use MediaPackageElementSelector in every WOH

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageElementSelector.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageElementSelector.java
@@ -42,6 +42,20 @@ public interface MediaPackageElementSelector<T extends MediaPackageElement> {
   Collection<T> select(MediaPackage mediaPackage, boolean withTagsAndFlavors);
 
   /**
+   * Returns the elements that are matched by this selector from the given publication of the given media package.
+   * If the publication could not be found on the media package, returns an empty collection.
+   *
+   * @param mediaPackage
+   *          the media package
+   * @param publicationChannel
+   *          the publication to get elements from
+   * @param withTagsAndFlavors
+   *          define if the elements must match with flavors and tags, or just one of these parameters
+   * @return the selected elements
+   */
+  Collection<T> select(MediaPackage mediaPackage, String publicationChannel, boolean withTagsAndFlavors);
+
+  /**
    * Returns the media package elements that are matched by this selector.
    *
    * @param elements
@@ -51,5 +65,4 @@ public interface MediaPackageElementSelector<T extends MediaPackageElement> {
    * @return the selected elements
    */
   Collection<T> select(List<MediaPackageElement> elements, boolean withTagsAndFlavors);
-
 }

--- a/modules/common/src/main/java/org/opencastproject/mediapackage/selector/AbstractMediaPackageElementSelector.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/selector/AbstractMediaPackageElementSelector.java
@@ -25,6 +25,7 @@ import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElement;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.mediapackage.MediaPackageElementSelector;
+import org.opencastproject.mediapackage.Publication;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -34,6 +35,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -65,6 +67,26 @@ public abstract class AbstractMediaPackageElementSelector<T extends MediaPackage
   @Override
   public Collection<T> select(MediaPackage mediaPackage, boolean withTagsAndFlavors) {
    return select(Arrays.asList(mediaPackage.getElements()), withTagsAndFlavors);
+  }
+
+  /**
+   * Similar to above, but will get media package elements from the given publication instead.
+   */
+  @Override
+  public Collection<T> select(MediaPackage mediaPackage, String publicationChannel, boolean withTagsAndFlavors) {
+    Optional<Publication> publication = Arrays.stream(mediaPackage.getPublications())
+        .filter(channel -> channel.getChannel().equals(publicationChannel)).findFirst();
+
+    // Skip if the media package does not contain a matching publication
+    if (publication.isEmpty()) {
+      return new LinkedHashSet<T>();
+    }
+
+    List<MediaPackageElement> list = new ArrayList(Arrays.asList(publication.get().getTracks()));
+    list.addAll(new ArrayList(Arrays.asList(publication.get().getAttachments())));
+    list.addAll(new ArrayList(Arrays.asList(publication.get().getCatalogs())));
+
+    return select(list, withTagsAndFlavors);
   }
 
   @Override

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SanitizeAdaptiveWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SanitizeAdaptiveWorkflowOperationHandler.java
@@ -29,6 +29,7 @@ import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.mediapackage.MediaPackageException;
 import org.opencastproject.mediapackage.Track;
+import org.opencastproject.mediapackage.selector.TrackSelector;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.data.Function2;
@@ -54,7 +55,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
 
@@ -164,8 +165,10 @@ public class SanitizeAdaptiveWorkflowOperationHandler extends AbstractWorkflowOp
     }
 
     // Select those tracks that have matching flavors
-    Track[] tracks = mediaPackage.getTracks(sourceFlavor);
-    List<Track> tracklist = Arrays.asList(tracks);
+    TrackSelector trackSelector = new TrackSelector();
+    trackSelector.addFlavor(sourceFlavor);
+    Collection<Track> tracks = trackSelector.select(mediaPackage, false);
+    List<Track> tracklist = new ArrayList<>(tracks);
 
     // Nothing to sanitize, do not set target tags or flavor on tracks, just return
     if (!tracklist.stream().filter(AdaptivePlaylist.isHLSTrackPred).findAny().isPresent()) {

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SegmentPreviewsWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SegmentPreviewsWorkflowOperationHandler.java
@@ -37,6 +37,7 @@ import org.opencastproject.mediapackage.MediaPackageException;
 import org.opencastproject.mediapackage.MediaPackageReference;
 import org.opencastproject.mediapackage.MediaPackageReferenceImpl;
 import org.opencastproject.mediapackage.Track;
+import org.opencastproject.mediapackage.selector.TrackSelector;
 import org.opencastproject.metadata.mpeg7.MediaTimePoint;
 import org.opencastproject.metadata.mpeg7.Mpeg7Catalog;
 import org.opencastproject.metadata.mpeg7.Mpeg7CatalogService;
@@ -206,12 +207,16 @@ public class SegmentPreviewsWorkflowOperationHandler extends AbstractWorkflowOpe
       throw new IllegalStateException("Encoding profile '" + encodingProfileName + "' was not found");
 
     // Select the tracks based on the tags and flavors
+    TrackSelector trackSelector = new TrackSelector();
+    trackSelector.addFlavor(sourceVideoFlavor);
+    for (String tag : sourceTagSet) {
+      trackSelector.addTag(tag);
+    }
+    Collection<Track> tracks = trackSelector.select(mediaPackage, true);
+
     Set<Track> videoTrackSet = new HashSet<>();
-    for (Track track : mediaPackage.getTracksByTags(sourceTagSet)) {
-      if (sourceVideoFlavor == null
-              || (track.getFlavor() != null && sourceVideoFlavor.equals(track.getFlavor()))) {
-        if (!track.hasVideo())
-          continue;
+    for (Track track: tracks) {
+      if (track.hasVideo()) {
         videoTrackSet.add(track);
       }
     }

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SelectStreamsWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SelectStreamsWorkflowOperationHandler.java
@@ -31,6 +31,7 @@ import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.mediapackage.MediaPackageElementParser;
 import org.opencastproject.mediapackage.MediaPackageException;
 import org.opencastproject.mediapackage.Track;
+import org.opencastproject.mediapackage.selector.TrackSelector;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
@@ -250,14 +251,16 @@ public class SelectStreamsWorkflowOperationHandler extends AbstractWorkflowOpera
     final MediaPackageElementFlavor targetTrackFlavor = tagsAndFlavors.getSingleTargetFlavor();
     final List<String> targetTrackTags = tagsAndFlavors.getTargetTags();
 
-    final Track[] tracks = mediaPackage.getTracks(sourceFlavor);
+    TrackSelector trackSelector = new TrackSelector();
+    trackSelector.addFlavor(sourceFlavor);
+    final Collection<Track> tracks = trackSelector.select(mediaPackage, false);
 
-    if (tracks.length == 0) {
+    if (tracks.size() == 0) {
       logger.info("No audio/video tracks with flavor '{}' found to prepare", sourceFlavor);
       return createResult(mediaPackage, WorkflowOperationResult.Action.CONTINUE);
     }
 
-    final List<AugmentedTrack> augmentedTracks = createAugmentedTracks(tracks, workflowInstance);
+    final List<AugmentedTrack> augmentedTracks = createAugmentedTracks(tracks.toArray(new Track[tracks.size()]), workflowInstance);
 
     final MuxResult result = MuxResult.empty();
     // Note that the logic below currently supports at most two input tracks

--- a/modules/speech-to-text-workflowoperation/src/main/java/org/opencastproject/workflow/handler/speechtotext/SpeechToTextWorkflowOperationHandler.java
+++ b/modules/speech-to-text-workflowoperation/src/main/java/org/opencastproject/workflow/handler/speechtotext/SpeechToTextWorkflowOperationHandler.java
@@ -29,6 +29,7 @@ import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.mediapackage.MediaPackageElementParser;
 import org.opencastproject.mediapackage.Track;
 import org.opencastproject.mediapackage.attachment.AttachmentImpl;
+import org.opencastproject.mediapackage.selector.TrackSelector;
 import org.opencastproject.mediapackage.track.TrackImpl;
 import org.opencastproject.metadata.api.MediaPackageMetadata;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalogService;
@@ -56,6 +57,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
@@ -132,13 +134,16 @@ public class
             Configuration.many, Configuration.one);
     MediaPackageElementFlavor sourceFlavor = tagsAndFlavors.getSingleSrcFlavor();
 
-    Track[] tracks = mediaPackage.getTracks(sourceFlavor);
-    if (tracks.length == 0) {
+    TrackSelector trackSelector = new TrackSelector();
+    trackSelector.addFlavor(sourceFlavor);
+    Collection<Track> tracks = trackSelector.select(mediaPackage, false);
+
+    if (tracks.size() == 0) {
       throw new WorkflowOperationException(
               String.format("No tracks with source flavor '%s' found for transcription", sourceFlavor));
     }
 
-    logger.info("Found {} track(s) with source flavor '{}'.", tracks.length, sourceFlavor);
+    logger.info("Found {} track(s) with source flavor '{}'.", tracks.size(), sourceFlavor);
 
     // Get the information in which language the audio track should be
     String languageCode = getMediaPackageLanguage(mediaPackage, workflowInstance);

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/AddCatalogWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/AddCatalogWorkflowOperationHandler.java
@@ -22,10 +22,10 @@
 package org.opencastproject.workflow.handler.workflow;
 
 import org.opencastproject.job.api.JobContext;
-import org.opencastproject.mediapackage.Catalog;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElement;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
+import org.opencastproject.mediapackage.selector.CatalogSelector;
 import org.opencastproject.util.MimeType;
 import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
 import org.opencastproject.workflow.api.WorkflowInstance;
@@ -43,7 +43,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.util.Arrays;
 import java.util.UUID;
 
 /**
@@ -120,8 +119,11 @@ public class AddCatalogWorkflowOperationHandler extends AbstractWorkflowOperatio
 
     MediaPackage mp = wInst.getMediaPackage();
 
+    CatalogSelector catalogSelector = new CatalogSelector();
+    catalogSelector.addFlavor(catalogFlavor);
+
     // if CatalogType is already part of the MediaPackage handle special cases
-    if (doesCatalogFlavorExist(catalogFlavor, mp.getCatalogs())) {
+    if (catalogSelector.select(mp, false).size() > 0) {
       if (collBehavior == CatalogTypeCollisionBehavior.FAIL) {
         throw new WorkflowOperationException("Catalog Type already exists and 'fail' was specified");
       }
@@ -152,18 +154,6 @@ public class AddCatalogWorkflowOperationHandler extends AbstractWorkflowOperatio
     }
 
     return createResult(mp, Action.CONTINUE);
-  }
-
-  /**
-   * Checks whether the catalogFlavor exists in the array of catalogs
-   *
-   * @param catalogFlavor
-   * @param catalogs
-   * @return true, if the catalogFlavor exists in the array of catalogs, else false
-   */
-  private boolean doesCatalogFlavorExist(MediaPackageElementFlavor catalogFlavor, Catalog[] catalogs) {
-    return Arrays.asList(catalogs).stream()
-      .anyMatch(cat -> catalogFlavor.matches(cat.getFlavor()));
   }
 
   /**

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/AnalyzeTracksWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/AnalyzeTracksWorkflowOperationHandler.java
@@ -25,6 +25,7 @@ import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.mediapackage.Track;
 import org.opencastproject.mediapackage.VideoStream;
+import org.opencastproject.mediapackage.selector.TrackSelector;
 import org.opencastproject.mediapackage.track.TrackImpl;
 import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
 import org.opencastproject.workflow.api.ConfiguredTagsAndFlavors;
@@ -42,6 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -82,8 +84,10 @@ public class AnalyzeTracksWorkflowOperationHandler extends AbstractWorkflowOpera
 
     ConfiguredTagsAndFlavors tagsAndFlavors = getTagsAndFlavors(workflowInstance, Configuration.none, Configuration.one, Configuration.none, Configuration.none);
     final MediaPackageElementFlavor singleSourceFlavor = tagsAndFlavors.getSingleSrcFlavor();
-    final Track[] tracks = mediaPackage.getTracks(singleSourceFlavor);
-    if (tracks.length <= 0) {
+    TrackSelector trackSelector = new TrackSelector();
+    trackSelector.addFlavor(singleSourceFlavor);
+    final Collection<Track> tracks = trackSelector.select(mediaPackage, false);
+    if (tracks.size() <= 0) {
       if (BooleanUtils.toBoolean(getConfig(workflowInstance, OPT_FAIL_NO_TRACK, "false"))) {
         throw new WorkflowOperationException("No matching tracks for flavor " + singleSourceFlavor.toString());
       }

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ProbeResolutionWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ProbeResolutionWorkflowOperationHandler.java
@@ -25,6 +25,7 @@ import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.mediapackage.Track;
 import org.opencastproject.mediapackage.VideoStream;
+import org.opencastproject.mediapackage.selector.TrackSelector;
 import org.opencastproject.mediapackage.track.TrackImpl;
 import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
 import org.opencastproject.workflow.api.ConfiguredTagsAndFlavors;
@@ -41,6 +42,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -84,9 +86,12 @@ public class ProbeResolutionWorkflowOperationHandler extends AbstractWorkflowOpe
         Configuration.none, Configuration.one, Configuration.none, Configuration.none);
     final MediaPackageElementFlavor sourceFlavor = tagsAndFlavors.getSingleSrcFlavor();
 
+    TrackSelector trackSelector = new TrackSelector();
+    trackSelector.addFlavor(sourceFlavor);
+
     // Ensure we have a matching track
-    final Track[] tracks = mediaPackage.getTracks(sourceFlavor);
-    if (tracks.length <= 0) {
+    final Collection<Track> tracks = trackSelector.select(mediaPackage, false);
+    if (tracks.size() <= 0) {
       logger.info("No tracks with specified flavor ({}).", sourceFlavor.toString());
       return createResult(mediaPackage, Action.CONTINUE);
     }

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/PublicationChannelToWorkspace.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/PublicationChannelToWorkspace.java
@@ -21,10 +21,15 @@
 package org.opencastproject.workflow.handler.workflow;
 
 import org.opencastproject.job.api.JobContext;
+import org.opencastproject.mediapackage.Attachment;
+import org.opencastproject.mediapackage.Catalog;
 import org.opencastproject.mediapackage.MediaPackage;
-import org.opencastproject.mediapackage.MediaPackageElement;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.mediapackage.Publication;
+import org.opencastproject.mediapackage.Track;
+import org.opencastproject.mediapackage.selector.AttachmentSelector;
+import org.opencastproject.mediapackage.selector.CatalogSelector;
+import org.opencastproject.mediapackage.selector.TrackSelector;
 import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
 import org.opencastproject.workflow.api.ConfiguredTagsAndFlavors;
 import org.opencastproject.workflow.api.WorkflowInstance;
@@ -39,7 +44,6 @@ import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -97,15 +101,15 @@ public class PublicationChannelToWorkspace extends AbstractWorkflowOperationHand
       return createResult(mediaPackage, Action.SKIP);
     }
 
-    Collection<MediaPackageElement> tracks = new ArrayList<>();
-
     //get tracks from publicationchannel with tags and flavors
-    Arrays.stream(publication.get().getTracks())
-        .filter(element -> element.containsTag(configuredSourceTags))
-        .forEach(tracks::add);
-    Arrays.stream(publication.get().getTracks())
-        .filter(element -> configuredSourceFlavors.contains(element.getFlavor()))
-        .forEach(tracks::add);
+    TrackSelector trackSelector = new TrackSelector();
+    for (MediaPackageElementFlavor flavor : configuredSourceFlavors) {
+      trackSelector.addFlavor(flavor);
+    }
+    for (String tag : configuredSourceTags) {
+      trackSelector.addTag(tag);
+    }
+    Collection<Track> tracks = trackSelector.select(mediaPackage, publicationChannel, false);
 
     if (!configuredTargetTags.isEmpty()) {
       tracks.forEach(track -> {
@@ -115,13 +119,14 @@ public class PublicationChannelToWorkspace extends AbstractWorkflowOperationHand
     tracks.forEach(mediaPackage::add);
 
     //get attachements from publicationchannel with tags and flavors
-    Collection<MediaPackageElement> attachments = new ArrayList<MediaPackageElement>();
-    Arrays.stream(publication.get().getAttachments())
-        .filter(element -> element.containsTag(configuredSourceTags))
-        .forEach(attachments::add);
-    Arrays.stream(publication.get().getAttachments())
-        .filter(element -> configuredSourceFlavors.contains(element.getFlavor()))
-        .forEach(attachments::add);
+    AttachmentSelector attachmentSelector = new AttachmentSelector();
+    for (MediaPackageElementFlavor flavor : configuredSourceFlavors) {
+      attachmentSelector.addFlavor(flavor);
+    }
+    for (String tag : configuredSourceTags) {
+      attachmentSelector.addTag(tag);
+    }
+    Collection<Attachment> attachments = attachmentSelector.select(mediaPackage, publicationChannel, false);
 
     if (!configuredTargetTags.isEmpty()) {
       attachments.forEach(attachment -> {
@@ -131,13 +136,14 @@ public class PublicationChannelToWorkspace extends AbstractWorkflowOperationHand
     attachments.forEach(mediaPackage::add);
 
     //get catalogs from publicationchannel with tags and flavors
-    Collection<MediaPackageElement> catalogs = new ArrayList<MediaPackageElement>();
-    Arrays.stream(publication.get().getCatalogs())
-        .filter(element -> element.containsTag(configuredSourceTags))
-        .forEach(catalogs::add);
-    Arrays.stream(publication.get().getCatalogs())
-        .filter(element -> configuredSourceFlavors.contains(element.getFlavor()))
-        .forEach(catalogs::add);
+    CatalogSelector catalogSelector = new CatalogSelector();
+    for (MediaPackageElementFlavor flavor : configuredSourceFlavors) {
+      catalogSelector.addFlavor(flavor);
+    }
+    for (String tag : configuredSourceTags) {
+      catalogSelector.addTag(tag);
+    }
+    Collection<Catalog> catalogs = catalogSelector.select(mediaPackage, publicationChannel, false);
 
     if (!configuredTargetTags.isEmpty()) {
       catalogs.forEach(catalog -> {

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/WebvttToCutMarksWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/WebvttToCutMarksWorkflowOperationHandler.java
@@ -28,6 +28,7 @@ import org.opencastproject.mediapackage.MediaPackageElementBuilder;
 import org.opencastproject.mediapackage.MediaPackageElementBuilderFactory;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.mediapackage.Track;
+import org.opencastproject.mediapackage.selector.SimpleElementSelector;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
 import org.opencastproject.subtitleparser.SubtitleParsingException;
 import org.opencastproject.subtitleparser.webvttparser.WebVTTParser;
@@ -58,6 +59,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
@@ -356,7 +358,10 @@ public class WebvttToCutMarksWorkflowOperationHandler extends AbstractWorkflowOp
   private WebVTTSubtitle readAndParseWebVTT(MediaPackage mp, MediaPackageElementFlavor sourceFlavor)
           throws WorkflowOperationException {
     // Identify WebVTT Element to process
-    MediaPackageElement[] webvttElements = mp.getElementsByFlavor(sourceFlavor);
+    SimpleElementSelector elementSelector = new SimpleElementSelector();
+    elementSelector.addFlavor(sourceFlavor);
+    Collection<MediaPackageElement> elements = elementSelector.select(mp, false);
+    MediaPackageElement[] webvttElements = elements.toArray(new MediaPackageElement[elements.size()]);
     if (webvttElements.length != 1) {
       throw new WorkflowOperationException("Couldn't uniqly identify WebVTT Element");
     }


### PR DESCRIPTION
Helps with #5265.

Goes through all workflow operation handler that use another method from MediaPackageElementSelector, and replaces their method with MediaPackageElementSelector.

This should result in no functional changes, this change is merely supposed to improve code quality.