### PR TITLE
Fix Non-Admin Access to New Admin UI

### DIFF
--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -276,9 +276,7 @@
     <sec:intercept-url pattern="/admin-ng/shared/**" access="ROLE_ANONYMOUS" />
     <sec:intercept-url pattern="/admin-ng/styles/**" access="ROLE_ANONYMOUS" />
 
-    <sec:intercept-url pattern="/admin-ui/static/media/**" access="ROLE_ANONYMOUS" />
-    <sec:intercept-url pattern="/admin-ui/static/js/**" access="ROLE_ANONYMOUS" />
-    <sec:intercept-url pattern="/admin-ui/static/css/**" access="ROLE_ANONYMOUS" />
+    <sec:intercept-url pattern="/admin-ui/assets/**" access="ROLE_ANONYMOUS" />
 
     <!-- Enable anonymous access to the /info/** resource -->
     <sec:intercept-url pattern="/info/**" method="GET" access="ROLE_ANONYMOUS" />


### PR DESCRIPTION
Some static files were moved around for the new Admin UI and we need to reflect these changes in our security config. Without this, a non-admin user can't see the new Admin UI despite having all the UI roles, just a blank page. This is easily reproduced on stable.opencast.org (but doesn't occur on legacy.opencast.org).

I couldn't find the exact PR responsible for this in the new admin interface repo, so maybe somebody who knows more can check if a blanket permission for `admin-ui/assets` is reasonable.