### PR TITLE
Skip subtitle generation from tracks without audio stream

### DIFF
--- a/modules/speech-to-text-workflowoperation/src/main/java/org/opencastproject/workflow/handler/speechtotext/SpeechToTextWorkflowOperationHandler.java
+++ b/modules/speech-to-text-workflowoperation/src/main/java/org/opencastproject/workflow/handler/speechtotext/SpeechToTextWorkflowOperationHandler.java
@@ -150,6 +150,11 @@ public class
     Boolean translate = getTranslationMode(mediaPackage, workflowInstance);
 
     for (Track track : tracks) {
+      if (!track.hasAudio()) {
+        logger.info("Track {} from media package {} doesn't contain audio stream. Skip subtitle generation.",
+            track.getFlavor(), mediaPackage.getIdentifier());
+        continue;
+      }
       createSubtitle(track, languageCode, mediaPackage, tagsAndFlavors, appendSubtitleAs, translate);
     }
 

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AmberscriptStartTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AmberscriptStartTranscriptionOperationHandler.java
@@ -135,6 +135,11 @@ public class AmberscriptStartTranscriptionOperationHandler extends AbstractWorkf
     Collection<Track> elements = elementSelector.select(mediaPackage, false);
     Job job = null;
     for (Track track : elements) {
+      if (!track.hasAudio()) {
+        logger.info("Track {} from media package {} doesn't contain audio stream. Skip subtitle generation.",
+            track.getFlavor(), mediaPackage.getIdentifier());
+        continue;
+      }
       try {
         job = service.startTranscription(mediaPackage.getIdentifier().toString(), track, language, jobType, speaker,
             transcriptionType, glossary, transcriptionStyle, targetLanguage);

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/GoogleSpeechStartTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/GoogleSpeechStartTranscriptionOperationHandler.java
@@ -148,6 +148,11 @@ public class GoogleSpeechStartTranscriptionOperationHandler extends AbstractWork
         logger.info("Skipping track {} since it contains a video stream", track);
         continue;
       }
+      if (!track.hasAudio()) {
+        logger.info("Track {} from media package {} doesn't contain audio stream. Skip subtitle generation.",
+            track.getFlavor(), mediaPackage.getIdentifier());
+        continue;
+      }
       try {
         job = service.startTranscription(mediaPackage.getIdentifier().toString(), track, language);
         // Only one job per media package

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/StartTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/StartTranscriptionOperationHandler.java
@@ -123,6 +123,11 @@ public class StartTranscriptionOperationHandler extends AbstractWorkflowOperatio
         logger.info("Skipping track {} since it contains a video stream", track);
         continue;
       }
+      if (!track.hasAudio()) {
+        logger.info("Track {} from media package {} doesn't contain audio stream. Skip subtitle generation.",
+            track.getFlavor(), mediaPackage.getIdentifier());
+        continue;
+      }
       try {
         job = service.startTranscription(mediaPackage.getIdentifier().toString(), track);
         // Only one job per media package


### PR DESCRIPTION
Transcription services uses the audio stream to generate subtitles. Therefor we should skip processing tracks without audio stream.

fixes #5818


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
