### PR TITLE
Remove prepared flavor

### DIFF
--- a/docs/guides/admin/docs/releasenotes/remove-prepared-flavor.txt
+++ b/docs/guides/admin/docs/releasenotes/remove-prepared-flavor.txt
@@ -1,0 +1,2 @@
+This removes all remnants of the prepared flavor from the workflows and the EditorServiceImpl.cfg as it currently serves
+no purpose and only makes things unnecessarily complicated. Instead, the source flavor will be used directly.

--- a/etc/org.opencastproject.editor.EditorServiceImpl.cfg
+++ b/etc/org.opencastproject.editor.EditorServiceImpl.cfg
@@ -10,9 +10,9 @@
 # Default: editor
 #preview.tag=editor
 #
-# Secondly try to select tracks ba a given flavor
-# Default: prepared
-#preview.subtype=prepared
+# Secondly try to select tracks by a given flavor
+# Default: source
+#preview.subtype=source
 
 # Sets the flavor of the video track preview images
 # Default: video+preview

--- a/etc/workflows/partial-process-uploaded-captions.xml
+++ b/etc/workflows/partial-process-uploaded-captions.xml
@@ -8,29 +8,6 @@
 
   <operations>
 
-    <!-- create or update captions/prepared -->
-
-    <operation
-      id="tag"
-      description="Remove old captions/prepared">
-      <configurations>
-        <configuration key="source-flavors">captions/prepared</configuration>
-        <configuration key="target-tags">-archive</configuration>
-      </configurations>
-    </operation>
-
-    <operation
-      if="${presenter_prepared_exists} OR ${presentation_prepared_exists}"
-      id="clone"
-      fail-on-error="true"
-      exception-handler-workflow="partial-error"
-      description="Create captions/prepared">
-      <configurations>
-        <configuration key="source-flavor">captions/source</configuration>
-        <configuration key="target-flavor">captions/prepared</configuration>
-      </configurations>
-    </operation>
-
     <!-- cut captions -->
 
     <operation

--- a/etc/workflows/partial-publish.xml
+++ b/etc/workflows/partial-publish.xml
@@ -9,38 +9,12 @@
   <configuration_panel_json/>
   <operations>
 
-    <!-- Fall back to */source if */prepared does not exist -->
-
-    <operation
-        id="analyze-tracks"
-        fail-on-error="true"
-        exception-handler-workflow="partial-error"
-        description="Analyze tracks in media package and set control variables">
-      <configurations>
-        <configuration key="source-flavor">*/prepared</configuration>
-      </configurations>
-    </operation>
-
-    <operation
-        if="NOT (${presentation_prepared_media} OR ${presenter_prepared_media})"
-        id="clone"
-        fail-on-error="true"
-        exception-handler-workflow="partial-error"
-        description="Preparing media">
-      <configurations>
-        <configuration key="source-flavor">*/source</configuration>
-        <configuration key="target-flavor">*/prepared</configuration>
-      </configurations>
-    </operation>
-
-    <!-- Continue processing -->
-
     <operation
       id="select-tracks"
       exception-handler-workflow="partial-error"
       description="Selecting audio/video streams for processing">
       <configurations>
-        <configuration key="source-flavor">*/prepared</configuration>
+        <configuration key="source-flavor">*/source</configuration>
         <configuration key="target-flavor">*/work</configuration>
         <configuration key="target-tags">-archive</configuration>
         <configuration key="audio-muxing">duplicate</configuration>
@@ -53,7 +27,7 @@
         id="tag"
         description="Tag captions for cutting">
       <configurations>
-        <configuration key="source-flavors">captions/prepared</configuration>
+        <configuration key="source-flavors">captions/source</configuration>
         <configuration key="target-flavor">captions/work</configuration>
         <configuration key="target-tags">-archive</configuration>
         <configuration key="copy">true</configuration>

--- a/etc/workflows/publish-uploaded-assets.xml
+++ b/etc/workflows/publish-uploaded-assets.xml
@@ -35,10 +35,9 @@
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
     <!-- Special handling for captions                                     -->
     <!--                                                                   -->
-    <!-- Creates captions/prepared and captions/delivery.                  -->
+    <!-- Creates captions/delivery.                                        -->
     <!-- Sets the following tags:                                          -->
     <!--    captions/source     archive, exclude-publish                   -->
-    <!--    captions/prepared   archive                                    -->
     <!--    captions/delivery   engage-download                            -->
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 

--- a/modules/editor-service-api/src/test/resources/edit.json
+++ b/modules/editor-service-api/src/test/resources/edit.json
@@ -24,7 +24,7 @@
   "tracks": [
     {
       "flavor": {
-        "subtype": "prepared",
+        "subtype": "source",
         "type": "presenter"
       },
       "video_stream": {
@@ -40,7 +40,7 @@
     },
     {
       "flavor": {
-        "subtype": "prepared",
+        "subtype": "source",
         "type": "presentation"
       },
       "video_stream": {

--- a/modules/editor-service-api/src/test/resources/editWithoutWorkflow.json
+++ b/modules/editor-service-api/src/test/resources/editWithoutWorkflow.json
@@ -2,7 +2,7 @@
   "tracks": [
     {
       "flavor": {
-        "subtype": "prepared",
+        "subtype": "source",
         "type": "presenter"
       },
       "video_stream": {
@@ -18,7 +18,7 @@
     },
     {
       "flavor": {
-        "subtype": "prepared",
+        "subtype": "source",
         "type": "presentation"
       },
       "video_stream": {

--- a/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
+++ b/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
@@ -179,7 +179,7 @@ public class EditorServiceImpl implements EditorService {
   private String distributionDirectory;
   private Boolean localPublication = null;
 
-  private static final String DEFAULT_PREVIEW_SUBTYPE = "prepared";
+  private static final String DEFAULT_PREVIEW_SUBTYPE = "source";
   private static final String DEFAULT_PREVIEW_TAG = "editor";
   private static final String DEFAULT_WAVEFORM_SUBTYPE = "waveform";
   private static final String DEFAULT_SMIL_CATALOG_FLAVOR = "smil/cutting";


### PR DESCRIPTION
This removes the `prepared` flavor from the workflows and configuration as it currently serves no purpose and causes issues like making it hard to know which captions to update. It was initially introduced to archive the output of `prepare-av`, but that step was removed during the rework f the workflows. This would make #5598 obsolete.

Might still be able to go into OC 16?