### PR TITLE
Remove series ACL file from workspaces

### DIFF
--- a/modules/conductor/src/main/java/org/opencastproject/event/handler/AssetManagerUpdatedEventHandler.java
+++ b/modules/conductor/src/main/java/org/opencastproject/event/handler/AssetManagerUpdatedEventHandler.java
@@ -275,8 +275,6 @@ public class AssetManagerUpdatedEventHandler {
               workspace.delete(mpAclAttachmentTuple.getB().getURI());
             } catch (Exception ex) {
               // We only want to clean up. If the file is gone, that is fine too.
-              logger.debug("Unable to delete series acl attachment for media package {} after updating it.",
-                  mp.getIdentifier().toString(), ex);
             }
           }
         }


### PR DESCRIPTION
On series ACL update all events of the series will be updated too. This results in a event handler call, where the series ACL should be written to the workspace for snapshotting. But the file will never be deleted. This patch fixes that.

This patch is successfully tested in production for some semesters.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
