### PR TITLE
Paella:  Prevent video download. Disable context menu.

### DIFF
--- a/etc/ui-config/mh_default_org/paella7/config.json
+++ b/etc/ui-config/mh_default_org/paella7/config.json
@@ -70,7 +70,7 @@
             "presentation/player+preview"
         ],
         "theme": "custom_theme",
-        "preventVideoDownload": true
+        "preventVideoDownload": false
     },
 
     "cookieConsent": [

--- a/etc/ui-config/mh_default_org/paella7/config.json
+++ b/etc/ui-config/mh_default_org/paella7/config.json
@@ -69,7 +69,8 @@
             "presenter/player+preview",
             "presentation/player+preview"
         ],
-        "theme": "custom_theme"
+        "theme": "custom_theme",
+        "preventVideoDownload": true
     },
 
     "cookieConsent": [

--- a/modules/engage-paella-player-7/src/js/PaellaOpencast.js
+++ b/modules/engage-paella-player-7/src/js/PaellaOpencast.js
@@ -230,6 +230,15 @@ export class PaellaOpencast extends Paella {
     }
 
     bindEvent(paella, Events.PLAYER_LOADED, async () => {
+      // Prevent video download: Disable context menu
+      if (paella?.config?.opencast?.preventVideoDownload == true) {
+        paella.videoContainer.streamProvider.players.forEach(player => {
+          player.video?.addEventListener('contextmenu', (e) => {
+            e.preventDefault();
+          });
+        });
+      }
+
       // Enable trimming
       // Retrieve video duration in case a default trim end time is needed
       const videoDuration = paella.videoManifest?.metadata?.duration;


### PR DESCRIPTION
There is no way to prevent the user from downloading an mp4 video, as this is a feature that is natively implemented by the browser, but we can make it a bit more complicated by preventing the context menu of the video from being shown. 

This PR disable the context menu (configurable in `config.json` file)

### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
