### PR TITLE
`download-maven-plugin` nitpicks

### DIFF
--- a/modules/admin-ui-interface/pom.xml
+++ b/modules/admin-ui-interface/pom.xml
@@ -31,7 +31,6 @@
                             <url>${interface.url}</url>
                             <sha256>${interface.sha256}</sha256>
                             <unpack>true</unpack>
-                            <checkSignature>true</checkSignature>
                             <outputDirectory>target/classes/admin-ui/</outputDirectory>
                         </configuration>
                     </execution>

--- a/modules/editor/pom.xml
+++ b/modules/editor/pom.xml
@@ -31,7 +31,6 @@
               <url>${editor.url}</url>
               <sha256>${editor.sha256}</sha256>
               <unpack>true</unpack>
-              <checkSignature>true</checkSignature>
               <outputDirectory>target/classes/editor/</outputDirectory>
             </configuration>
           </execution>

--- a/modules/studio/pom.xml
+++ b/modules/studio/pom.xml
@@ -31,7 +31,6 @@
               <url>${opencast.studio.url}</url>
               <sha256>${opencast.studio.sha256}</sha256>
               <unpack>true</unpack>
-              <checkSignature>true</checkSignature>
               <outputDirectory>${project.build.directory}/classes/opencast-studio/</outputDirectory>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -621,6 +621,9 @@
           <groupId>com.googlecode.maven-download-plugin</groupId>
           <artifactId>download-maven-plugin</artifactId>
           <version>1.6.8</version>
+          <configuration>
+            <checkSignature>true</checkSignature>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -622,7 +622,7 @@
           <artifactId>download-maven-plugin</artifactId>
           <version>1.6.8</version>
           <configuration>
-            <checkSignature>true</checkSignature>
+            <alwaysVerifyChecksum>true</alwaysVerifyChecksum>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Just some Maven cleanup to shut up some warnings and avoid future copypasta mistakes.

Targeting the oldest branch people (read: me) still develop in, but this should be fine, since it should literally not change anything.