### PR TITLE
Fix editor track selection for updating tags

### DIFF
--- a/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/impl/VideoEditorServiceImpl.java
+++ b/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/impl/VideoEditorServiceImpl.java
@@ -31,6 +31,8 @@ import org.opencastproject.job.api.JobBarrier;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.mediapackage.MediaPackageElementParser;
 import org.opencastproject.mediapackage.MediaPackageException;
+import org.opencastproject.mediapackage.MediaPackageReference;
+import org.opencastproject.mediapackage.MediaPackageReferenceImpl;
 import org.opencastproject.mediapackage.Track;
 import org.opencastproject.mediapackage.identifier.IdImpl;
 import org.opencastproject.security.api.OrganizationDirectoryService;
@@ -193,12 +195,15 @@ public class VideoEditorServiceImpl extends AbstractJobProducer implements Video
     }
     MediaPackageElementFlavor sourceTrackFlavor = null;
     String sourceTrackUri = null;
+    MediaPackageReference ref = null;
     // get source track metadata
     for (SmilMediaParam param : trackParamGroup.getParams()) {
       if (SmilMediaParam.PARAM_NAME_TRACK_SRC.equals(param.getName())) {
         sourceTrackUri = param.getValue();
       } else if (SmilMediaParam.PARAM_NAME_TRACK_FLAVOR.equals(param.getName())) {
         sourceTrackFlavor = MediaPackageElementFlavor.parseFlavor(param.getValue());
+      } else if (SmilMediaParam.PARAM_NAME_TRACK_ID.equals(param.getName())) {
+        ref = new MediaPackageReferenceImpl("track", param.getValue());
       }
     }
     File sourceFile;
@@ -411,6 +416,7 @@ public class VideoEditorServiceImpl extends AbstractJobProducer implements Video
       Track editedTrack = (Track) MediaPackageElementParser.getFromXml(inspectionJob.getPayload());
       logger.info("Finished editing track {}", editedTrack);
       editedTrack.setIdentifier(newTrackId);
+      editedTrack.setReference(ref);
       if (videoclips.size() > 0) {
         editedTrack.setFlavor(new MediaPackageElementFlavor(sourceTrackFlavor.getType(), SINK_FLAVOR_SUBTYPE));
       }
@@ -418,7 +424,7 @@ public class VideoEditorServiceImpl extends AbstractJobProducer implements Video
         String extension = FilenameUtils.getExtension(sourceTrackUri);
         if (VideoEditorProperties.WEBVTT_EXTENSION.equals(extension)) {
           editedTrack.setFlavor(new MediaPackageElementFlavor(sourceTrackFlavor.getType(),
-                  sourceTrackFlavor.getSubtype() + "+" + SINK_FLAVOR_SUBTYPE));
+              sourceTrackFlavor.getSubtype() + "+" + SINK_FLAVOR_SUBTYPE));
         }
       }
 

--- a/modules/videoeditor-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videoeditor/VideoEditorWorkflowOperationHandler.java
+++ b/modules/videoeditor-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videoeditor/VideoEditorWorkflowOperationHandler.java
@@ -570,7 +570,11 @@ public class VideoEditorWorkflowOperationHandler extends ResumableWorkflowOperat
                 editedTrack.getIdentifier(), FilenameUtils.getName(editedTrack.getURI().toString()));
         editedTrack.setURI(editedTrackNewUri);
         for (Track track : sourceTracks) {
-          if (track.getIdentifier().equals(editedTrack.getReference().getIdentifier())) {
+          var reference = editedTrack.getReference();
+          if (reference == null) {
+            logger.warn("Edited track {} has no reference track assigned; skip restoring tags.",
+                editedTrack.getIdentifier());
+          } else if (track.getIdentifier().equals(reference.getIdentifier())) {
             editedTrack.setTags(track.getTags());
             mp.addDerived(editedTrack, track);
             mpAdded = true;

--- a/modules/videoeditor-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videoeditor/VideoEditorWorkflowOperationHandler.java
+++ b/modules/videoeditor-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videoeditor/VideoEditorWorkflowOperationHandler.java
@@ -570,7 +570,7 @@ public class VideoEditorWorkflowOperationHandler extends ResumableWorkflowOperat
                 editedTrack.getIdentifier(), FilenameUtils.getName(editedTrack.getURI().toString()));
         editedTrack.setURI(editedTrackNewUri);
         for (Track track : sourceTracks) {
-          if (track.getFlavor().getType().equals(editedTrackFlavor.getType())) {
+          if (track.getIdentifier().equals(editedTrack.getReference().getIdentifier())) {
             editedTrack.setTags(track.getTags());
             mp.addDerived(editedTrack, track);
             mpAdded = true;

--- a/modules/videoeditor-workflowoperation/src/test/resources/editor_smil_mediapackage.xml
+++ b/modules/videoeditor-workflowoperation/src/test/resources/editor_smil_mediapackage.xml
@@ -6,7 +6,7 @@
   <ns3:title>editor test</ns3:title>
   <ns3:license>Creative Commons 3.0: Attribution-NonCommercial-NoDerivs</ns3:license>
   <ns3:media>
-    <ns3:track ref="track:d3d6736c-e6d5-11ee-bdf1-18c04d393d83" type="presenter/work" id="66177125-bf92-46bd-b404-e5eb11790faa">
+    <ns3:track type="presenter/work" id="66177125-bf92-46bd-b404-e5eb11790faa">
       <ns3:mimetype>video/mp4</ns3:mimetype>
       <ns3:tags/>
       <ns3:url>http://localhost:8080/files/mediapackage/eb18ea5d-d948-4c18-9566-1cf929563493/905f86b4-a0eb-47db-b54f-9f0e5f12b14b/mh720p.mp4</ns3:url>

--- a/modules/videoeditor-workflowoperation/src/test/resources/editor_smil_mediapackage.xml
+++ b/modules/videoeditor-workflowoperation/src/test/resources/editor_smil_mediapackage.xml
@@ -6,7 +6,7 @@
   <ns3:title>editor test</ns3:title>
   <ns3:license>Creative Commons 3.0: Attribution-NonCommercial-NoDerivs</ns3:license>
   <ns3:media>
-    <ns3:track type="presenter/work" id="66177125-bf92-46bd-b404-e5eb11790faa">
+    <ns3:track ref="track:d3d6736c-e6d5-11ee-bdf1-18c04d393d83" type="presenter/work" id="66177125-bf92-46bd-b404-e5eb11790faa">
       <ns3:mimetype>video/mp4</ns3:mimetype>
       <ns3:tags/>
       <ns3:url>http://localhost:8080/files/mediapackage/eb18ea5d-d948-4c18-9566-1cf929563493/905f86b4-a0eb-47db-b54f-9f0e5f12b14b/mh720p.mp4</ns3:url>


### PR DESCRIPTION
Set a media package element reference on the edited track to identify it later so that the tags can be updated based on the source track.

The check if `editedTrack.getReference()` is null should not be necessary as every track should have a reference, or is that assumption wrong?

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
