### PR TITLE
Invalidate cached user on changes

### DIFF
--- a/modules/security-jwt/src/main/java/org/opencastproject/security/jwt/DynamicLoginHandler.java
+++ b/modules/security-jwt/src/main/java/org/opencastproject/security/jwt/DynamicLoginHandler.java
@@ -156,9 +156,9 @@ public class DynamicLoginHandler implements InitializingBean, JWTLoginHandler {
           }
         } catch (UsernameNotFoundException e) {
           newUserLogin(username, jwt);
-          userDirectoryService.invalidate(username);
         }
 
+        userDirectoryService.invalidate(username);
         cache.put(jwt.getSignature(), new CachedJWT(jwt, username));
         return username;
       } else {

--- a/modules/security-shibboleth/src/main/java/org/opencastproject/security/shibboleth/ShibbolethRequestHeaderAuthenticationFilter.java
+++ b/modules/security-shibboleth/src/main/java/org/opencastproject/security/shibboleth/ShibbolethRequestHeaderAuthenticationFilter.java
@@ -80,8 +80,8 @@ public class ShibbolethRequestHeaderAuthenticationFilter extends RequestHeaderAu
         }
       } catch (UsernameNotFoundException e) {
         loginHandler.newUserLogin(o, request);
-        userDirectoryService.invalidate(o);
       }
+      userDirectoryService.invalidate(o);
     }
     return o;
   }


### PR DESCRIPTION
In certain circumstances, you may want to configure multiple authentication mechanisms in Opencast, but with the same user source. For example, a user should be able to log in using Shibboleth and also using JWT from an external trusted application. In this case, the user roles should be merged. This is handled correctly by Opencast. User data is then cached for performance reasons. However, on the first request using a different login mechanism, the user details should be set correctly, but the old cached user details are used instead. All subsequent requests are fine. This patch should fix that.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
