### PR TITLE
Fix use of s3 distribution service in live scheduler

### DIFF
--- a/docs/guides/admin/docs/configuration/liveschedule.md
+++ b/docs/guides/admin/docs/configuration/liveschedule.md
@@ -75,13 +75,14 @@ live.mimeType=application/x-mpegURL
 # Default is presenter/delivery
 #live.targetFlavors=presenter/delivery
 
-# The distribution service to use: download or aws.s3
-live.distributionService=download
-
 # A list of combinations with target flavor and resolution for which streaming URIs should be published.
 # For example: live.publishStreaming=presenter/delivery:1920x540
 # Default is not to publish streaming URIs
 # live.publishStreaming=
+
+# The distribution service to use: download or aws.s3
+# Default: (distribution.channel=download)
+#DownloadDistributionService.target=(distribution.channel=download)
 ```
 
 ### Step 2: Configure the capture agent

--- a/etc/org.opencastproject.liveschedule.impl.LiveScheduleServiceImpl.cfg
+++ b/etc/org.opencastproject.liveschedule.impl.LiveScheduleServiceImpl.cfg
@@ -35,10 +35,14 @@ live.mimeType=application/x-mpegURL
 # Default is presenter/delivery
 #live.targetFlavors=presenter/delivery
 
-# The distribution service to use: download or aws.s3
-live.distributionService=download
-
 # A list of combinations with target flavor and resolution for which streaming URIs should be published.
 # For example: live.publishStreaming=presenter/delivery:1920x540
 # Default is not to publish streaming URIs
 # live.publishStreaming=
+
+# The distribution service to use: download or aws.s3
+live.distributionService=download
+
+# The distribution service to use: download or aws.s3
+# Default: (distribution.channel=download)
+#DownloadDistributionService.target=(distribution.channel=download)

--- a/etc/org.opencastproject.liveschedule.impl.LiveScheduleServiceImpl.cfg
+++ b/etc/org.opencastproject.liveschedule.impl.LiveScheduleServiceImpl.cfg
@@ -41,8 +41,5 @@ live.mimeType=application/x-mpegURL
 # live.publishStreaming=
 
 # The distribution service to use: download or aws.s3
-live.distributionService=download
-
-# The distribution service to use: download or aws.s3
 # Default: (distribution.channel=download)
 #DownloadDistributionService.target=(distribution.channel=download)


### PR DESCRIPTION
Fix for: if the download distribution service comes up before the s3 distribution service, it will be used even if the 'aws-s3' distribution service was set in the 'live.distributionService' configuration.
This fix has been in our code base for a long time but it seems we forgot to create a PR...

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
