### PR TITLE
Make a dynamic OSGi dependency static

### DIFF
--- a/modules/conductor/src/main/java/org/opencastproject/event/handler/ConductingSeriesUpdatedEventHandler.java
+++ b/modules/conductor/src/main/java/org/opencastproject/event/handler/ConductingSeriesUpdatedEventHandler.java
@@ -29,8 +29,6 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,9 +70,7 @@ public class ConductingSeriesUpdatedEventHandler implements SeriesUpdateHandler 
     } else if (SeriesItem.Type.UpdateCatalog.equals(seriesItem.getType())
                  || SeriesItem.Type.UpdateAcl.equals(seriesItem.getType())
                  || SeriesItem.Type.Delete.equals(seriesItem.getType())) {
-      if (searchUpdatedEventHandler != null) {
-        searchUpdatedEventHandler.handleEvent(seriesItem);
-      }
+      searchUpdatedEventHandler.handleEvent(seriesItem);
       assetManagerUpdatedEventHandler.handleEvent(seriesItem);
     }
   }
@@ -86,16 +82,8 @@ public class ConductingSeriesUpdatedEventHandler implements SeriesUpdateHandler 
   }
 
   /** OSGi DI callback. */
-  @Reference (
-      policy = ReferencePolicy.DYNAMIC,
-      cardinality = ReferenceCardinality.OPTIONAL,
-      unbind = "unsetSearchUpdatedEventHandler"
-  )
+  @Reference
   public void setSearchUpdatedEventHandler(SearchUpdatedEventHandler h) {
     this.searchUpdatedEventHandler = h;
-  }
-
-  public void unsetSearchUpdatedEventHandler(SearchUpdatedEventHandler h) {
-    this.searchUpdatedEventHandler = null;
   }
 }


### PR DESCRIPTION
I don't see any reason for it to be dynamic, neither do I see an easy way to **not** have it in the system.