### PR TITLE
Fix removal of event ACL from search when updating series ACL

### DIFF
--- a/modules/conductor/src/main/java/org/opencastproject/event/handler/SearchUpdatedEventHandler.java
+++ b/modules/conductor/src/main/java/org/opencastproject/event/handler/SearchUpdatedEventHandler.java
@@ -223,13 +223,13 @@ public class SearchUpdatedEventHandler {
           if (seriesItem.getOverrideEpisodeAcl()) {
 
             MediaPackageElement[] distributedEpisodeAcls = mp.getElementsByFlavor(XACML_POLICY_EPISODE);
-            authorizationService.removeAcl(mp, AclScope.Episode);
-
             for (MediaPackageElement distributedEpisodeAcl : distributedEpisodeAcls) {
               List<MediaPackageElement> mpes = distributionService.retractSync(CHANNEL_ID, mp,
                       distributedEpisodeAcl.getIdentifier());
               if (mpes == null) {
                 logger.error("Unable to retract episode XACML {}", distributedEpisodeAcl.getIdentifier());
+              } else {
+                authorizationService.removeAcl(mp, AclScope.Episode);
               }
             }
           }


### PR DESCRIPTION
We first have to retract the file and then remove the MPE from the media package, otherwise the retraction will fail.

To trigger this bug, set `prop.admin.series.acl.event.update.mode` to `optional` in `org.opencastproject.organization-mh_default_org.cfg` and click on "Update event permissions" in the series ACL tab in the Admin UI. This will fail with a 500 Server Error and "No element ... found in mediapackage ..." in the log from the DownloadDistributionService.