### PR TITLE
Process-smil WOH tag-with-profile configuration does not work depending on the encoding profile suffix configured

### DIFF
--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/MultiEncodeWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/MultiEncodeWorkflowOperationHandler.java
@@ -469,9 +469,13 @@ public class MultiEncodeWorkflowOperationHandler extends AbstractWorkflowOperati
   private void tagByProfile(Track track, List<EncodingProfile> profiles) {
     String rawfileName = track.getURI().getRawPath();
     for (EncodingProfile ep : profiles) {
-      String suffix = ep.getSuffix();
+      // #DCE
+      // Add any character at the beginning of the suffix so that it is properly
+      // converted in toSafeName (because the regex used there may treat the first
+      // character differently; the default one does now).
+      String suffixToSanitize = "X" + ep.getSuffix();
       // !! workspace.putInCollection renames the file - need to do the same with suffix
-      suffix = workspace.toSafeName(suffix);
+      String suffix = workspace.toSafeName(suffixToSanitize).substring(1);
       if (suffix.length() > 0 && rawfileName.endsWith(suffix)) {
         track.addTag(ep.getIdentifier());
         return;

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ProcessSmilWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ProcessSmilWorkflowOperationHandler.java
@@ -493,9 +493,12 @@ public class ProcessSmilWorkflowOperationHandler extends AbstractWorkflowOperati
   private void tagByProfile(Track track, List<EncodingProfile> profiles) {
     String rawfileName = track.getURI().getRawPath();
     for (EncodingProfile ep : profiles) {
-      String suffix = ep.getSuffix();
+      // #5687: Add any character at the beginning of the suffix so that it is properly
+      // converted in toSafeName (because the regex used there may treat the first
+      // character differently; the default regex currently does).
+      String suffixToSanitize = "X" + ep.getSuffix();
       // !! workspace.putInCollection renames the file - need to do the same with suffix
-      suffix = workspace.toSafeName(suffix);
+      String suffix = workspace.toSafeName(suffixToSanitize).substring(1);
       if (suffix.length() > 0 && rawfileName.endsWith(suffix)) {
         track.addTag(ep.getIdentifier());
         return;


### PR DESCRIPTION
This PR fixes #5687 

The issue was that if an encoding profile had a suffix starting with a '-' e.g. -presentation-3q-300k-25fps.mp4, workspace.toSafeName would change the first character to '_' e.g. _presentation-3q-300k-25fps.mp4, and the track would never be tagged with the profile name. This fix just adds a dummy character as the first one before toSafeName is called so that the 'suffix' is treated as a suffix, independently of the regex used.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
