### PR TITLE
Move multiple series title check logic

### DIFF
--- a/modules/list-providers-service/src/main/java/org/opencastproject/list/impl/ListProvidersServiceImpl.java
+++ b/modules/list-providers-service/src/main/java/org/opencastproject/list/impl/ListProvidersServiceImpl.java
@@ -36,7 +36,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -158,24 +157,6 @@ public class ListProvidersServiceImpl implements ListProvidersService {
           throws ListProviderException {
     ResourceListProvider provider = getProvider(listName);
     Map<String, String> list = provider.getList(listName, query);
-    if ("SERIES".equals(listName)) {
-      for (Map.Entry<String,String> entry : list.entrySet()) {
-        int repeated = Collections.frequency(list.values(), entry.getValue());
-        if (repeated > 1) {
-          String newSeriesName = null;
-          //If a series name is repeated, will add the first 7 characters of the series ID to the display name on the
-          //admin-ui
-          try {
-            newSeriesName = entry.getValue() + " " + "(ID: " + entry.getKey().substring(0, 7) + "...)";
-          } catch (StringIndexOutOfBoundsException e) {
-            newSeriesName = entry.getValue() + " " + "(ID: " + entry.getKey() + ")";
-          }
-          logger.debug(String.format("Repeated series title \"%s\" found, changing to \"%s\" for admin-ui display",
-              entry.getValue(), newSeriesName));
-          list.put(entry.getKey(), newSeriesName);
-        }
-      }
-    }
     return inverseValueKey ? ListProviderUtil.invertMap(list) : list;
   }
 


### PR DESCRIPTION
This moves the logic to check if the series list provider returns multiple identical titles to the series list provider.

Furthermore, only if the ID gets cut the ellipsis is added.

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
