### PR TITLE
Fix link in editor config file

### DIFF
--- a/etc/ui-config/mh_default_org/editor/editor-settings.toml
+++ b/etc/ui-config/mh_default_org/editor/editor-settings.toml
@@ -101,7 +101,8 @@
 [subtitles.languages]
 ## A list of languages for which new subtitles can be created
 # For each language, various tags can be specified
-# A list of officially recommended tags can be found at https://docs.opencast.org/develop/admin/#modules/subtitles/#tags
+# A list of officially recommended tags can be found at
+# https://docs.opencast.org/develop/admin/#configuration/subtitles/#tags
 # At least the "lang" tag MUST be specified
 german = { lang = "de-DE" }
 english = { lang = "en-US", type = "closed-caption" }


### PR DESCRIPTION
This change was part of an older editor release and was overlooked (likely by me) when merging editor releases into Opencast. So here it is.