### PR TITLE
More configuration options for database pool settings

### DIFF
--- a/etc/custom.properties
+++ b/etc/custom.properties
@@ -125,14 +125,21 @@ org.opencastproject.download.directory=${org.opencastproject.storage.dir}/downlo
 #org.opencastproject.db.jdbc.pass=dbpassword
 
 # The jdbc connection pool properties. See https://mchange.com/projects/c3p0/#basic_pool_configuration
-# max.idle.time should be lower than the database server idle connection timeout duration (wait_timeout for MariaDB)
+# and https://www.mchange.com/projects/c3p0/#configuration_properties
 #org.opencastproject.db.jdbc.pool.max.size=15
 #org.opencastproject.db.jdbc.pool.min.size=3
 #org.opencastproject.db.jdbc.pool.acquire.increment=3
 #org.opencastproject.db.jdbc.pool.max.statements=0
-#org.opencastproject.db.jdbc.pool.login.timeout=1000
-#org.opencastproject.db.jdbc.pool.max.idle.time=3600
-#org.opencastproject.db.jdbc.pool.max.connection.age=0
+#org.opencastproject.db.jdbc.pool.login.timeout=60
+# max.idle.time should be lower than the database server idle connection timeout duration (wait_timeout for MariaDB)
+#org.opencastproject.db.jdbc.pool.max.idle.time=1800
+#org.opencastproject.db.jdbc.pool.max.connection.age=28800
+# Idle connection testing documentation: https://www.mchange.com/projects/c3p0/#configuring_connection_testing
+#org.opencastproject.db.jdbc.pool.test.connection.on.checkin = false
+# Setting test.connection.on.checkout to true is the most costly choice from a client-performance perspective.
+# In most cases a combination of test.connection.on.checkin and idle.connection.test.period will be a better choice.
+#org.opencastproject.db.jdbc.pool.test.connection.on.checkout = false
+#org.opencastproject.db.jdbc.pool.idle.connection.test.period = 300
 
 
 ######### Workspace Cleanup #########

--- a/modules/db/src/main/java/org/opencastproject/db/Activator.java
+++ b/modules/db/src/main/java/org/opencastproject/db/Activator.java
@@ -91,6 +91,12 @@ public class Activator implements BundleActivator {
         bundleContext.getProperty("org.opencastproject.db.jdbc.pool.max.idle.time"));
     Integer maxConnectionAge = getConfigProperty(
         bundleContext.getProperty("org.opencastproject.db.jdbc.pool.max.connection.age"));
+    Boolean testConnectionOnCheckin = getConfigBooleanProperty(
+        bundleContext.getProperty("org.opencastproject.db.jdbc.pool.test.connection.on.checkin"));
+    Boolean testConnectionOnCheckout = getConfigBooleanProperty(
+        bundleContext.getProperty("org.opencastproject.db.jdbc.pool.test.connection.on.checkout"));
+    Integer idleConnectionTestPeriod = getConfigProperty(
+        bundleContext.getProperty("org.opencastproject.db.jdbc.pool.idle.connection.test.period"));
 
     pooledDataSource = new ComboPooledDataSource();
     pooledDataSource.setDriverClass(jdbcDriver);
@@ -99,9 +105,17 @@ public class Activator implements BundleActivator {
     pooledDataSource.setPassword(jdbcPass);
     if (minPoolSize != null) {
       pooledDataSource.setMinPoolSize(minPoolSize);
+      // initial pool size should be at least the min value
+      if (pooledDataSource.getInitialPoolSize() < minPoolSize) {
+        pooledDataSource.setInitialPoolSize(minPoolSize);
+      }
     }
     if (maxPoolSize != null) {
       pooledDataSource.setMaxPoolSize(maxPoolSize);
+      // initial pool size should be at most the max value
+      if (pooledDataSource.getInitialPoolSize() > maxPoolSize) {
+        pooledDataSource.setInitialPoolSize(maxPoolSize);
+      }
     }
     if (acquireIncrement != null) {
       pooledDataSource.setAcquireIncrement(acquireIncrement);
@@ -124,6 +138,15 @@ public class Activator implements BundleActivator {
 
     if (maxConnectionAge != null) {
       pooledDataSource.setMaxConnectionAge(maxConnectionAge);
+    }
+    if (testConnectionOnCheckin != null) {
+      pooledDataSource.setTestConnectionOnCheckin(testConnectionOnCheckin);
+    }
+    if (testConnectionOnCheckout != null) {
+      pooledDataSource.setTestConnectionOnCheckout(testConnectionOnCheckout);
+    }
+    if (idleConnectionTestPeriod != null) {
+      pooledDataSource.setIdleConnectionTestPeriod(idleConnectionTestPeriod);
     }
 
     Connection connection = null;
@@ -199,6 +222,10 @@ public class Activator implements BundleActivator {
 
   private Integer getConfigProperty(String config) {
     return config == null ? null : Integer.parseInt(config);
+  }
+
+  private Boolean getConfigBooleanProperty(String config) {
+    return config == null ? null : Boolean.parseBoolean(config);
   }
 
 }


### PR DESCRIPTION
A long running and mostly inactive Opencast instance produces error messages like `A PooledConnection that has already signalled a Connection error is still in use!`. Now we can tune the connection settings to test validity of idle pooled connections more precisely.

This patch was tested in production for some semesters. Since then, no spam with connection-closed-exceptions has been reported in the log.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
