### PR TITLE
Adjust `created` field of Tobira harvest response for events

### DIFF
--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Item.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Item.java
@@ -50,6 +50,7 @@ import org.opencastproject.workspace.api.Workspace;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -155,7 +156,9 @@ class Item {
           Jsons.p("title", title),
           Jsons.p("partOf", event.getDublinCore().getFirst(DublinCore.PROPERTY_IS_PART_OF)),
           Jsons.p("description", event.getDublinCore().getFirst(PROPERTY_DESCRIPTION)),
-          Jsons.p("created", event.getDublinCore().getFirst(DublinCore.PROPERTY_CREATED)),
+          Jsons.p("created", Instant.parse(
+            event.getDublinCore().getFirst(DublinCore.PROPERTY_CREATED)
+          ).toEpochMilli()),
           Jsons.p("startTime", period.map(p -> p.getStart().getTime()).orElse(null)),
           Jsons.p("endTime", period.map(p -> p.getEnd().getTime()).orElse(null)),
           Jsons.p("creators", Jsons.arr(new ArrayList<>(creators))),


### PR DESCRIPTION
This changed in OC 16 with the Solr/Opensearch swap as far as I can see, but it needs to be in a specific format in order to be harvested by Tobira. (Edit: I am referring to this commit: https://github.com/opencast/opencast/commit/5880526444317ea9396c97f4fa876480b83cd09d)

No version bump since this only restores old behaviour and is not a breaking change.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
