### PR TITLE
Skip the OBR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -569,6 +569,7 @@
           <version>5.1.9</version>
           <inherited>true</inherited>
           <configuration>
+            <obrRepository>NONE</obrRepository>
             <instructions>
               <Bundle-Category>opencastproject</Bundle-Category>
               <Bundle-DocURL>https://opencast.org/</Bundle-DocURL>


### PR DESCRIPTION
The `maven-bundle-plugin` installs the resulting bundles to a/the so called OBR, but we don't use that, so this just wastes build time.

On my M1 MacBook Air this saves roughly **2 minutes**!