### PR TITLE
Use current LTS version of Node.js

### DIFF
--- a/.github/workflows/auto-update-npm-libraries.yml
+++ b/.github/workflows/auto-update-npm-libraries.yml
@@ -24,7 +24,7 @@ jobs:
       - name: use node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: update engage-ui test libraries
         working-directory: modules/engage-ui

--- a/.github/workflows/test-admin-interface-frontend.yml
+++ b/.github/workflows/test-admin-interface-frontend.yml
@@ -24,7 +24,7 @@ jobs:
     - name: use node.js
       uses: actions/setup-node@v4
       with:
-        node-version: 16.x
+        node-version: 20.x
 
     # Ubuntu 22.04 lies wrt to firefox in its repo
     # the 'firefox' package is just a script which tells you to use snap

--- a/.github/workflows/test-paella-7.yml
+++ b/.github/workflows/test-paella-7.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: 16
+        node-version: 20
     - name: Install dependencies
       run: npm ci
     - name: Install Playwright Browsers

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <json-simple.version>1.1.1</json-simple.version>
     <junit5.version>5.10.2</junit5.version>
     <karaf.version>4.4.4</karaf.version>
-    <node.version>v18.16.0</node.version>
+    <node.version>v20.12.2</node.version>
     <osgi.core.version>8.0.0</osgi.core.version>
     <osgi.annotation.version>8.1.0</osgi.annotation.version>
     <org.osgi.service.component.version>1.5.1</org.osgi.service.component.version>


### PR DESCRIPTION
This patch updates all parts of Opencast to use the current LTS version of Node.js during the build process. Previously, some tasks even still used the no longer supported Node 16, resulting in warnings like this:

```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'eslint@9.0.0',
npm WARN EBADENGINE   required: { node: '^18.18.0 || ^20.9.0 || >=21.1.0' },
npm WARN EBADENGINE   current: { node: 'v16.20.2', npm: '8.19.4' }
npm WARN EBADENGINE }
```

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
