### PR TITLE
Add `SearchResult::getCreatedDate` and use it to fix Tobira harvest API

### DIFF
--- a/modules/search-service-api/src/main/java/org/opencastproject/search/api/SearchResult.java
+++ b/modules/search-service-api/src/main/java/org/opencastproject/search/api/SearchResult.java
@@ -35,6 +35,8 @@ import org.opencastproject.security.api.AccessControlList;
 
 import com.google.gson.Gson;
 
+import org.elasticsearch.index.mapper.DateFieldMapper;
+
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
@@ -271,6 +273,11 @@ public class SearchResult {
 
   public SearchService.IndexEntryType getType() {
     return type;
+  }
+
+  public Instant getCreatedDate() {
+    var acc = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(this.dublinCore.getFirst(DublinCore.PROPERTY_CREATED));
+    return Instant.from(acc);
   }
 
   public String getOrgId() {

--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Item.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Item.java
@@ -51,7 +51,6 @@ import org.opencastproject.workspace.api.Workspace;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -157,9 +156,7 @@ class Item {
           Jsons.p("title", title),
           Jsons.p("partOf", event.getDublinCore().getFirst(DublinCore.PROPERTY_IS_PART_OF)),
           Jsons.p("description", event.getDublinCore().getFirst(PROPERTY_DESCRIPTION)),
-          Jsons.p("created", Instant.parse(
-            event.getDublinCore().getFirst(DublinCore.PROPERTY_CREATED)
-          ).toEpochMilli()),
+          Jsons.p("created", event.getCreatedDate().toEpochMilli()),
           Jsons.p("startTime", period.map(p -> p.getStart().getTime()).orElse(null)),
           Jsons.p("endTime", period.map(p -> p.getEnd().getTime()).orElse(null)),
           Jsons.p("creators", Jsons.arr(new ArrayList<>(creators))),


### PR DESCRIPTION
Before 16, the search service already returned a `Date` for `created`. When we switched to ElasticSearch, this was turned into a formatted String instead, which first went unnoticed. When noticed, it was fixed by calling `Instant.parse` which works for some cases, but not all.

The date format returned by ES is not always the same. When adding documents to ES, it will parse fields declared as dates and store the date as "ms since epoch UTC" internally to be able to filter by it. But it also remembers the original format and does not format the ms in a well defined format. The formats that can be parsed by ES can be configured, but by default (our case) it's
"strict_date_optional_time||epoch_millis". Documents with invalid dates will lead to an exception, i.e. will not be added to the index. So when querying the index, we have to expect any date format that can be parsed by the above default format. Compare [1].

And well, that's what this PR does: use the correct method from ES to parse it. I added the method to `SearchResult` as I figured that might be useful in the future.

[1]: https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html

This is a fix for this fix: #5863 

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
