### PR TITLE
Update setenv with currently supported options for Karaf

### DIFF
--- a/assemblies/resources/bin/setenv
+++ b/assemblies/resources/bin/setenv
@@ -20,27 +20,25 @@
 
 # Possible configuration options for the start script:
 #
-# export JAVA_HOME         # Location of Java installation
-# export JAVA_MIN_MEM      # Minimum memory for the JVM
-# export JAVA_MAX_MEM      # Maximum memory for the JVM
-# export JAVA_PERM_MEM     # Minimum perm memory for the JVM
-# export JAVA_MAX_PERM_MEM # Maximum perm memory for the JVM
-# export EXTRA_JAVA_OPTS   # Additional JVM options
-# export KARAF_HOME        # Karaf home folder
-# export KARAF_DATA        # Karaf data folder
-# export KARAF_BASE        # Karaf base folder
-# export KARAF_ETC         # Karaf etc  folder
-# export KARAF_OPTS        # Additional Karaf options
-# export KARAF_REDIRECT    # Enable/set the std/err redirection when using bin/start
+# export JAVA_HOME           # Location of Java installation
+# export JAVA_OPTS           # Generic JVM options, for instance, where you can pass the memory configuration
+# export JAVA_NON_DEBUG_OPTS # Additional non-debug JVM options
+# export EXTRA_JAVA_OPTS     # Additional JVM options
+# export KARAF_HOME          # Karaf home folder
+# export KARAF_DATA          # Karaf data folder
+# export KARAF_BASE          # Karaf base folder
+# export KARAF_ETC           # Karaf etc  folder
+# export KARAF_LOG           # Karaf log  folder
+# export KARAF_SYSTEM_OPTS   # First citizen Karaf options
+# export KARAF_OPTS          # Additional available Karaf options
+# export KARAF_REDIRECT      # Enable/set the std/err redirection when using bin/start
 #
 # Debug options
-# export KARAF_DEBUG       # Enable debug mode
-# export JAVA_DEBUG_PORT   # Set debug port (defaults to 5005)
+# export KARAF_DEBUG         # Enable debug mode
+# export JAVA_DEBUG_PORT     # Set debug port (defaults to 5005)
 
 
 export EXTRA_JAVA_OPTS="${EXTRA_JAVA_OPTS} -Dorg.eclipse.jetty.server.Request.maxFormContentSize=1500000 -Dfile.encoding=UTF-8 -Dlog4j2.formatMsgNoLookups=true"
-export JAVA_MAX_MEM="${JAVA_MAX_MEM:-1G}"
-export JAVA_PERM_MEM="${JAVA_PERM_MEM:-256M}"
 export KARAF_NOROOT=true
 
 # Mitigation for new Tesseract 4.x locking up the system


### PR DESCRIPTION
The setenv file was out of date with current Karaf. In particular, the memory options were no longer applied. Instead, users should use the `JAVA_OPTS` variable to set desired memory options.

This also removes the perm memory options. Setting this is no longer necessary as of Java 8.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
