### PR TITLE
Defaults should be commented out

### DIFF
--- a/etc/org.opencastproject.organization-mh_default_org.cfg
+++ b/etc/org.opencastproject.organization-mh_default_org.cfg
@@ -362,4 +362,4 @@ prop.admin.shortcut.add_media.previous_tab=shift+alt+left
 # Enable the sttatistics views in the admin intterface.
 # Format: boolean
 # Default: false
-#prop.admin.statisttics.enabled=false
+#prop.admin.statistics.enabled=false

--- a/etc/org.opencastproject.organization-mh_default_org.cfg
+++ b/etc/org.opencastproject.organization-mh_default_org.cfg
@@ -137,7 +137,7 @@ prop.org.opencastproject.admin.mediamodule.url=${prop.org.opencastproject.engage
 # Value: <boolean>
 # Default: false
 #
-prop.org.opencastproject.admin.display_about=false
+#prop.org.opencastproject.admin.display_about=false
 
 # Link to the Engage UI.
 #


### PR DESCRIPTION
This PR comments out a default that should have been commented out but was left uncommented accidentally.  Also fixed a spelling mistake I missed with #5909 relating to opencast/opencast-admin-interface#660

TODO: There are a number of *other* defaults which are not commented out...

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
