### PR TITLE
Paella: Fix error displayed before authenticating user.

### DIFF
--- a/modules/engage-paella-player-7/src/js/PaellaOpencast.js
+++ b/modules/engage-paella-player-7/src/js/PaellaOpencast.js
@@ -78,10 +78,6 @@ function myWebsiteCheckConsentFunction(type) {
   return consent_level[type] || false;
 }
 
-function sleep(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
 const initParams = {
   customPluginContext: [
     require.context('../plugins', true, /\.js/),
@@ -106,6 +102,9 @@ const initParams = {
   },
 
   loadVideoManifest: async function (url, config, player) {
+    const stopLoadVideoManifest = () => {
+      return new Promise(() => {});
+    };
     // check cookie consent (if enabled)
     const cookieConsent = config?.opencast?.cookieConsent?.enable ?? true;
     const cookieConsentConfig = config?.opencast?.cookieConsent?.config ?? {
@@ -147,9 +146,9 @@ const initParams = {
         player.log.info('Video not found and user is not authenticated. Try to log in.');
         location.href = getUrlFromOpencastPaella('auth.html?redirect=' + encodeURIComponent(window.location.href));
         // We need to interrupt the player loading to redirect the user to the auth page.
-        await sleep(100);
+        await stopLoadVideoManifest();
         // This Error should not happen, as the user is redirected to the auth page.
-        throw Error('Video not found and user is not authenticated. Try to log in.');
+        throw Error('Video not found and user is not authenticated. Log in and try again.');
       }
       else {
         // TODO: the video does not exist or the user can't see it

--- a/modules/engage-paella-player-7/src/js/PaellaOpencast.js
+++ b/modules/engage-paella-player-7/src/js/PaellaOpencast.js
@@ -102,8 +102,13 @@ const initParams = {
   },
 
   loadVideoManifest: async function (url, config, player) {
-    const stopLoadVideoManifest = () => {
-      return new Promise(() => {});
+    const redirectToAuthPage = async () => {
+      location.href = getUrlFromOpencastPaella('auth.html?redirect=' + encodeURIComponent(window.location.href));
+      // Create a loader spinner.
+      player._loader = new player.initParams.Loader(player);
+      player._loader.create();
+      // We need to interrupt the player loading to redirect the user to the auth page.
+      await new Promise(() => {});
     };
     // check cookie consent (if enabled)
     const cookieConsent = config?.opencast?.cookieConsent?.enable ?? true;
@@ -144,9 +149,7 @@ const initParams = {
 
       if (!me.roles.includes('ROLE_USER')) {
         player.log.info('Video not found and user is not authenticated. Try to log in.');
-        location.href = getUrlFromOpencastPaella('auth.html?redirect=' + encodeURIComponent(window.location.href));
-        // We need to interrupt the player loading to redirect the user to the auth page.
-        await stopLoadVideoManifest();
+        await redirectToAuthPage();
         // This Error should not happen, as the user is redirected to the auth page.
         throw Error('Video not found and user is not authenticated. Log in and try again.');
       }

--- a/modules/engage-paella-player-7/src/js/PaellaOpencast.js
+++ b/modules/engage-paella-player-7/src/js/PaellaOpencast.js
@@ -78,6 +78,10 @@ function myWebsiteCheckConsentFunction(type) {
   return consent_level[type] || false;
 }
 
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 const initParams = {
   customPluginContext: [
     require.context('../plugins', true, /\.js/),
@@ -142,6 +146,10 @@ const initParams = {
       if (!me.roles.includes('ROLE_USER')) {
         player.log.info('Video not found and user is not authenticated. Try to log in.');
         location.href = getUrlFromOpencastPaella('auth.html?redirect=' + encodeURIComponent(window.location.href));
+        // We need to interrupt the player loading to redirect the user to the auth page.
+        await sleep(100);
+        // This Error should not happen, as the user is redirected to the auth page.
+        throw Error('Video not found and user is not authenticated. Try to log in.');
       }
       else {
         // TODO: the video does not exist or the user can't see it


### PR DESCRIPTION
This Fix a bug in the loading process when the player tries lo authenticate the user. 
Before redirecting to the login page, an error message is briefly displayed.

To test, try to open a video that does not exists without being authenticated. Ex: https://develop.opencast.org/paella7/ui/watch.html?id=no-valid-video

### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
