### PR TITLE
Update temporal if empty

### DIFF
--- a/modules/inspection-workflowoperation/src/test/java/org/opencastproject/workflow/handler/inspection/InspectWorkflowOperationHandlerTest.java
+++ b/modules/inspection-workflowoperation/src/test/java/org/opencastproject/workflow/handler/inspection/InspectWorkflowOperationHandlerTest.java
@@ -36,6 +36,8 @@ import org.opencastproject.metadata.dublincore.DublinCore;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalogService;
 import org.opencastproject.metadata.dublincore.DublinCoreValue;
+import org.opencastproject.metadata.dublincore.EncodingSchemeUtils;
+import org.opencastproject.metadata.dublincore.Precision;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
 import org.opencastproject.workflow.api.WorkflowInstance;
 import org.opencastproject.workflow.api.WorkflowInstance.WorkflowState;
@@ -115,6 +117,11 @@ public class InspectWorkflowOperationHandlerTest {
     EasyMock.expect(dc.hasValue(DublinCore.PROPERTY_EXTENT)).andReturn(false);
     dc.set((EName) EasyMock.anyObject(), (DublinCoreValue) EasyMock.anyObject());
     EasyMock.expect(dc.hasValue(DublinCore.PROPERTY_CREATED)).andReturn(false);
+    dc.set((EName) EasyMock.anyObject(), (DublinCoreValue) EasyMock.anyObject());
+    EasyMock.expect(dc.hasValue(DublinCore.PROPERTY_CREATED)).andReturn(true);
+    EasyMock.expect(dc.hasValue(DublinCore.PROPERTY_TEMPORAL)).andReturn(false);
+    EasyMock.expect(dc.getFirst(DublinCore.PROPERTY_CREATED))
+        .andReturn(EncodingSchemeUtils.encodeDate(DATE, Precision.Minute).getValue());
     dc.set((EName) EasyMock.anyObject(), (DublinCoreValue) EasyMock.anyObject());
     dc.toXml((ByteArrayOutputStream) EasyMock.anyObject(), EasyMock.anyBoolean());
     // EasyMock.expect(dc.getIdentifier()).andReturn("123");


### PR DESCRIPTION
If the dcterm extent of the episode dublincore catalog is empty, it is updated by the inspect operation with the current length of the media package; this change applies the same behavior for the dcterm temporal.

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
