### PR TITLE
Remove obsolete `version` field from `docker-compose` files

### DIFF
--- a/docs/scripts/devel-dependency-containers/docker-compose-all-sql.yml
+++ b/docs/scripts/devel-dependency-containers/docker-compose-all-sql.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   elasticsearch:
     container_name: opencast-opensearch

--- a/docs/scripts/devel-dependency-containers/docker-compose-mariadb.yml
+++ b/docs/scripts/devel-dependency-containers/docker-compose-mariadb.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   elasticsearch:
     container_name: opencast-opensearch

--- a/docs/scripts/devel-dependency-containers/docker-compose-postgresql.yml
+++ b/docs/scripts/devel-dependency-containers/docker-compose-postgresql.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   elasticsearch:
     container_name: opencast-opensearch

--- a/docs/scripts/devel-dependency-containers/docker-compose.yml
+++ b/docs/scripts/devel-dependency-containers/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   elasticsearch:
     container_name: opencast-opensearch


### PR DESCRIPTION
My Docker warns me by now:

> ```
> WARN[0000] [redacted]/docs/scripts/devel-dependency-containers/docker-compose.yml: `version` is obsolete
> ```

cf. https://github.com/compose-spec/compose-spec/blob/master/04-version-and-name.md#version-top-level-element-obsolete