### PR TITLE
Allow karma to use Chromium browser

### DIFF
--- a/docs/guides/developer/docs/develop/setup-opencast-for-develop.md
+++ b/docs/guides/developer/docs/develop/setup-opencast-for-develop.md
@@ -49,7 +49,7 @@ Required:
     ffmpeg >= 3.2.4
     maven >= 3.6
     python
-    firefox/chrome
+    firefox/chrome/chromium
     unzip
     gcc-c++
     tar

--- a/modules/admin-ui-frontend/test/karma.conf.js
+++ b/modules/admin-ui-frontend/test/karma.conf.js
@@ -73,7 +73,7 @@ module.exports = function (config) {
             preferHeadless: true,
             // limit the list of browsers used by karma
             postDetection: (browsers) => {
-                const allowed = ['Chrome'];
+                const allowed = ['Chrome', 'Chromium'];
                 // Karma can't start FirefoxHeadless on Macs
                 // See https://github.com/opencast/opencast/issues/3894
                 if (os.platform() !== 'darwin') {


### PR DESCRIPTION
To build the admin ui frontend karma requires access to a suitable browser. Under Ubuntu 22.04 Firefox snap does not run in headless mode, so the alternative "Chrome" browser Chromium should be a valid browser to use.
