### PR TITLE
ESLint nitpicks in the `lti` module

### DIFF
--- a/modules/lti/.eslintrc.json
+++ b/modules/lti/.eslintrc.json
@@ -1,8 +1,8 @@
 {
   "extends": ["react-app"],
   "parserOptions": {
-		"project": "./tsconfig.json"
-	},
+    "project": "./tsconfig.json"
+  },
   "overrides": [
     {
       "files": [

--- a/modules/lti/package.json
+++ b/modules/lti/package.json
@@ -36,25 +36,6 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "shared-config"
-    ],
-    "rules": {
-      "no-console": "error"
-    },
-    "overrides": [
-      {
-        "files": [
-          "**/*.ts?(x)"
-        ],
-        "rules": {
-          "no-console": "error"
-        }
-      }
-    ]
-  },
   "browserslist": {
     "production": [
       ">0.2%",


### PR DESCRIPTION
Looking at updating ESLint across the board, I found a few small things in the `lti` package.

* Formatting was werid.
* There was unused ESLint configuration in `package.json`.