### PR TITLE
Skip editor processing on empty cutting list

### DIFF
--- a/docs/guides/admin/docs/releasenotes/editor-woh-option-default-value.txt
+++ b/docs/guides/admin/docs/releasenotes/editor-woh-option-default-value.txt
@@ -1,0 +1,1 @@
+The default value of the `editor` WOH property `skip-if-not-trimmed` has changed to `true`.

--- a/docs/guides/admin/docs/workflowoperationhandlers/editor-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/editor-woh.md
@@ -18,7 +18,7 @@ by the video editor frontend.
 |skipped-flavors   |`*/work`   |The flavor(s) of all media files to be "processed" (cloned) if the editor operation is skipped|
 |target-flavor-subtype|`trimmed`|The flavor subtype to be applied to all resulting videos, e.g. for a value of `baz`, a track with flavor `foo/bar` will generate another track with flavor `foo/baz`|
 |target-smil-flavor| `smil/cutting` |the flavor of the SMIL file containing the final video segments.<br/>Should be the same as the `smil.catalog.flavor` property in `etc/org.opencastproject.adminui.cfg`|
-|skip-if-not-trimmed|`false`       |(Optional) if set to `true`, the track encoding will be skipped if no trimming points were defined (i.e. there is only one segment from the very beginning to the very end of the video). Defaults to `false`|
+|skip-if-not-trimmed|`false`       |(Optional) if set to `true`, the track encoding will be skipped if no trimming points were defined (i.e. there is only one segment from the very beginning to the very end of the video). Defaults to `true`|
 |skip-processing|`true`|Do not do the actual encoding, just create the smil file and exit. This option is used with *process-smil* workflow operation, which will use the smil to run the encodings then. Default is false. |
 |*preview_flavors*|*`*/preview`*|*(Legacy) Flavors used to preview the video in the editor.*<br/>***Currently has no effect. Preview flavors are now configured in the file `etc/org.opencastproject.adminui.cfg`***|
 |*interactive*|*`false`*|*(Legacy) If `true` make the operation interactive, i.e. pause and wait for user input.*<br/>***Do not use. Interactive operations are deprecated in the current API.***|

--- a/etc/workflows/partial-transcode-studio-tracks.xml
+++ b/etc/workflows/partial-transcode-studio-tracks.xml
@@ -27,7 +27,6 @@
         <configuration key="smil-flavors">smil/cutting</configuration>
         <configuration key="target-smil-flavor">smil/cutting</configuration>
         <configuration key="target-flavor-subtype">source+trimmed</configuration>
-        <configuration key="skip-if-not-trimmed">true</configuration>
       </configurations>
     </operation>
 

--- a/modules/videoeditor-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videoeditor/VideoEditorWorkflowOperationHandler.java
+++ b/modules/videoeditor-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videoeditor/VideoEditorWorkflowOperationHandler.java
@@ -413,7 +413,8 @@ public class VideoEditorWorkflowOperationHandler extends ResumableWorkflowOperat
       }
     }
 
-    boolean skipIfNoTrim = BooleanUtils.toBoolean(worflowOperationInstance.getConfiguration(SKIP_NOT_TRIMMED_PROPERTY));
+    boolean skipIfNoTrim = BooleanUtils.toBooleanDefaultIfNull(BooleanUtils.toBooleanObject(
+        worflowOperationInstance.getConfiguration(SKIP_NOT_TRIMMED_PROPERTY)), true);
 
     // Get source tracks
     TrackSelector trackSelector = new TrackSelector();


### PR DESCRIPTION
Skip processing recording, if it isn't trimmed or cutted. This will speedup processing in this case and save storage and energy.

Do we really want to set this value in each workflow? Maybe it make sense to change the default value of the editor WOH? What do you think about?

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
