### PR TITLE
Fixes handling of OAI-PMH setSpec

### DIFF
--- a/modules/oaipmh-persistence/src/main/java/org/opencastproject/oaipmh/persistence/impl/SearchResultItemImpl.java
+++ b/modules/oaipmh-persistence/src/main/java/org/opencastproject/oaipmh/persistence/impl/SearchResultItemImpl.java
@@ -62,6 +62,24 @@ public class SearchResultItemImpl implements SearchResultItem {
     }
   }
 
+  public SearchResultItemImpl(final String mediaPackageId, final String mediaPackageXml,
+      final String organization, final String repoId, final Date modificationDate,
+      final Boolean isDeleted, final MediaPackage mediaPackage,
+      final List<SearchResultElementItem> mediaPackageElements,
+      final List<String> setSpecs) {
+    this.mediaPackageId = mediaPackageId;
+    this.mediaPackageXml = mediaPackageXml;
+    this.organization = organization;
+    this.repoId = repoId;
+    this.modificationDate = modificationDate;
+    this.isDeleted = isDeleted;
+    this.mediaPackage = mediaPackage;
+    this.mediaPackageElements = new ArrayList<>();
+    this.mediaPackageElements.addAll(mediaPackageElements);
+    this.setSpecs = new ArrayList<>();
+    this.setSpecs.addAll(setSpecs);
+  }
+
   @Override
   public String getId() {
     return mediaPackageId;


### PR DESCRIPTION
Currently, when a published episode no longer conforms to a specific OAI-PMH set specification, it disappears from the list of changed records. The OAI-PMH harvester is unaware of the change and cannot process it properly. Marking the episode as deleted in the OAI-PMH listing requests resolves the issue.

This patch is successfully tested in production.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
