### PR TITLE
Fix vosk output filenames

### DIFF
--- a/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/VoskEngine.java
+++ b/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/VoskEngine.java
@@ -107,6 +107,8 @@ public class VoskEngine implements SpeechToTextEngine {
     }
 
     var output = new File(workingDirectory, FilenameUtils.getBaseName(mediaFile.getAbsolutePath()));
+    //Vosk takes an -o $output_filenanme and writes the actual output to $output_filename.vtt...
+    var actualOutputFile = new File(output + ".vtt");
     final List<String> command = Arrays.asList(
             voskExecutable,
             "-i", mediaFile.getAbsolutePath(),
@@ -130,17 +132,17 @@ public class VoskEngine implements SpeechToTextEngine {
         throw new SpeechToTextEngineException(
                 String.format("Vosk exited abnormally with status %d (command: %s)%s", exitCode, command, error));
       }
-      if (!output.isFile()) {
+      if (!actualOutputFile.isFile()) {
         throw new SpeechToTextEngineException("Vosk produced no output");
       }
-      logger.info("Subtitles file generated successfully: {}", output);
+      logger.info("Subtitles file generated successfully: {}", actualOutputFile);
     } catch (Exception e) {
       logger.debug("Transcription failed closing Vosk transcription process for: {}", mediaFile);
       throw new SpeechToTextEngineException(e);
     } finally {
       IoSupport.closeQuietly(process);
     }
-    return new Result(language, output);
+    return new Result(language, actualOutputFile);
   }
 
 }

--- a/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/VoskEngine.java
+++ b/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/VoskEngine.java
@@ -106,9 +106,7 @@ public class VoskEngine implements SpeechToTextEngine {
       language = voskLanguage;
     }
 
-    var output = new File(workingDirectory, FilenameUtils.getBaseName(mediaFile.getAbsolutePath()));
-    //Vosk takes an -o $output_filenanme and writes the actual output to $output_filename.vtt...
-    var actualOutputFile = new File(output + ".vtt");
+    var output = new File(workingDirectory, FilenameUtils.getBaseName(mediaFile.getAbsolutePath()) + ".vtt");
     final List<String> command = Arrays.asList(
             voskExecutable,
             "-i", mediaFile.getAbsolutePath(),
@@ -132,17 +130,17 @@ public class VoskEngine implements SpeechToTextEngine {
         throw new SpeechToTextEngineException(
                 String.format("Vosk exited abnormally with status %d (command: %s)%s", exitCode, command, error));
       }
-      if (!actualOutputFile.isFile()) {
+      if (!output.isFile()) {
         throw new SpeechToTextEngineException("Vosk produced no output");
       }
-      logger.info("Subtitles file generated successfully: {}", actualOutputFile);
+      logger.info("Subtitles file generated successfully: {}", output);
     } catch (Exception e) {
       logger.debug("Transcription failed closing Vosk transcription process for: {}", mediaFile);
       throw new SpeechToTextEngineException(e);
     } finally {
       IoSupport.closeQuietly(process);
     }
-    return new Result(language, actualOutputFile);
+    return new Result(language, output);
   }
 
 }


### PR DESCRIPTION
This PR properly handles the output filename fed to vosk-cli.  Vosk adds a `.vtt` to the end of the output file's name.

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
