### PR TITLE
Fix deleting user references from the admin UI

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/UsersEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/UsersEndpoint.java
@@ -163,6 +163,15 @@ public class UsersEndpoint {
   }
 
   /**
+   * @param jpaUserReferenceProvider
+   *          the user provider to set
+   */
+  @Reference
+  public void setJpaUserReferenceProvider(JpaUserReferenceProvider jpaUserReferenceProvider) {
+    this.jpaUserReferenceProvider = jpaUserReferenceProvider;
+  }
+
+  /**
    * @param jpaUserAndRoleProvider
    *          the user provider to set
    */
@@ -439,7 +448,7 @@ public class UsersEndpoint {
 
     try {
       try {
-        jpaUserAndRoleProvider.deleteUser(username, organization.getId());
+        jpaUserReferenceProvider.deleteUser(username, organization.getId());
       } catch (NotFoundException e) {
         userReferenceNotFound = true;
       }


### PR DESCRIPTION
Fixes #5753, where a `matterhoron-reference` user could not be deleted, presumably because it wasn't found.

This was broken by #5062, and looks like a classic merge conflict resolution mistake to me. The result is that we look up the user we want to delete in the user and roles provider twice, and ignore the user reference provider, which happens to be `null` anyway, since it is never bound in the first place.