### PR TITLE
Speed up starting and stopping the OpenSearch dev container

### DIFF
--- a/docs/scripts/devel-dependency-containers/docker-compose-all-sql.yml
+++ b/docs/scripts/devel-dependency-containers/docker-compose-all-sql.yml
@@ -3,6 +3,7 @@ services:
   elasticsearch:
     container_name: opencast-opensearch
     image: opensearchproject/opensearch:1
+    init: true
     ports:
       - 127.0.0.1:9200:9200
       - 127.0.0.1:9300:9300

--- a/docs/scripts/devel-dependency-containers/docker-compose-mariadb.yml
+++ b/docs/scripts/devel-dependency-containers/docker-compose-mariadb.yml
@@ -3,6 +3,7 @@ services:
   elasticsearch:
     container_name: opencast-opensearch
     image: opensearchproject/opensearch:1
+    init: true
     ports:
       - 127.0.0.1:9200:9200
       - 127.0.0.1:9300:9300

--- a/docs/scripts/devel-dependency-containers/docker-compose-postgresql.yml
+++ b/docs/scripts/devel-dependency-containers/docker-compose-postgresql.yml
@@ -3,6 +3,7 @@ services:
   elasticsearch:
     container_name: opencast-opensearch
     image: opensearchproject/opensearch:1
+    init: true
     ports:
       - 127.0.0.1:9200:9200
       - 127.0.0.1:9300:9300

--- a/docs/scripts/devel-dependency-containers/docker-compose.yml
+++ b/docs/scripts/devel-dependency-containers/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   elasticsearch:
     container_name: opencast-opensearch
     image: opensearchproject/opensearch:1
+    init: true
     ports:
       - 127.0.0.1:9200:9200
       - 127.0.0.1:9300:9300


### PR DESCRIPTION
This puts the process under the control of a process manager (`tini` specifically) so it can handle signals better.

cf. https://github.com/opensearch-project/opensearch-build/issues/3229#issuecomment-2080402340