### PR TITLE
Paella7: Avoid opening downloaded video

### DIFF
--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.downloadsPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.downloadsPlugin.js
@@ -187,7 +187,7 @@ export default class DownloadsPlugin extends PopUpButtonPlugin {
 
           createElementWithHtmlText(`
             <li>
-              <a href="${d.url}" download target="_blank">
+              <a href="${d.url}" download>
                 <span class="mimetype">[${d.mimetype}]</span><span class="res">${meta}</span>
               </a>
             </li>


### PR DESCRIPTION
This should help with some cases where clicking on a video in the Paella7 download plugin would open the video instead of triggering a "Do you want to download this?" dialog from the browser.
