### PR TITLE
Opencast-Paella usertracking error reading currentTime when video container is not ready

### DIFF
--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.opencast.userTrackingDataPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.opencast.userTrackingDataPlugin.js
@@ -39,8 +39,13 @@ export default class OpencastUserTrackingDataPlugin extends DataPlugin {
   }
 
   async write(context, { id }, data) {
-    const currentTime = await this.player.videoContainer.currentTime();
-    const playing = !(await this.player.videoContainer.paused());
+    let currentTime = 0;
+    let playing = false;
+    // If player is ready, it's safe to request it's current time
+    if (this.player.ready) {
+      currentTime = await this.player.videoContainer.currentTime();
+      playing = !(await this.player.videoContainer.paused());
+    }
     this.player.log.debug(`Logging event for video id ${ id } at time: ${ currentTime }`);
 
     const opencastLog = {


### PR DESCRIPTION
### Your pull request should…

Duplicate: Load a dual HLS video event
EXPECTED: Usertracking does not throw a null error attempting to read the video container's currentTime during load
ACTUAL: The first hls video frequently causes an Events.VIDEO_QUALITY_CHANGED event prior to the load of the second hls video and before and the video container has fully initialized. That early Events.VIDEO_QUALITY_CHANGED event causes the usertracking to try to get the current time from the video container before the video container is initialized which causes a null error to be thrown.

This pull adds protection in the usertracking plugin to prevent it from getting currentTime from the video container before the video container is initialized. This patch has been in production at our site for many months.