### PR TITLE
Add SERIES.WRITE_ONLY list provider

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/SeriesListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/SeriesListProvider.java
@@ -75,8 +75,9 @@ public class SeriesListProvider implements ResourceListProvider {
   public static final String LANGUAGE = PROVIDER_PREFIX + ".LANGUAGE";
   public static final String ORGANIZERS = PROVIDER_PREFIX + ".ORGANIZERS";
   public static final String LICENSE = PROVIDER_PREFIX + ".LICENSE";
+  public static final String SERIES_WRITE_ONLY = PROVIDER_PREFIX + ".WRITE_ONLY";
 
-  private static final String[] NAMES = { PROVIDER_PREFIX, CONTRIBUTORS, ORGANIZERS, TITLE_EXTENDED };
+  private static final String[] NAMES = { PROVIDER_PREFIX, CONTRIBUTORS, ORGANIZERS, TITLE_EXTENDED, SERIES_WRITE_ONLY };
 
   /** The search index. */
   private ElasticsearchIndex searchIndex;
@@ -131,6 +132,9 @@ public class SeriesListProvider implements ResourceListProvider {
         seriesQuery.sortByTitle(SortCriterion.Order.Ascending);
         seriesQuery.sortByCreatedDateTime(SortCriterion.Order.Descending);
         seriesQuery.sortByOrganizers(SortCriterion.Order.Ascending);
+        if (SERIES_WRITE_ONLY.equals(listName)) {
+          seriesQuery.withAction(Permissions.Action.WRITE);
+        }
         SearchResult<Series> searchResult = searchIndex.getByQuery(seriesQuery);
         Calendar calendar = Calendar.getInstance();
         for (SearchResultItem<Series> item : searchResult.getItems()) {


### PR DESCRIPTION
This adds a version of the series list provider that returns only series with `write` permission.

The alternative is to make this the default behavior.

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
