### PR TITLE
Fixed created value on scheduling event series

### DIFF
--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -587,6 +587,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
         DublinCoreValue eventTime = EncodingSchemeUtils.encodePeriod(new DCMIPeriod(startDate, endDate),
                 Precision.Second);
         dc.set(DublinCore.PROPERTY_TEMPORAL, eventTime);
+        dc.set(DublinCore.PROPERTY_CREATED, EncodingSchemeUtils.encodeDate(startDate, Precision.Second));
         try {
           mediaPackage = updateDublincCoreCatalog(mediaPackage, dc);
         } catch (Exception e) {


### PR DESCRIPTION
The values of start date field and created field are synchronized. All changes of start date value will trigger an update of created value. Also on upload or schedule event. But on schedule of multible events the created value is not set correctly. It stick at first start date on all events.
