### PR TITLE
Add Playlists to Tobira Harvest API

### DIFF
--- a/modules/playlists/src/main/java/org/opencastproject/playlists/PlaylistService.java
+++ b/modules/playlists/src/main/java/org/opencastproject/playlists/PlaylistService.java
@@ -51,6 +51,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 @Component(
@@ -165,6 +166,19 @@ public class PlaylistService {
       return playlists;
     } catch (PlaylistDatabaseException e) {
       throw new IllegalStateException("Could not get playlist from database with id ");
+    }
+  }
+
+  public List<Playlist> getAllForAdministrativeRead(Date from, Date to, int limit)
+          throws IllegalStateException, UnauthorizedException {
+    if (!this.securityService.getUser().hasRole(GLOBAL_ADMIN_ROLE)) {
+      throw new UnauthorizedException("Only admins can call this method");
+    }
+
+    try {
+      return persistence.getAllForAdministrativeRead(from, to, limit);
+    } catch (PlaylistDatabaseException e) {
+      throw new IllegalStateException("Could not get playlist from database", e);
     }
   }
 

--- a/modules/playlists/src/main/java/org/opencastproject/playlists/persistence/PlaylistDatabaseService.java
+++ b/modules/playlists/src/main/java/org/opencastproject/playlists/persistence/PlaylistDatabaseService.java
@@ -24,6 +24,7 @@ import org.opencastproject.playlists.Playlist;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.requests.SortCriterion;
 
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -58,6 +59,9 @@ public interface PlaylistDatabaseService {
    * @throws PlaylistDatabaseException if there is a problem communicating with the underlying data store
    */
   List<Playlist> getPlaylists(int limit, int offset, SortCriterion sortCriterion)
+          throws PlaylistDatabaseException;
+
+  List<Playlist> getAllForAdministrativeRead(Date from, Date endDate, int limit)
           throws PlaylistDatabaseException;
 
   /**

--- a/modules/playlists/src/main/java/org/opencastproject/playlists/persistence/PlaylistDatabaseServiceImpl.java
+++ b/modules/playlists/src/main/java/org/opencastproject/playlists/persistence/PlaylistDatabaseServiceImpl.java
@@ -163,6 +163,29 @@ public class PlaylistDatabaseServiceImpl implements PlaylistDatabaseService {
     }
   }
 
+  public List<Playlist> getAllForAdministrativeRead(Date startDate, Date endDate, int limit)
+          throws PlaylistDatabaseException {
+    try {
+      return db.exec(em -> {
+        final var criteriaBuilder = em.getCriteriaBuilder();
+        final var criteriaQuery = criteriaBuilder.createQuery(Playlist.class);
+        final var from = criteriaQuery.from(Playlist.class);
+        final var select = criteriaQuery.select(from)
+            .where(
+                criteriaBuilder.greaterThanOrEqualTo(from.get("updated"), startDate),
+                criteriaBuilder.lessThan(from.get("updated"), endDate)
+            )
+            .orderBy(criteriaBuilder.asc(from.get("updated")));
+
+        return em.createQuery(select)
+            .setMaxResults(limit)
+            .getResultList();
+      });
+    } catch (Exception e) {
+      throw new PlaylistDatabaseException("Error fetching playlists from database", e);
+    }
+  }
+
   /**
    * {@inheritDoc}
    * @see PlaylistDatabaseService#updatePlaylist(Playlist, String)

--- a/modules/tobira/pom.xml
+++ b/modules/tobira/pom.xml
@@ -58,6 +58,11 @@
       <artifactId>opencast-dublincore</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-playlists</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/TobiraEndpoint.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/TobiraEndpoint.java
@@ -25,6 +25,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static org.opencastproject.util.doc.rest.RestParameter.Type;
 
+import org.opencastproject.playlists.PlaylistService;
 import org.opencastproject.search.api.SearchService;
 import org.opencastproject.security.api.AuthorizationService;
 import org.opencastproject.series.api.SeriesService;
@@ -95,12 +96,13 @@ public class TobiraEndpoint {
   // adding new JSON fields is a non-breaking change. You should also consider whether Tobira needs
   // to resynchronize, i.e. to get new data.
   private static final int VERSION_MAJOR = 1;
-  private static final int VERSION_MINOR = 5;
+  private static final int VERSION_MINOR = 6;
   private static final String VERSION = VERSION_MAJOR + "." + VERSION_MINOR;
 
   private SearchService searchService;
   private SeriesService seriesService;
   private AuthorizationService authorizationService;
+  private PlaylistService playlistService;
   private Workspace workspace;
 
   @Activate
@@ -121,6 +123,11 @@ public class TobiraEndpoint {
   @Reference
   public void setAuthorizationService(AuthorizationService service) {
     this.authorizationService = service;
+  }
+
+  @Reference
+  public void setPlaylistService(PlaylistService service) {
+    this.playlistService = service;
   }
 
   @Reference
@@ -199,7 +206,7 @@ public class TobiraEndpoint {
       var json = Harvest.harvest(
           preferredAmount,
           new Date(since),
-          searchService, seriesService, authorizationService, workspace);
+          searchService, seriesService, authorizationService, playlistService, workspace);
 
       // TODO: encoding
       return Response.ok(json.toJson()).build();


### PR DESCRIPTION
Adds Playlists to Tobira's harvest API such that Tobira can sync those and store them in its own DB.

CC @Arnei as you implemented playlists and might want to have a look (especially the second commit).

Can be reviewed commit by commit. 

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
