### PR TITLE
Add slide text and segments to Tobira harvest API

### DIFF
--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Item.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Item.java
@@ -165,6 +165,7 @@ class Item {
           }))),
           Jsons.p("captions", Jsons.arr(captions)),
           Jsons.p("slideText", slideText.map(t -> t.toString()).orElse(null)),
+          Jsons.p("segments", Jsons.arr(findSegments(mp))),
           Jsons.p("updated", event.getModified().getTime())
       );
     }
@@ -326,6 +327,17 @@ class Item {
         .map(a -> a.getURI().toString())
         .findFirst()
         .orElse(null);
+  }
+
+  private static List<Jsons.Val> findSegments(MediaPackage mp) {
+    return Arrays.stream(mp.getAttachments())
+      .filter(a -> a.getFlavor().getSubtype().equals("segment+preview"))
+      .map(s -> Jsons.obj(
+          Jsons.p("uri", s.toString()),
+          Jsons.p("startTime", s.getReference().getProperty("time"))
+        )
+      )
+      .collect(Collectors.toCollection(ArrayList::new));
   }
 
   private static Jsons.Val findTimelinePreview(MediaPackage mp) {

--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Item.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Item.java
@@ -125,6 +125,12 @@ class Item {
 
       final var captions = findCaptions(mp);
 
+      // Get the generated slide text.
+      final var slideText = Arrays.stream(mp.getElements())
+          .filter(mpe -> mpe.getFlavor().eq("mpeg-7/text"))
+          .map(element -> element.getURI())
+          .findFirst();
+
       // Obtain duration from tracks, as that's usually more accurate (stores information from
       // inspect operations). Fall back to `getDcExtent`.
       final var duration = Arrays.stream(mp.getTracks())
@@ -158,6 +164,7 @@ class Item {
               "created", "creator", "title", "extent", "isPartOf", "description", "identifier",
           }))),
           Jsons.p("captions", Jsons.arr(captions)),
+          Jsons.p("slideText", slideText.map(t -> t.toString()).orElse(null)),
           Jsons.p("updated", event.getModified().getTime())
       );
     }

--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/TobiraEndpoint.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/TobiraEndpoint.java
@@ -81,7 +81,7 @@ public class TobiraEndpoint {
 
   // Versioning the Tobira API:
   //
-  // Since both Tobira and this API are changing over time, we need some machanism for ensuring they
+  // Since both Tobira and this API are changing over time, we need some mechanism for ensuring they
   // are compatible. We don't want to enforce a 1:1 thing, where a particular Tobira needs one
   // exact API as that makes the update process harder (especially once this module is included in
   // the community version). So instead we have some semver-like versioning here. Increase the
@@ -95,7 +95,7 @@ public class TobiraEndpoint {
   // adding new JSON fields is a non-breaking change. You should also consider whether Tobira needs
   // to resynchronize, i.e. to get new data.
   private static final int VERSION_MAJOR = 1;
-  private static final int VERSION_MINOR = 5;
+  private static final int VERSION_MINOR = 6;
   private static final String VERSION = VERSION_MAJOR + "." + VERSION_MINOR;
 
   private SearchService searchService;


### PR DESCRIPTION
See commits. With this PR, the generated slide text is exposed so we can use that in Tobira's search index. I'm not super sure if the filter I built for this could let through false positives or negatives, though in testing this didn't seem to be the case. Please let me know if you think this might be an issue, and/or have any suggestions how this could be solidified.

Furthermore, the slide segments with their respective starting time is passed in order to be used for Paella's slide plugin on the Tobira side.

Related Tobira issues: https://github.com/elan-ev/tobira/issues/368, https://github.com/elan-ev/tobira/issues/1065

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
