### PR TITLE
Fixed NPE on filtering data

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/userdirectory/UIRolesRoleProvider.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/userdirectory/UIRolesRoleProvider.java
@@ -124,6 +124,9 @@ public class UIRolesRoleProvider implements RoleProvider {
   }
 
   private static boolean like(String string, final String query) {
+    if (string == null) {
+      return false;
+    }
     String regex = query.replace("_", ".").replace("%", ".*?");
     Pattern p = Pattern.compile(regex, Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
     return p.matcher(string).matches();

--- a/modules/external-api/src/main/java/org/opencastproject/external/userdirectory/ExternalApiRoleProvider.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/userdirectory/ExternalApiRoleProvider.java
@@ -130,6 +130,9 @@ public class ExternalApiRoleProvider implements RoleProvider {
   }
 
   private static boolean like(String string, final String query) {
+    if (string == null) {
+      return false;
+    }
     String regex = query.replace("_", ".").replace("%", ".*?");
     Pattern p = Pattern.compile(regex, Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
     return p.matcher(string).matches();

--- a/modules/security-aai/src/main/java/org/opencastproject/security/aai/ConfigurableLoginHandler.java
+++ b/modules/security-aai/src/main/java/org/opencastproject/security/aai/ConfigurableLoginHandler.java
@@ -545,6 +545,9 @@ public class ConfigurableLoginHandler implements ShibbolethLoginHandler, RolePro
   }
 
   private boolean like(String string, final String query) {
+    if (string == null) {
+      return false;
+    }
     String regex = query.replace("_", ".").replace("%", ".*?");
     Pattern p = Pattern.compile(regex, Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
     return p.matcher(string).matches();

--- a/modules/security-aai/src/main/java/org/opencastproject/security/aai/DynamicLoginHandler.java
+++ b/modules/security-aai/src/main/java/org/opencastproject/security/aai/DynamicLoginHandler.java
@@ -311,6 +311,9 @@ public class DynamicLoginHandler implements ShibbolethLoginHandler, AAIRoleProvi
   }
 
   private boolean like(String string, final String query) {
+    if (string == null) {
+      return false;
+    }
     String regex = query.replace("_", ".").replace("%", ".*?");
     Pattern p = Pattern.compile(regex, Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
     return p.matcher(string).matches();

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/CustomRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/CustomRoleProvider.java
@@ -172,6 +172,9 @@ public class CustomRoleProvider implements RoleProvider {
   }
 
   private static boolean like(String string, final String query) {
+    if (string == null) {
+      return false;
+    }
     String regex = query.replace("_", ".").replace("%", ".*?");
     Pattern p = Pattern.compile(regex, Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
     return p.matcher(string).matches();

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/OrganizationRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/OrganizationRoleProvider.java
@@ -142,6 +142,9 @@ public class OrganizationRoleProvider implements RoleProvider {
   }
 
   private boolean like(String string, final String query) {
+    if (string == null) {
+      return false;
+    }
     String regex = query.replace("_", ".").replace("%", ".*?");
     Pattern p = Pattern.compile(regex, Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
     return p.matcher(string).matches();

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserIdRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserIdRoleProvider.java
@@ -202,6 +202,9 @@ public class UserIdRoleProvider implements RoleProvider, ManagedService {
   }
 
   private static boolean like(String string, final String query) {
+    if (string == null) {
+      return false;
+    }
     String regex = query.replace("_", ".").replace("%", ".*?");
     Pattern p = Pattern.compile(regex, Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
     return p.matcher(string).matches();


### PR DESCRIPTION
Systems with at least one role without a description (value=null) will throw a NullPointerException when calling the REST endpoint /admin-ng/acl/roles.json?target=ACL&query=foo with query argument set. This issue is addressed in some modules, but not averywhere. I hope I found them all.
