### PR TITLE
Turn old admin interface into plugin

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -150,7 +150,6 @@
     <feature>opencast-services-processing-light-load</feature>
 
     <bundle start-level="82">mvn:org.opencastproject/opencast-admin-ui/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-admin-ui-frontend/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-admin-ui-interface/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-analyze-mediapackage-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-animate-workflowoperation/${project.version}</bundle>
@@ -259,7 +258,6 @@
     <feature>opencast-core</feature>
 
     <bundle start-level="82">mvn:org.opencastproject/opencast-admin-ui/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-admin-ui-frontend/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-admin-ui-interface/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-animate-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-analyze-mediapackage-workflowoperation/${project.version}</bundle>
@@ -391,7 +389,6 @@
     <feature>opencast-core</feature>
 
     <bundle start-level="82">mvn:org.opencastproject/opencast-admin-ui/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-admin-ui-frontend/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-admin-ui-interface/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-analyze-mediapackage-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-animate-api/${project.version}</bundle>
@@ -733,6 +730,15 @@
       <condition>opencast-adminpresentation</condition>
     </conditional>
     <bundle start-level="82">mvn:org.opencastproject/opencast-engage-paella-player/${project.version}</bundle>
+  </feature>
+
+  <feature name="opencast-plugin-admin-ng" version="${project.version}">
+    <conditional>
+      <condition>opencast-allinone</condition>
+      <condition>opencast-admin</condition>
+      <condition>opencast-adminpresentation</condition>
+    </conditional>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-admin-ui-frontend/${project.version}</bundle>
   </feature>
 
   <feature name="opencast-pluginmanager" version="${project.version}">

--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -121,6 +121,7 @@
             <installedFeatures>
               <feature>opencast-security-cas</feature>
               <feature>opencast-security-jwt</feature>
+              <feature>opencast-plugin-admin-ng</feature>
               <feature>opencast-plugin-legacy-annotation</feature>
               <feature>opencast-plugin-paella-player-6</feature>
               <feature>opencast-plugin-transcription-services</feature>

--- a/docs/guides/admin/docs/releasenotes/admin-ng-plugin.txt
+++ b/docs/guides/admin/docs/releasenotes/admin-ng-plugin.txt
@@ -1,0 +1,1 @@
+The old admin interface is now a plugin and needs to be specifically enabled before it can be used.

--- a/etc/org.opencastproject.plugin.impl.PluginManagerImpl.cfg
+++ b/etc/org.opencastproject.plugin.impl.PluginManagerImpl.cfg
@@ -6,6 +6,7 @@
 ##
 
 # List of available plugins
+opencast-plugin-admin-ng                    = off
 opencast-plugin-legacy-annotation           = off
 opencast-plugin-paella-player-6             = off
 opencast-plugin-transcription-services      = off

--- a/etc/workflows/fast.yaml
+++ b/etc/workflows/fast.yaml
@@ -105,7 +105,7 @@ operations:
     configurations:
       - download-source-flavors: "*/preview"
       - channel-id: "internal"
-      - url-pattern: "${org_org_opencastproject_admin_ui_url!'http://localhost:8080'}/admin-ng/index.html#/events/events/${event_id}/tools/editor"
+      - url-pattern: "${org_org_opencastproject_admin_ui_url!'http://localhost:8080'}/editor-ui/index.html?id=${event_id}"
       - check-availability: false
 
   - id: publish-engage

--- a/etc/workflows/partial-preview.xml
+++ b/etc/workflows/partial-preview.xml
@@ -174,7 +174,7 @@
         <configuration key="download-source-tags">preview,editor</configuration>
         <configuration key="channel-id">internal</configuration>
         <configuration key="url-pattern">
-          ${org_org_opencastproject_admin_ui_url!'http://localhost:8080'}/admin-ng/index.html#/events/events/${event_id}/tools/editor
+          ${org_org_opencastproject_admin_ui_url!'http://localhost:8080'}/editor-ui/index.html?id=${event_id}
         </configuration>
         <configuration key="check-availability">false</configuration>
       </configurations>

--- a/etc/workflows/publish-uploaded-assets.xml
+++ b/etc/workflows/publish-uploaded-assets.xml
@@ -3,7 +3,7 @@
   <id>publish-uploaded-assets</id>
   <title>Publish uploaded assets</title>
   <tags>
-     <!-- Only launched from add asset in admin-ng, not available for selection by end users via the Admin UI -->
+     <!-- Only launched from add asset in admin interface, not available for selection by end users via the Admin UI -->
   </tags>
   <description>Publish uploaded assets</description>
   <configuration_panel>


### PR DESCRIPTION
This patch disables the old admin interface by default. Users can still activate this if they really want/need the old interface. This should force users to acknowledge and test the new interface while allowing a fallback in some edge cases.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
