### PR TITLE
Quickfix dangling hard links on cephfs volumes

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/util/FileSupport.java
+++ b/modules/common/src/main/java/org/opencastproject/util/FileSupport.java
@@ -248,6 +248,7 @@ public final class FileSupport {
 
       try {
         createLink(targetPath, sourcePath);
+        targetPath.toFile().length(); // this forces a stat call which is a quickfix for a bug in ceph (https://www.mail-archive.com/ceph-users@lists.ceph.com/msg53368.html)
       } catch (UnsupportedOperationException e) {
         logger.debug("Copy file because creating hard-links is not supported by the current file system: {}",
                 ExceptionUtils.getMessage(e));
@@ -290,6 +291,7 @@ public final class FileSupport {
     try {
       deleteIfExists(targetPath);
       createLink(targetPath, sourcePath);
+      targetPath.toFile().length(); // this forces a stat call which is a quickfix for a bug in ceph (https://www.mail-archive.com/ceph-users@lists.ceph.com/msg53368.html)
     } catch (Exception e) {
       logger.debug("Unable to create a link from {} to {}: {}", sourcePath, targetPath, e);
       return false;


### PR DESCRIPTION
This is a quickfix that forces a `stat` call after creating hard links. In a cephfs scenario this might be necessary in order to limit the amount of strayed inodes (see https://www.mail-archive.com/ceph-users@lists.ceph.com/msg53368.html).

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
