### PR TITLE
Improve Assetmanager multi store behavior

### DIFF
--- a/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/AbstractFileSystemAssetStore.java
+++ b/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/AbstractFileSystemAssetStore.java
@@ -71,6 +71,14 @@ public abstract class AbstractFileSystemAssetStore implements AssetStore {
   protected abstract String getRootDirectory();
   protected abstract String getRootDirectory(String orgId, String mpId);
 
+  /**
+   * Optional further handling of the complete deletion of mediapackage from the local store.
+   * This method will be called after the deletion of the mediapackage directory.
+   * @param orgId Organization ID
+   * @param mpId Mediapackage ID
+   */
+  protected abstract void onDeleteMediaPackage(String orgId, String mpId);
+
   @Override
   public void put(StoragePath storagePath, Source source) throws AssetStoreException {
     // Retrieving the file from the workspace has the advantage that in most cases the file already exists in the local
@@ -148,8 +156,12 @@ public abstract class AbstractFileSystemAssetStore implements AssetStore {
     try {
       FileUtils.deleteDirectory(dir);
       // also delete the media package directory if all versions have been deleted
-      FileSupport.deleteHierarchyIfEmpty(file(path(getRootDirectory(sel.getOrganizationId(), sel.getMediaPackageId()),
-              sel.getOrganizationId())), dir.getParentFile());
+      boolean mpDirDeleted = FileSupport.deleteHierarchyIfEmpty(file(path(
+              getRootDirectory(sel.getOrganizationId(), sel.getMediaPackageId()), sel.getOrganizationId())),
+              dir.getParentFile());
+      if (mpDirDeleted) {
+        onDeleteMediaPackage(sel.getOrganizationId(), sel.getMediaPackageId());
+      }
       return true;
     } catch (IOException e) {
       logger.error("Error deleting directory from archive {}", dir);
@@ -217,8 +229,12 @@ public abstract class AbstractFileSystemAssetStore implements AssetStore {
 
   /** Create a file from a storage path and an optional extension. */
   private File createFile(StoragePath p, Opt<String> extension) {
+    String rootDirectory = getRootDirectory(p.getOrganizationId(), p.getMediaPackageId());
+    if (rootDirectory == null) {
+      rootDirectory = getRootDirectory();
+    }
     return file(
-            getRootDirectory(),
+            rootDirectory,
             p.getOrganizationId(),
             p.getMediaPackageId(),
             p.getVersion().toString(),


### PR DESCRIPTION
Since PR #4955, Assetmanager supports multiple stores. Moving a mediapackage to different store can result in an AssetManagerException like this: `An asset with checksum … (md5) has already been archived but trying to copy or link asset StoragePath(orgId=mh_default_org, mpId=…, version=…, mpeId=…) to it failed` This is because the path to the mediapackage is cached in the Assetmanager for 60 minutes. That's too long. Reducing the period to 1 minute is enough to get performance boost and be dynamic.

Assetmanager decides which asset store to use for each snapshot. That's not the best way. If you have a snapshot in store A and you create another snapshot, the second one may go to store B. This means that hardlinking between the two asset stores may not work and the files will be copied. This patch changes this behavior. All snapshots of a mediapackage are stored in the same asset store.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
