### PR TITLE
Fix Opencast startup failure when index service boots later

### DIFF
--- a/docs/guides/admin/docs/configuration/searchindex/elasticsearch.md
+++ b/docs/guides/admin/docs/configuration/searchindex/elasticsearch.md
@@ -33,6 +33,7 @@ Additionally, the following settings can be configured in
 * `max.retry.attempts.update`
 * `retry.waiting.period.get`
 * `retry.waiting.period.update`
+* `retry.delay.on.startup`
 
 The identifier defines which index opencast is looking for. This might be interesting if you run an
 Elasticsearch cluster and want to follow a naming scheme. But you should be aware that the index actually consists of
@@ -44,6 +45,10 @@ are too many concurrent requests. The retry behavior can be configured different
 This way you could set more retry attempts for index updates because of the more serious consequences if those requests
 fail. The waiting period is used to not overwhelm the Elasticsearch with retry requests, making the problem worse. By
 default, no retry will be attempted.
+
+The `retry.delay.on.startup` defines how long Opencast will wait between retry attempts 
+when the connection to the index service fails on startup. The default is 10 seconds.
+
 
 Version
 -------

--- a/etc/org.opencastproject.elasticsearch.index.ElasticsearchIndex.cfg
+++ b/etc/org.opencastproject.elasticsearch.index.ElasticsearchIndex.cfg
@@ -29,3 +29,9 @@
 # How long to wait between retry attempts of update requests (in milliseconds).
 # Default: 1s
 #retry.waiting.period.update=1000
+
+# How long to wait between retry attempts when opencast failed to connect the
+# index service on startup (in milliseconds, so the default '10000' equals 10 Seconds).
+# Value has to be greater than 0.
+# Default: 10000
+#retry.delay.on.startup=10000


### PR DESCRIPTION
Fixes #5943

This PR adds a check in the Elasticsearch initialization method. The check includes sending a request to the index service and evaluating the response. If the service is not reachable, a retry loop will continuously check the connection until it succeeds.

**Changes:**

- Added a connection check in the Elasticsearch init method.
- Implemented a retry loop with a configurable wait period.

**How to test:**

1. Start Opencast without Elastic-/OpenSearch running.
2. Check the logs. Opencast should log every 10 seconds that it is retrying to connect to the index service.
3. Start the index service.
4. Opencast should continue with the startup process once the index service is available.

If steps 2 and 4 are successful, the test is complete.

**New Configuration:**

A new configuration value has been added to `etc/org.opencastproject.elasticsearch.index.ElasticsearchIndex.cfg`:

- retry.delay.on.startup: This sets the interval (in milliseconds) between retry attempts.

**Testing the New Configuration:**

1. Change the value of retry.delay.on.startup, for example, to 1 second (1000 milliseconds).
2. Start Opencast without Elastic-/OpenSearch running.
3. Check the logs and verify that the time between retry log messages matches the configured value.

