### PR TITLE
Fixed bug: tag-engage workflow failes when event is not published

### DIFF
--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/TagEngageWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/TagEngageWorkflowOperationHandler.java
@@ -134,7 +134,8 @@ public class TagEngageWorkflowOperationHandler extends AbstractWorkflowOperation
     try {
       mediaPackageForSearch = searchService.get(mediaPackageId);
     } catch (NotFoundException | UnauthorizedException e) {
-      throw new WorkflowOperationException(e);
+      logger.info("No tag engage workflow found for {}", mediaPackageId);
+      return createResult(WorkflowOperationResult.Action.SKIP);
     }
 
     // update tags & flavors in published mp

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/TagEngageWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/TagEngageWorkflowOperationHandler.java
@@ -133,9 +133,11 @@ public class TagEngageWorkflowOperationHandler extends AbstractWorkflowOperation
     MediaPackage mediaPackageForSearch = null;
     try {
       mediaPackageForSearch = searchService.get(mediaPackageId);
-    } catch (NotFoundException | UnauthorizedException e) {
+    } catch (NotFoundException e) {
       logger.info("Media package {} is not published to Engage, skipping", mediaPackageId);
       return createResult(WorkflowOperationResult.Action.SKIP);
+    } catch (UnauthorizedException e) {
+      throw new WorkflowOperationException(e);
     }
 
     // update tags & flavors in published mp

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/TagEngageWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/TagEngageWorkflowOperationHandler.java
@@ -134,7 +134,7 @@ public class TagEngageWorkflowOperationHandler extends AbstractWorkflowOperation
     try {
       mediaPackageForSearch = searchService.get(mediaPackageId);
     } catch (NotFoundException | UnauthorizedException e) {
-      logger.info("No tag engage workflow found for {}", mediaPackageId);
+      logger.info("Media package {} is not published to Engage, skipping", mediaPackageId);
       return createResult(WorkflowOperationResult.Action.SKIP);
     }
 


### PR DESCRIPTION
Fixed the bug that the tag-engage workflow failed when trying to add or remove the video365 tag for an unpublished event. Now the workflow is skipped when the event has not been published yet. 
