### PR TITLE
Change how we make user references deletable in the admin UI(-s)

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/modules/users/partials/userActionsCell.html
+++ b/modules/admin-ui-frontend/app/scripts/modules/users/partials/userActionsCell.html
@@ -10,6 +10,6 @@
    data-object="row"
    class="remove"
    title="{{ 'USERS.USERS.TABLE.TOOLTIP.DELETE' | translate }}"
-   ng-if="row.manageable || ( row.provider != 'opencast' && row.provider != 'system' )"
+   ng-if="row.manageable"
    with-role="ROLE_UI_USERS_DELETE">
 </a>

--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/security/impl/jpa/JpaUserReference.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/security/impl/jpa/JpaUserReference.java
@@ -122,8 +122,10 @@ public class JpaUserReference {
     for (JpaRole role : roles) {
       roleSet.add(JaxbRole.fromRole(role));
     }
-    return new JaxbUser(username, null, name, email, providerName, JaxbOrganization.fromOrganization(organization),
+    var user = new JaxbUser(username, null, name, email, providerName, JaxbOrganization.fromOrganization(organization),
             roleSet);
+    user.setManageable(true);
+    return user;
   }
 
   /**


### PR DESCRIPTION
This indirectly forward-ports #5058 to the new admin UI; instead of special-casing the frontend, we just mark user references `manageable` in the backend.

Note, this reverts the frontend change made in #5058 as well since this is no longer needed.

/cc opencast/opencast-admin-interface#327.