### PR TITLE
Handle lang tag by asset upload correctly

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -1140,8 +1140,16 @@ public class IndexServiceImpl implements IndexService {
           String flavorSubType = (String)((JSONObject) assetDataMap.get(asset)).get("flavorSubType");
           String tags = (String)((JSONObject) assetDataMap.get(asset)).get("tags");
           String[] tagsArray = null;
+          // Captions may have lang:LANG_CODE tag set.
+          String langTag = null;
           if (tags != null) {
             tagsArray = tags.split(",");
+            for (String tag : tagsArray) {
+              if (StringUtils.startsWith(StringUtils.trimToEmpty(tag), "lang:")) {
+                langTag = StringUtils.trimToEmpty(tag);
+                break;
+              }
+            }
           }
           // Use 'multiple' setting to allow multiple elements with same flavor or not.
           boolean overwriteExisting = !(Boolean) ((JSONObject) assetDataMap.get(asset)).getOrDefault("multiple", false);
@@ -1154,8 +1162,11 @@ public class IndexServiceImpl implements IndexService {
               // remove existing attachments of the new flavor
               Attachment[] existing = mp.getAttachments(newElemflavor);
               for (int i = 0; i < existing.length; i++) {
-                mp.remove(existing[i]);
-                logger.info("Overwriting existing asset {} {}", type, newElemflavor);
+                // if lang tag is set, we should only remove elements with the same lang tag
+                if (null == langTag || existing[i].containsTag(langTag)) {
+                  mp.remove(existing[i]);
+                  logger.info("Overwriting existing asset {} {}", type, newElemflavor);
+                }
               }
             }
             // correct the flavor of the new attachment
@@ -1172,8 +1183,11 @@ public class IndexServiceImpl implements IndexService {
               // remove existing catalogs of the new flavor
               Catalog[] existing = mp.getCatalogs(newElemflavor);
               for (int i = 0; i < existing.length; i++) {
-                mp.remove(existing[i]);
-                logger.info("Overwriting existing asset {} {}", type, newElemflavor);
+                // if lang tag is set, we should only remove elements with the same lang tag
+                if (null == langTag || existing[i].containsTag(langTag)) {
+                  mp.remove(existing[i]);
+                  logger.info("Overwriting existing asset {} {}", type, newElemflavor);
+                }
               }
             }
             Catalog[] catArray = mp.getCatalogs(new MediaPackageElementFlavor(assetOrig, "*"));
@@ -1192,8 +1206,11 @@ public class IndexServiceImpl implements IndexService {
               // remove existing catalogs of the new flavor
               Track[] existing = mp.getTracks(newElemflavor);
               for (int i = 0; i < existing.length; i++) {
-                mp.remove(existing[i]);
-                logger.info("Overwriting existing asset {} {}", type, newElemflavor);
+                // if lang tag is set, we should only remove elements with the same lang tag
+                if (null == langTag || existing[i].containsTag(langTag)) {
+                  mp.remove(existing[i]);
+                  logger.info("Overwriting existing asset {} {}", type, newElemflavor);
+                }
               }
             }
             Track[]  trackArray = mp.getTracks(new MediaPackageElementFlavor(assetOrig, "*"));


### PR DESCRIPTION
On asset upload all elements with same flavor will be deleted from media package. The new behavior of handling multilingual subtitles expect the language is set with a lang:LANG-CODE tag. This should be handled properly.

fixes #5745

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
