### PR TITLE
Encode player redirect id parameter

### DIFF
--- a/modules/engage-ui/pom.xml
+++ b/modules/engage-ui/pom.xml
@@ -33,6 +33,17 @@
       <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
+    <!-- Testing -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymock</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/modules/engage-ui/src/main/java/org/opencastproject/engage/ui/PlayerRedirect.java
+++ b/modules/engage-ui/src/main/java/org/opencastproject/engage/ui/PlayerRedirect.java
@@ -36,6 +36,8 @@ import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 import javax.ws.rs.GET;
@@ -91,7 +93,7 @@ public class PlayerRedirect {
   public Response redirect(@PathParam("id") String id) {
     final Organization org = securityService.getOrganization();
     final String playerPath = Objects.toString(org.getProperties().get("player"), PLAYER_DEFAULT)
-            .replace("#{id}", id);
+            .replace("#{id}", URLEncoder.encode(id, StandardCharsets.UTF_8));
     logger.debug("redirecting to player: {}", playerPath);
     return Response
             .status(Response.Status.TEMPORARY_REDIRECT)

--- a/modules/engage-ui/src/test/java/org/opencastproject/engage/ui/PlayerRedirectTest.java
+++ b/modules/engage-ui/src/test/java/org/opencastproject/engage/ui/PlayerRedirectTest.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.engage.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.opencastproject.security.api.Organization;
+import org.opencastproject.security.api.SecurityService;
+
+import org.easymock.EasyMock;
+import org.easymock.EasyMockSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
+public class PlayerRedirectTest extends EasyMockSupport {
+
+  private SecurityService securityService;
+  private Organization organization;
+  private PlayerRedirect playerRedirect;
+
+  @BeforeEach
+  public void setup() {
+    securityService = createMock(SecurityService.class);
+    organization = createMock(Organization.class);
+    playerRedirect = new PlayerRedirect();
+    playerRedirect.setSecurityService(securityService);
+  }
+
+  @Test
+  public void shouldRedirectToDefaultPlayerWhenNoPlayerIsConfigured() {
+    String eventId = "event1";
+    EasyMock.expect(securityService.getOrganization()).andReturn(organization);
+    EasyMock.expect(organization.getProperties()).andReturn(new HashMap<>());
+    replayAll();
+
+    try (Response response = playerRedirect.redirect(eventId)) {
+      assertEquals(Response.Status.TEMPORARY_REDIRECT.getStatusCode(), response.getStatus());
+      assertEquals("/paella7/ui/watch.html?id=event1", response.getHeaderString("location"));
+    }
+
+    verifyAll();
+  }
+
+  @Test
+  public void shouldRedirectToConfiguredPlayer() {
+    String eventId = "event2";
+    Map<String, String> properties = new HashMap<>();
+    properties.put("player", "/custom/ui/watch.html?id=#{id}");
+    EasyMock.expect(securityService.getOrganization()).andReturn(organization);
+    EasyMock.expect(organization.getProperties()).andReturn(properties);
+    replayAll();
+
+    try (Response response = playerRedirect.redirect(eventId)) {
+      assertEquals(Response.Status.TEMPORARY_REDIRECT.getStatusCode(), response.getStatus());
+      assertEquals("/custom/ui/watch.html?id=event2", response.getHeaderString("location"));
+    }
+
+    verifyAll();
+  }
+
+  @Test
+  public void shouldHandleSpecialCharactersInEventId() {
+    String eventId = "event%20with%20spaces";
+    EasyMock.expect(securityService.getOrganization()).andReturn(organization);
+    EasyMock.expect(organization.getProperties()).andReturn(new HashMap<>());
+    replayAll();
+
+    try (Response response = playerRedirect.redirect(eventId)) {
+      assertEquals(Response.Status.TEMPORARY_REDIRECT.getStatusCode(), response.getStatus());
+      assertEquals("/paella7/ui/watch.html?id=event%2520with%2520spaces", response.getHeaderString("location"));
+    }
+
+    verifyAll();
+  }
+
+  @Test
+  public void shouldHandleUTF8EventId() {
+    String eventId = "üäöß$%&/()=?!§";
+    EasyMock.expect(securityService.getOrganization()).andReturn(organization);
+    EasyMock.expect(organization.getProperties()).andReturn(new HashMap<>());
+    replayAll();
+
+    try (Response response = playerRedirect.redirect(eventId)) {
+      assertEquals(Response.Status.TEMPORARY_REDIRECT.getStatusCode(), response.getStatus());
+      assertEquals("/paella7/ui/watch.html?id=%C3%BC%C3%A4%C3%B6%C3%9F%24%25%26%2F%28%29%3D%3F%21%C2%A7",
+          response.getHeaderString("location"));
+    }
+
+    verifyAll();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
     <jettison.version>1.5.4</jettison.version>
     <joda-time.version>2.12.5</joda-time.version>
     <json-simple.version>1.1.1</json-simple.version>
+    <junit5.version>5.10.0</junit5.version>
     <karaf.version>4.4.4</karaf.version>
     <node.version>v16.13.0</node.version>
     <osgi.core.version>8.0.0</osgi.core.version>
@@ -1302,6 +1303,18 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>4.13.2</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <version>${junit5.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>${junit5.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
The player redirect location header is not URL encoded, which results in the following exception
`org.eclipse.jetty.util.Utf8Appendable$NotUtf8Exception: Not valid UTF8! byte XY in state 3` if the id contains a character like a German umlaut (e.g. ö). This patch URL encodes the id parameter with utf8 charset.

The test cases are implemented with **junit5**!

Reproduce: https://stable.opencast.org/play/öäü?€

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
