### PR TITLE
Ignore subtitle tracks in select-tracks WHO

### DIFF
--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SelectStreamsWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SelectStreamsWorkflowOperationHandler.java
@@ -257,9 +257,20 @@ public class SelectStreamsWorkflowOperationHandler extends AbstractWorkflowOpera
       return createResult(mediaPackage, WorkflowOperationResult.Action.CONTINUE);
     }
 
-    final List<AugmentedTrack> augmentedTracks = createAugmentedTracks(tracks, workflowInstance);
+    final List<AugmentedTrack> augmentedTracksAll = createAugmentedTracks(tracks, workflowInstance);
+    List<AugmentedTrack> augmentedTracks = new ArrayList<>();
 
     final MuxResult result = MuxResult.empty();
+
+    // add non video/audio tracks, like captions, directly to result as only video/audio tracks are relevant for selection
+    for (final AugmentedTrack t : augmentedTracksAll) {
+      if (t.hasVideo() || t.hasAudio()) {
+        augmentedTracks.add(t);
+      } else {
+        result.add(copyTrack(t.track));
+      }
+    }
+
     // Note that the logic below currently supports at most two input tracks
 
     if (allNonHidden(augmentedTracks, SubTrack.VIDEO)) {


### PR DESCRIPTION
fixes https://github.com/opencast/opencast/issues/5817

Subtitle tracks interfere with the proper functioning of the select-track WHO. Therefore we have to exclude them from the selection process.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* ~[ ] include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
