### PR TITLE
Mark RPMs as available

### DIFF
--- a/docs/guides/admin/docs/installation/rpm-el.md
+++ b/docs/guides/admin/docs/installation/rpm-el.md
@@ -8,9 +8,6 @@ This repository provides preconfigured Opencast installations and all necessary 
 > In addition to this guide, we have also recorded [a full installation done in 30 minutes](https://vt.uos.de/71hfc)
 > if you like to see how this works before you try it yourself.
 
-<div class=warn>
-  <b>Opencast {{ opencast_major_version() }}</b> is not yet available.
-</div>
 
 Currently Supported
 -------------------

--- a/docs/guides/admin/docs/installation/rpm-el7.md
+++ b/docs/guides/admin/docs/installation/rpm-el7.md
@@ -11,9 +11,6 @@ This guide is based on an RPM software repository available for Red Hat based Li
 by [Osnabrück University](https://uni-osnabrueck.de).
 This repository provides preconfigured Opencast installations and all necessary 3rd-party-tools.
 
-<div class=warn>
-  <b>Opencast {{ opencast_major_version() }}</b> is not yet available.
-</div>
 
 Currently Supported
 -------------------


### PR DESCRIPTION
This patch fixes an issue in the Opencast documentation, accidentally marking the RPMs for Opencast 15 as not yet available.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
