### PR TITLE
Do not number multiple scheduled events

### DIFF
--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -577,9 +577,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
         // Set the new media package identifier
         mediaPackage.setIdentifier(id);
 
-        // Update dublincore title and temporal
-        String newTitle = dc.getFirst(DublinCore.PROPERTY_TITLE) + String.format(" %0" + Integer.toString(periods.size()).length() + "d", currentCounter + 1);
-        dc.set(DublinCore.PROPERTY_TITLE, newTitle);
+        // Update dublincore temporal
         DublinCoreValue eventTime = EncodingSchemeUtils.encodePeriod(new DCMIPeriod(startDate, endDate),
                 Precision.Second);
         dc.set(DublinCore.PROPERTY_TEMPORAL, eventTime);
@@ -589,7 +587,6 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
         } catch (Exception e) {
           Misc.chuck(e);
         }
-        mediaPackage.setTitle(newTitle);
 
         String mediaPackageId = mediaPackage.getIdentifier().toString();
         //Converting from iCal4j DateTime objects to plain Date objects to prevent AMQ issues below


### PR DESCRIPTION
Scheduling multiple events from the Admin UI results in sequential numbered events titles (see screenshot below). This is good for testing but useless in production. We should change this behavior to not number multiple scheduled events.

![image](https://github.com/opencast/opencast/assets/26736/12fe5076-6cb2-4f2c-a85b-6dc75b60e8cd)


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
