### PR TITLE
Change segment `startTime` from mpeg7 to milliseconds in Tobira API

### DIFF
--- a/modules/tobira/pom.xml
+++ b/modules/tobira/pom.xml
@@ -55,6 +55,11 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-mpeg7</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-dublincore</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Item.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Item.java
@@ -34,6 +34,7 @@ import org.opencastproject.metadata.dublincore.DublinCore;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
 import org.opencastproject.metadata.dublincore.DublinCoreUtil;
 import org.opencastproject.metadata.dublincore.EncodingSchemeUtils;
+import org.opencastproject.metadata.mpeg7.MediaTimePointImpl;
 import org.opencastproject.search.api.SearchResultItem;
 import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.security.api.AccessControlParser;
@@ -334,9 +335,10 @@ class Item {
       .filter(a -> a.getFlavor().getSubtype().equals("segment+preview"))
       .map(s -> Jsons.obj(
           Jsons.p("uri", s.toString()),
-          Jsons.p("startTime", s.getReference().getProperty("time"))
-        )
-      )
+          Jsons.p("startTime", MediaTimePointImpl.parseTimePoint(
+              s.getReference().getProperty("time")
+          ).getTimeInMilliseconds())
+      ))
       .collect(Collectors.toCollection(ArrayList::new));
   }
 


### PR DESCRIPTION
All durations in the API are transmitted as milliseconds, so this should be too. On the Tobira side we want to save it as milliseconds too, since Paella wants that anyway.

This is a breaking API change and the API was already released as OC 15.5, so why no API version bump? The Tobira API is declared internal and only to be used by Tobira. And Tobira did not use it yet! So nothing can break.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
