### PR TITLE
Change Playlist Update behaviour

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -38,6 +38,7 @@
     <bundle>mvn:com.entwinemedia.common/functional/${functional.version}</bundle>
     <bundle>mvn:com.fasterxml.jackson.core/jackson-core/${jackson.version}</bundle>
     <bundle>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/${jackson.version}</bundle>
+    <bundle>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-xml/${jackson.version}</bundle>
     <bundle>mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${jackson.version}</bundle>
     <bundle>mvn:org.yaml/snakeyaml/2.2</bundle>
     <bundle>mvn:com.google.guava/guava/${guava.version}</bundle>

--- a/docs/guides/developer/docs/architecture/api/playlists-api.md
+++ b/docs/guides/developer/docs/architecture/api/playlists-api.md
@@ -237,35 +237,3 @@ __Response__
 `200 (OK)`: The removed playlist.
 `403 (FORBIDDEN)`: The user doesn't have the rights to make this request.  
 `404 (NOT FOUND)`: The specified playlist does not exist.
-
-
-### POST /api/playlists/{id}/entries
-
-Updates the entries of a playlist.
-
-__Response__
-
-`200 (OK)`: The updated playlist.
-`400 (BAD REQUEST)`: The request is invalid or inconsistent.  
-`403 (FORBIDDEN)`: The user doesn't have the rights to make this request.  
-`404 (NOT FOUND)`: The specified playlist does not exist.
-
-| Field             | Type                                            | Description             |
-|-------------------|-------------------------------------------------|-------------------------|
-| `playlistEntries` | [`List<PlaylistEntry>`](types.md#PlaylistEntry) | Playlist in JSON format |
-
-
-__Example__
-
-```json
-[
-    {
-        "contentId": "ID-about-opencast",
-        "type": "EVENT"
-    },
-    {
-        "contentId": "ID-3d-print",
-        "type": "EVENT"
-    }
-]
-```

--- a/modules/external-api/pom.xml
+++ b/modules/external-api/pom.xml
@@ -195,11 +195,6 @@
       <artifactId>opencast-playlists</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-      <version>${jackson.version}</version>
-    </dependency>
     <!-- Testing -->
     <dependency>
       <groupId>io.rest-assured</groupId>

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/PlaylistsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/PlaylistsEndpoint.java
@@ -29,7 +29,6 @@ import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
-import static org.opencastproject.playlists.PlaylistRestService.SAMPLE_PLAYLIST_ENTRIES_JSON;
 import static org.opencastproject.playlists.PlaylistRestService.SAMPLE_PLAYLIST_JSON;
 import static org.opencastproject.util.DateTimeSupport.toUTC;
 import static org.opencastproject.util.RestUtil.getEndpointUrl;
@@ -45,7 +44,6 @@ import org.opencastproject.playlists.PlaylistEntry;
 import org.opencastproject.playlists.PlaylistRestService;
 import org.opencastproject.playlists.PlaylistService;
 import org.opencastproject.playlists.serialization.JaxbPlaylist;
-import org.opencastproject.playlists.serialization.JaxbPlaylistEntry;
 import org.opencastproject.rest.RestConstants;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.systems.OpencastConstants;
@@ -61,7 +59,6 @@ import org.opencastproject.util.requests.SortCriterion;
 
 import com.entwinemedia.fn.data.json.Field;
 import com.entwinemedia.fn.data.json.JValue;
-import com.fasterxml.jackson.core.JsonProcessingException;
 
 import org.json.simple.parser.ParseException;
 import org.osgi.service.component.ComponentContext;
@@ -326,46 +323,6 @@ public class PlaylistsEndpoint {
       return ApiResponses.notFound("Cannot find playlist instance with id '%s'.", id);
     } catch (UnauthorizedException e) {
       return Response.status(Response.Status.FORBIDDEN).build();
-    }
-  }
-
-  @POST
-  @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_11_0 })
-  @Path("{id}/entries")
-  @RestQuery(
-      name = "updateEntries",
-      description = "Updates the entries of a playlist",
-      returnDescription = "The updated playlist.",
-      pathParameters = {
-          @RestParameter(name = "id", isRequired = true, description = "Playlist identifier", type = STRING),
-      },
-      restParameters = {
-          @RestParameter(name = "playlistEntries", isRequired = false, description = "Playlist entries in JSON format",
-              type = TEXT, jaxbClass = JaxbPlaylistEntry[].class, defaultValue = SAMPLE_PLAYLIST_ENTRIES_JSON)
-      },
-      responses = {
-          @RestResponse(responseCode = SC_OK, description = "Playlist updated."),
-          @RestResponse(responseCode = SC_NOT_FOUND, description = "No playlist with that identifier exists."),
-          @RestResponse(responseCode = SC_UNAUTHORIZED, description = "Not authorized to perform this action"),
-          @RestResponse(description = "The request is invalid or inconsistent.", responseCode = HttpServletResponse.SC_BAD_REQUEST),
-      })
-  public Response updateEntriesAsJson(
-      @HeaderParam("Accept") String acceptHeader,
-      @PathParam("id") String playlistId,
-      @FormParam("playlistEntries") String entriesText) {
-    try {
-      // Map JSON to JPA
-      List<PlaylistEntry> playlistEntries = restService.parseJsonToPlaylistEntries(entriesText);
-
-      // Persist
-      Playlist playlist = service.updateEntries(playlistId, playlistEntries);
-      return ApiResponses.Json.ok(acceptHeader, playlistToJson(playlist));
-    } catch (UnauthorizedException e) {
-      return Response.status(Response.Status.FORBIDDEN).build();
-    } catch (JsonProcessingException e) {
-      return Response.status(Response.Status.BAD_REQUEST).build();
-    } catch (NotFoundException e) {
-      return ApiResponses.notFound("Cannot find playlist instance with id '%s'.", playlistId);
     }
   }
 

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/PlaylistsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/PlaylistsEndpoint.java
@@ -291,16 +291,11 @@ public class PlaylistsEndpoint {
       @PathParam("id") String id,
       @FormParam("playlist") String playlistText) {
     try {
-      // Map JSON to JPA
-      Playlist playlist = restService.parseJsonToPlaylist(playlistText);
-      playlist.setId(id);
-
-      // Persist
-      playlist = service.update(playlist);
+      Playlist playlist = service.updateWithJson(id, playlistText);
       return ApiResponses.Json.ok(acceptHeader, playlistToJson(playlist));
     } catch (UnauthorizedException e) {
       return Response.status(Response.Status.FORBIDDEN).build();
-    } catch (ParseException | IOException | IllegalArgumentException e) {
+    } catch (IOException | IllegalArgumentException e) {
       return Response.status(Response.Status.BAD_REQUEST).build();
     }
   }

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/PlaylistsEndpointTest.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/PlaylistsEndpointTest.java
@@ -30,7 +30,6 @@ import static org.junit.Assert.assertEquals;
 import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.playlists.Playlist;
-import org.opencastproject.playlists.PlaylistEntry;
 import org.opencastproject.test.rest.RestServiceTestEnv;
 
 import org.json.simple.JSONArray;
@@ -39,8 +38,6 @@ import org.json.simple.parser.JSONParser;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import java.util.ArrayList;
 
 /** Unit tests for {@link PlaylistsEndpoint} */
 public class PlaylistsEndpointTest {
@@ -185,16 +182,5 @@ public class PlaylistsEndpointTest {
         .expect()
         .statusCode(SC_FORBIDDEN).when()
         .delete(env.host("/{id}"));
-  }
-
-  @Test
-  public void testUpdateEntriesPlaylist() throws Exception {
-    String response = given()
-        .pathParam("id", PLAYLIST_ID)
-        .formParam("playlistEntries", new ArrayList<PlaylistEntry>())
-        .expect()
-        .statusCode(SC_OK).when()
-        .post(env.host("/{id}/entries"))
-        .asString();
   }
 }

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/TestPlaylistsEndpoint.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/TestPlaylistsEndpoint.java
@@ -36,7 +36,6 @@ import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.requests.SortCriterion;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.Lists;
 
 import org.easymock.EasyMock;
@@ -113,8 +112,6 @@ public class TestPlaylistsEndpoint extends PlaylistsEndpoint {
     PlaylistRestService restService = createNiceMock(PlaylistRestService.class);
     expect(restService.parseJsonToPlaylist(invalidPlaylistJson)).andThrow(new ParseException(0));
     expect(restService.parseJsonToPlaylist(anyObject(String.class))).andReturn(playlist);
-    expect(restService.parseJsonToPlaylistEntries(invalidPlaylistJson)).andThrow(new JsonProcessingException("") { });
-    expect(restService.parseJsonToPlaylistEntries(anyObject(String.class))).andReturn(Lists.newArrayList(entry1, entry2));
     replay(restService);
 
     setPlaylistService(service);

--- a/modules/playlists/pom.xml
+++ b/modules/playlists/pom.xml
@@ -63,6 +63,11 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-xml</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-search-service-api</artifactId>
       <version>${project.version}</version>
@@ -119,7 +124,6 @@
       <artifactId>h2</artifactId>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
   <build>
     <plugins>

--- a/modules/playlists/src/main/java/org/opencastproject/playlists/PlaylistRestService.java
+++ b/modules/playlists/src/main/java/org/opencastproject/playlists/PlaylistRestService.java
@@ -467,12 +467,7 @@ public class PlaylistRestService {
   )
           throws UnauthorizedException {
     try {
-      // Map JSON to JPA
-      Playlist playlist = parseJsonToPlaylist(playlistText);
-      playlist.setId(id);
-
-      // Persist
-      playlist = service.update(playlist);
+      Playlist playlist = service.updateWithJson(id, playlistText);
       return Response.ok().entity(new JaxbPlaylist(playlist)).build();
     } catch (Exception e) {
       return Response.serverError().build();

--- a/modules/playlists/src/main/java/org/opencastproject/playlists/PlaylistService.java
+++ b/modules/playlists/src/main/java/org/opencastproject/playlists/PlaylistService.java
@@ -42,6 +42,10 @@ import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.requests.SortCriterion;
 
 import com.entwinemedia.fn.data.Opt;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
@@ -231,6 +235,34 @@ public class PlaylistService {
       return playlist;
     } catch (PlaylistDatabaseException e) {
       throw new IllegalStateException("Could not update playlist from database with id ");
+    }
+  }
+
+  /**
+   * Overwrite an existing playlist with a playlist in JSON format.
+   * Only fields present in the JSON will be overwritten! Conversely, if a field is not present in the JSON,
+   * the field in the existing playlist will not change.
+   * @param id Identifier of the playlist to update.
+   * @param json JSON containing data to update the playlist with.
+   * @return The updated {@link Playlist}
+   */
+  public Playlist updateWithJson(String id, String json) throws JsonProcessingException, UnauthorizedException {
+    try {
+      Playlist existingPlaylist = persistence.getPlaylist(id);
+      if (!checkPermission(existingPlaylist, Permissions.Action.WRITE)) {
+        throw new UnauthorizedException("User does not have write permissions");
+      }
+
+      JaxbAnnotationModule module = new JaxbAnnotationModule();
+      ObjectMapper objectMapper = new ObjectMapper();
+      objectMapper.registerModule(module);
+
+      ObjectReader updater = objectMapper.readerForUpdating(new JaxbPlaylist(existingPlaylist));
+      JaxbPlaylist merged = updater.readValue(json);
+
+      return update(merged.toPlaylist());
+    } catch (NotFoundException | PlaylistDatabaseException e) {
+      throw new IllegalStateException("Could not get playlist from database with id " + id);
     }
   }
 

--- a/modules/playlists/src/main/java/org/opencastproject/playlists/PlaylistService.java
+++ b/modules/playlists/src/main/java/org/opencastproject/playlists/PlaylistService.java
@@ -43,6 +43,7 @@ import org.opencastproject.util.requests.SortCriterion;
 
 import com.entwinemedia.fn.data.Opt;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
@@ -256,6 +257,7 @@ public class PlaylistService {
       JaxbAnnotationModule module = new JaxbAnnotationModule();
       ObjectMapper objectMapper = new ObjectMapper();
       objectMapper.registerModule(module);
+      objectMapper.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
 
       ObjectReader updater = objectMapper.readerForUpdating(new JaxbPlaylist(existingPlaylist));
       JaxbPlaylist merged = updater.readValue(json);


### PR DESCRIPTION
Resolves #5730.

Changes how playlist endpoints update playlists by adding a new method to the playlist service. Instead of removing fields from a playlist if they were not present, this change leaves them intact. Now, in order to remove a field from a playlist, the field needs to be explicitely set to "null", e.g. `"description": null`. This should make updating playlists easier and more future proof.

Warning, this does not work for entries in arrays! If you wish to update a single entry in an array, you still have to send the whole array. If you only send the entry you wish to update, all other entries will be removed.