### PR TITLE
Fix missing configuration panel for fast.yaml workflow

### DIFF
--- a/etc/workflows/fast.yaml
+++ b/etc/workflows/fast.yaml
@@ -13,6 +13,17 @@ configuration_panel: |-
      <input id="straightToPublishing" name="straightToPublishing" type="checkbox" class="configField" value="true" checked=checked />
      <label for="straightToPublishing">Straight to publishing</label>
   </div>
+configuration_panel_json: |-
+  [{
+    "fieldset": [
+      {
+        "type": "checkbox",
+        "name": "straightToPublishing",
+        "label": "Straight to publishing",
+        "value": true
+      }
+    ]
+  }]
 operations:
   - id: defaults
     description: "Applying default configuration values"


### PR DESCRIPTION
Fixes one point in https://github.com/opencast/opencast-admin-interface/issues/1420.

This PR adds the missing configuration panel in the fast workflow. With this panel, the configuration in the workflow selection should appear again in the new admin UI.