### PR TITLE
Fix for event state when workflow is paused when rebuilding ES index (fixes #5868)

### DIFF
--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -2213,7 +2213,9 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
               }
               current++;
 
-              if (!WorkflowUtil.isActive(WorkflowInstance.WorkflowState.values()[indexData.getState()].toString())) {
+              // Include PAUSED; otherwise, paused workflows will show up as "Finished"
+              if (!WorkflowUtil.isActive(WorkflowInstance.WorkflowState.values()[indexData.getState()].toString())
+                      || WorkflowState.PAUSED == WorkflowInstance.WorkflowState.values()[indexData.getState()]) {
                 String orgid = indexData.getOrganizationId();
                 if (null == orgid) {
                   String mpId = indexData.getMediaPackageId();


### PR DESCRIPTION
This fixes the following: when the elastic search index is rebuilt, events that have the last workflow in paused state are shown as "Finished" instead of "Paused". The paused state is an active state because there's a workflow that has not finished but the event cannot be set to finished.
Fixes #5868 
 

