### PR TITLE
Remove duplicates in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,9 +24,6 @@ node/
 # ignore VSCode project data
 .vscode/
 
-# ingore OS artifacts
-.DS_Store
-
 # Ignore all temporary editor files
 *.swp
 *.iml


### PR DESCRIPTION
This patch removes one occurrence of `.DS_Store` from the `.gitignore` file since it was listed twice.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
