### PR TITLE
Mark old admin interface configuration as deprecated

### DIFF
--- a/etc/org.opencastproject.organization-mh_default_org.cfg
+++ b/etc/org.opencastproject.organization-mh_default_org.cfg
@@ -160,6 +160,20 @@ prop.org.opencastproject.admin.display_about=false
 #
 #prop.org.opencastproject.assetmanager.url=http://localhost:8080
 
+# Path to the default video player used by the engage interfaces and the LTI tools. Parameters for selecting the
+# specific videos will be appended automatically.  Common values include:
+#
+# - paella player 7: /paella7/ui/watch.html?id=#{id}
+#
+# Default: /paella7/ui/watch.html?id=#{id}
+#prop.player=/paella7/ui/watch.html?id=#{id}
+
+
+###
+# ⚠️ Settings specific to the old admin interface
+#   These settings are deprecated and will likely be removed with Opencast 17
+# ##
+
 # Set a flag to display External Roles on User modal
 #
 # Value: <boolean>
@@ -174,14 +188,6 @@ prop.adminui.user.external_role_display=false
 # - USERS.NAME.AND.USERNAME will list users by name and username (e.g. "John Sample (jsample)")
 # Default: USERS.NAME.AND.USERNAME
 #prop.adminui.user.listname=USERS.NAME.AND.USERNAME
-
-# Path to the default video player used by the engage interfaces and the LTI tools. Parameters for selecting the
-# specific videos will be appended automatically.  Common values include:
-#
-# - paella player 7: /paella7/ui/watch.html?id=#{id}
-#
-# Default: /paella7/ui/watch.html?id=#{id}
-#prop.player=/paella7/ui/watch.html?id=#{id}
 
 # Shortcut definitions for admin UI video player
 # Format: prop.admin.shortcut.player<action>=<key>


### PR DESCRIPTION
This patch moves all configuration only affecting the old admin interface to the bottom of the configuration file and marks them as deprecated.

This doesn't mean that they can't be used in the future if certain features are re-implemented. But for now, they just don't do anything.

To help identifying if properties are used in the new admin interface I used the following script (and made sure they are also not used in Opencast's backend code):

```sh
#!/bin/sh

sed -n 's/^#\{0,1\}prop\.\([^ =]*\)[ =].*$/\1/p' org.opencastproject.organization-mh_default_org.cfg \
| while read prop
do
  (
  cd ../../opencast-admin-interface/
  if grep -rnql "$prop" src
  then
    printf '%4s  %-60s %s\n' yes "${prop}" "used by admin interface"
  else
    printf '%4s  %-60s %s\n' no  "${prop}" "not used by admin interface"
  fi
  )
done
```

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
