### PR TITLE
Remove Spurious Warnings During Build

### DIFF
--- a/assemblies/dist-develop/pom.xml
+++ b/assemblies/dist-develop/pom.xml
@@ -11,6 +11,7 @@
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <packaging.definition>${project.basedir}/target/classes/package.xml</packaging.definition>
     <enableJobDispatching>true</enableJobDispatching>
+    <enableDeveloperMode>true</enableDeveloperMode>
   </properties>
   <artifactId>opencast-dist-develop</artifactId>
   <packaging>karaf-assembly</packaging>

--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -145,6 +145,7 @@
                   <ant antfile="../resources/build.xml">
                     <target name="basic configuration"/>
                     <target name="job dispatching"/>
+                    <target name="developer mode"/>
                   </ant>
                 </target>
               </configuration>

--- a/assemblies/resources/build.xml
+++ b/assemblies/resources/build.xml
@@ -14,16 +14,10 @@
     <concat destfile="target/assembly/etc/system.properties" append="true">
       <filelist dir="../resources" files="system.properties.append"/>
     </concat>
-    <concat destfile="target/assembly/etc/shell.init.script" append="true">
-      <filelist dir="resources" files="shell.init.script.append"/>
-    </concat>
     <!-- Adding extra OSGi system packages to configuration -->
     <replace file="target/assembly/etc/config.properties" token="org.osgi.framework.system.packages= \" value="org.osgi.framework.system.packages= com.sun.image.codec.jpeg, com.sun.jndi.ldap, \"/>
     <!-- Disabled write permissions on karaf configuration by deactivating config saves -->
     <replaceregexp file="target/assembly/etc/config.properties" match="^felix.fileinstall.enableConfigSave .*=.*$" replace="felix.fileinstall.enableConfigSave = false" byline="true"/>
-    <!-- Special configuration for development -->
-    <replaceregexp file="target/classes/package.xml" match="tar\.gz" replace="dir" byline="true"/>
-    <replaceregexp file="target/classes/package.xml" match="baseDirectory&gt;.*&lt;/baseDirectory&gt;" replace="includeBaseDirectory&gt;false&lt;/includeBaseDirectory&gt;" byline="true"/>
   </target>
 
   <target if="enableJobDispatching" name="job dispatching">
@@ -33,5 +27,15 @@
       match="^#dispatch.interval=0$"
       replace="dispatch.interval=2"
       byline="true" />
+  </target>
+
+  <target if="enableDeveloperMode" name="developer mode">
+    <echo>Enabling developer mode</echo>
+    <concat destfile="target/assembly/etc/shell.init.script" append="true">
+      <filelist dir="resources" files="shell.init.script.append"/>
+    </concat>
+    <!-- Special configuration for development -->
+    <replaceregexp file="target/classes/package.xml" match="tar\.gz" replace="dir" byline="true"/>
+    <replaceregexp file="target/classes/package.xml" match="baseDirectory&gt;.*&lt;/baseDirectory&gt;" replace="includeBaseDirectory&gt;false&lt;/includeBaseDirectory&gt;" byline="true"/>
   </target>
 </project>


### PR DESCRIPTION
This PR removes warnings in the vein of
```
[INFO] --- maven-antrun-plugin:3.1.0:run (default) @ opencast-dist-worker ---
[INFO] Executing tasks
[WARNING]      [echo] Basic configuration
[ERROR]    [concat] /home/greg/opencast/upstream/assemblies/dist-worker/resources/shell.init.script.append does not exist.
[ERROR] [replaceregexp] The following file is missing: '/home/greg/opencast/upstream/assemblies/dist-worker/target/classes/package.xml'
[ERROR] [replaceregexp] The following file is missing: '/home/greg/opencast/upstream/assemblies/dist-worker/target/classes/package.xml'
[INFO] Executed tasks
```

in the non-developer builds.

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
