### PR TITLE
Update config file and docs for correct shibboleth logout

### DIFF
--- a/docs/guides/admin/docs/configuration/security.aai.md
+++ b/docs/guides/admin/docs/configuration/security.aai.md
@@ -83,8 +83,11 @@ within the HTTP request headers.
 To ensure that a logout is not just logging out the user from the Opencast application but also from Shibboleth,
 you will need to configure the logout-success-url:
 
-    <!-- Enables log out -->
-    <sec:logout logout-success-url="/Shibboleth.sso/Logout?return=www.opencast.org" />
+    <bean id="logoutSuccessHandler" class="org.opencastproject.kernel.security.LogoutSuccessHandler">
+        <property name="userDirectoryService" ref="userDirectoryService" />
+        <!-- Shibboleth log out -->
+        <property name="defaultTargetUrl" value="/Shibboleth.sso/Logout?return=www.opencast.org"/>
+    </bean>
 
 **IMPORTANT:** In the section *Shibboleth Support*, be sure to adapt the value of *principalRequestHeader* to the
 respective name of the Shibboleth attribute you use in your Shibboleth Federation:

--- a/docs/guides/admin/docs/configuration/security.aai.md
+++ b/docs/guides/admin/docs/configuration/security.aai.md
@@ -81,7 +81,7 @@ within the HTTP request headers.
     <sec:custom-filter ref="shibbolethHeaderFilter" position="PRE_AUTH_FILTER"/>
 
 To ensure that a logout is not just logging out the user from the Opencast application but also from Shibboleth,
-you will need to configure the logout-success-url:
+you will need to configure the defaultTargetUrl inside the logoutSuccessHandler:
 
     <bean id="logoutSuccessHandler" class="org.opencastproject.kernel.security.LogoutSuccessHandler">
         <property name="userDirectoryService" ref="userDirectoryService" />

--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -409,11 +409,6 @@
     <!-- Enables log out -->
     <sec:logout success-handler-ref="logoutSuccessHandler" />
 
-    <!-- Shibboleth log out
-         Please specifiy the URL to return to after logging out
-    <sec:logout logout-success-url="/Shibboleth.sso/Logout?return=http://www.opencast.org" />
-    -->
-
     <!-- JWT single log out
          Please specify the URL to return to after logging out. Comment out the logoutSuccessHandler above.
     <sec:logout logout-success-url="https://auth.example.org/sign_out?rd=http://www.opencast.org" />
@@ -548,6 +543,9 @@
 
   <bean id="logoutSuccessHandler" class="org.opencastproject.kernel.security.LogoutSuccessHandler">
     <property name="userDirectoryService" ref="userDirectoryService" />
+    <!-- Shibboleth log out
+    <property name="defaultTargetUrl" value="/Shibboleth.sso/Logout?return=www.opencast.org"/>
+    -->
   </bean>
 
   <!-- ################# -->


### PR DESCRIPTION
Since `<sec:logout logout-success-url="/Shibboleth.sso/Logout?return=www.opencast.org" />` has no effect anymore, the config file and the docs should be updated to the correct way of redirecting after shibboleth logout.