### PR TITLE
LTI translation strings

### DIFF
--- a/.crowdin.yaml
+++ b/.crowdin.yaml
@@ -15,3 +15,7 @@ files:
   -
     source: '/modules/engage-paella-player-7/src/i18n/en-US.json'
     translation: '/modules/engage-paella-player-7/src/i18n/%locale%.json'
+
+  -
+    source: '/modules/lti/src/i18n/lang-en_US.json'
+    translation: '/modules/lti/src/i18n/lang-%locale_with_underscore%.json'

--- a/.github/workflows/test-lti-tools.yml
+++ b/.github/workflows/test-lti-tools.yml
@@ -23,10 +23,6 @@ jobs:
       working-directory: modules/lti/
       run: npm ci
 
-    - name: copy translation from where they do not belong
-      working-directory: modules/lti/
-      run: ./copy-translations.sh
-
     - name: install selenium
       working-directory: modules/lti/
       run: pip install -r requirements.txt

--- a/modules/lti/.gitignore
+++ b/modules/lti/.gitignore
@@ -18,4 +18,3 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-src/i18n/*json

--- a/modules/lti/copy-translations.sh
+++ b/modules/lti/copy-translations.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-set -eu
-
-mkdir -p src/i18n
-cp ../admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/* src/i18n

--- a/modules/lti/package.json
+++ b/modules/lti/package.json
@@ -30,7 +30,6 @@
     "autoprefixer": "10.4.5"
   },
   "scripts": {
-    "i18n": "./copy-translations.sh",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",

--- a/modules/lti/pom.xml
+++ b/modules/lti/pom.xml
@@ -91,21 +91,6 @@
               </execution>
 
               <execution>
-                <id>i18n</id>
-                <goals>
-                  <goal>exec</goal>
-                </goals>
-                <phase>compile</phase>
-                <configuration>
-                  <executable>npm</executable>
-                  <arguments>
-                    <argument>run</argument>
-                    <argument>i18n</argument>
-                  </arguments>
-                </configuration>
-              </execution>
-
-              <execution>
                 <id>build</id>
                 <goals>
                   <goal>exec</goal>
@@ -156,17 +141,6 @@
                 </goals>
                 <configuration>
                   <arguments>ci</arguments>
-                </configuration>
-              </execution>
-
-              <execution>
-                <phase>initialize</phase>
-                <id>i18n</id>
-                <goals>
-                  <goal>npm</goal>
-                </goals>
-                <configuration>
-                  <arguments>run i18n</arguments>
                 </configuration>
               </execution>
 

--- a/modules/lti/src/i18n/lang-da_DK.json
+++ b/modules/lti/src/i18n/lang-da_DK.json
@@ -1,0 +1,58 @@
+{
+  "LTI": {
+    "ERROR_LOADING_METADATA": "Error loading event metadata. Please try again later.",
+    "SERIES_TITLE": "View Series",
+    "UPLOAD_TITLE": "Upload event",
+    "LOADING": "Loading…",
+    "NEW_UPLOAD": "Upload new event",
+    "EDIT_UPLOAD": "Edit event",
+    "CURRENT_JOBS": "Today's jobs",
+    "PRESENTER": "Presenter",
+    "PRESENTER_DESCRIPTION": "Video file for the presenter track",
+    "VIDEOFILE": "Videofile",
+    "VIDEOFILE_DESCRIPTION": "Video file for upload",
+    "CAPTION": "Captions",
+    "CAPTION_DESCRIPTION": "Caption file in VTT format",
+    "UPLOAD": "Upload",
+    "UPLOADING": "Uploading",
+    "EDIT": "Save",
+    "EDIT_TITLE": "Edit event",
+    "NO_OPTION_SELECTED": "No option selected",
+    "EDITING": "Saving…",
+    "SELECT_OPTION": "Select option",
+    "JOB_TITLE": "Title",
+    "JOB_STATUS": "Status",
+    "UPLOAD_SUCCESS": "Upload succeeded!",
+    "UPLOAD_FAILURE": "Upload failed!",
+    "UPLOAD_FAILURE_DESCRIPTION": "Please try again later.",
+    "EDIT_SUCCESS": "Edit succeeded, beginning republishing.",
+    "EDIT_FAILURE": "Edit failed!",
+    "COPY_SUCCESS": "Copying started…",
+    "COPY_SUCCESS_DESCRIPTION": "Please wait a moment…",
+    "GENERIC_ERROR": "Error: {{message}}",
+    "DELETION_SUCCESS": "Event deletion successful",
+    "DELETION_SUCCESS_DESCRIPTION": "The event will be removed from the list in a few moments…",
+    "EVENT_LOCKED": "The event is currently being worked on. Please wait until making further changes…",
+    "DELETION_FAILURE": "Event deletion failed",
+    "DELETION_FAILURE_DESCRIPTION": "Please try again later…",
+    "RESULT_HEADING": "Results {{range.begin}}-{{range.end}} of {{total}}",
+    "CONFIRM_DELETION": "Really delete this event?",
+    "COPY_TO_SERIES": "Copy event to series",
+    "SELECT_COPY_TARGET": "Select destination series",
+    "COPY": "Copy",
+    "COPY_IN_PROGRESS": "Starting copy…",
+    "CREATOR": "by {{creator}}"
+  },
+  "EVENTS": {
+    "EVENTS": {
+      "DETAILS": {
+        "METADATA": {
+          "LANGUAGE": "Language",
+          "LICENSE": "License",
+          "PRESENTERS": "Presenter(s)",
+          "TITLE": "Title"
+        }
+      }
+    }
+  }
+}

--- a/modules/lti/src/i18n/lang-de_DE.json
+++ b/modules/lti/src/i18n/lang-de_DE.json
@@ -1,0 +1,58 @@
+{
+  "LTI": {
+    "ERROR_LOADING_METADATA": "Error loading event metadata. Please try again later.",
+    "SERIES_TITLE": "View Series",
+    "UPLOAD_TITLE": "Upload event",
+    "LOADING": "Loading…",
+    "NEW_UPLOAD": "Upload new event",
+    "EDIT_UPLOAD": "Edit event",
+    "CURRENT_JOBS": "Today's jobs",
+    "PRESENTER": "Presenter",
+    "PRESENTER_DESCRIPTION": "Video file for the presenter track",
+    "VIDEOFILE": "Videofile",
+    "VIDEOFILE_DESCRIPTION": "Video file for upload",
+    "CAPTION": "Captions",
+    "CAPTION_DESCRIPTION": "Caption file in VTT format",
+    "UPLOAD": "Upload",
+    "UPLOADING": "Uploading",
+    "EDIT": "Save",
+    "EDIT_TITLE": "Edit event",
+    "NO_OPTION_SELECTED": "No option selected",
+    "EDITING": "Saving…",
+    "SELECT_OPTION": "Select option",
+    "JOB_TITLE": "Title",
+    "JOB_STATUS": "Status",
+    "UPLOAD_SUCCESS": "Upload succeeded!",
+    "UPLOAD_FAILURE": "Upload failed!",
+    "UPLOAD_FAILURE_DESCRIPTION": "Please try again later.",
+    "EDIT_SUCCESS": "Edit succeeded, beginning republishing.",
+    "EDIT_FAILURE": "Edit failed!",
+    "COPY_SUCCESS": "Copying started…",
+    "COPY_SUCCESS_DESCRIPTION": "Please wait a moment…",
+    "GENERIC_ERROR": "Error: {{message}}",
+    "DELETION_SUCCESS": "Event deletion successful",
+    "DELETION_SUCCESS_DESCRIPTION": "The event will be removed from the list in a few moments…",
+    "EVENT_LOCKED": "The event is currently being worked on. Please wait until making further changes…",
+    "DELETION_FAILURE": "Event deletion failed",
+    "DELETION_FAILURE_DESCRIPTION": "Please try again later…",
+    "RESULT_HEADING": "Ergebnisse {{range.begin}}-{{range.end}} von {{total}}",
+    "CONFIRM_DELETION": "Really delete this event?",
+    "COPY_TO_SERIES": "Copy event to series",
+    "SELECT_COPY_TARGET": "Select destination series",
+    "COPY": "Copy",
+    "COPY_IN_PROGRESS": "Starting copy…",
+    "CREATOR": "by {{creator}}"
+  },
+  "EVENTS": {
+    "EVENTS": {
+      "DETAILS": {
+        "METADATA": {
+          "LANGUAGE": "Language",
+          "LICENSE": "License",
+          "PRESENTERS": "Presenter(s)",
+          "TITLE": "Title"
+        }
+      }
+    }
+  }
+}

--- a/modules/lti/src/i18n/lang-el_GR.json
+++ b/modules/lti/src/i18n/lang-el_GR.json
@@ -1,0 +1,58 @@
+{
+  "LTI": {
+    "ERROR_LOADING_METADATA": "Error loading event metadata. Please try again later.",
+    "SERIES_TITLE": "View Series",
+    "UPLOAD_TITLE": "Upload event",
+    "LOADING": "Loading…",
+    "NEW_UPLOAD": "Upload new event",
+    "EDIT_UPLOAD": "Edit event",
+    "CURRENT_JOBS": "Today's jobs",
+    "PRESENTER": "Presenter",
+    "PRESENTER_DESCRIPTION": "Video file for the presenter track",
+    "VIDEOFILE": "Videofile",
+    "VIDEOFILE_DESCRIPTION": "Video file for upload",
+    "CAPTION": "Captions",
+    "CAPTION_DESCRIPTION": "Caption file in VTT format",
+    "UPLOAD": "Upload",
+    "UPLOADING": "Uploading",
+    "EDIT": "Save",
+    "EDIT_TITLE": "Edit event",
+    "NO_OPTION_SELECTED": "No option selected",
+    "EDITING": "Saving…",
+    "SELECT_OPTION": "Select option",
+    "JOB_TITLE": "Title",
+    "JOB_STATUS": "Status",
+    "UPLOAD_SUCCESS": "Upload succeeded!",
+    "UPLOAD_FAILURE": "Upload failed!",
+    "UPLOAD_FAILURE_DESCRIPTION": "Please try again later.",
+    "EDIT_SUCCESS": "Edit succeeded, beginning republishing.",
+    "EDIT_FAILURE": "Edit failed!",
+    "COPY_SUCCESS": "Copying started…",
+    "COPY_SUCCESS_DESCRIPTION": "Please wait a moment…",
+    "GENERIC_ERROR": "Error: {{message}}",
+    "DELETION_SUCCESS": "Event deletion successful",
+    "DELETION_SUCCESS_DESCRIPTION": "The event will be removed from the list in a few moments…",
+    "EVENT_LOCKED": "The event is currently being worked on. Please wait until making further changes…",
+    "DELETION_FAILURE": "Event deletion failed",
+    "DELETION_FAILURE_DESCRIPTION": "Please try again later…",
+    "RESULT_HEADING": "Results {{range.begin}}-{{range.end}} of {{total}}",
+    "CONFIRM_DELETION": "Really delete this event?",
+    "COPY_TO_SERIES": "Copy event to series",
+    "SELECT_COPY_TARGET": "Select destination series",
+    "COPY": "Copy",
+    "COPY_IN_PROGRESS": "Starting copy…",
+    "CREATOR": "by {{creator}}"
+  },
+  "EVENTS": {
+    "EVENTS": {
+      "DETAILS": {
+        "METADATA": {
+          "LANGUAGE": "Language",
+          "LICENSE": "License",
+          "PRESENTERS": "Presenter(s)",
+          "TITLE": "Title"
+        }
+      }
+    }
+  }
+}

--- a/modules/lti/src/i18n/lang-en_GB.json
+++ b/modules/lti/src/i18n/lang-en_GB.json
@@ -1,0 +1,58 @@
+{
+  "LTI": {
+    "ERROR_LOADING_METADATA": "Error loading event metadata. Please try again later.",
+    "SERIES_TITLE": "View Series",
+    "UPLOAD_TITLE": "Upload event",
+    "LOADING": "Loading…",
+    "NEW_UPLOAD": "Upload new event",
+    "EDIT_UPLOAD": "Edit event",
+    "CURRENT_JOBS": "Today's jobs",
+    "PRESENTER": "Presenter",
+    "PRESENTER_DESCRIPTION": "Video file for the presenter track",
+    "VIDEOFILE": "Videofile",
+    "VIDEOFILE_DESCRIPTION": "Video file for upload",
+    "CAPTION": "Captions",
+    "CAPTION_DESCRIPTION": "Caption file in VTT format",
+    "UPLOAD": "Upload",
+    "UPLOADING": "Uploading",
+    "EDIT": "Save",
+    "EDIT_TITLE": "Edit event",
+    "NO_OPTION_SELECTED": "No option selected",
+    "EDITING": "Saving…",
+    "SELECT_OPTION": "Select option",
+    "JOB_TITLE": "Title",
+    "JOB_STATUS": "Status",
+    "UPLOAD_SUCCESS": "Upload succeeded!",
+    "UPLOAD_FAILURE": "Upload failed!",
+    "UPLOAD_FAILURE_DESCRIPTION": "Please try again later.",
+    "EDIT_SUCCESS": "Edit succeeded, beginning republishing.",
+    "EDIT_FAILURE": "Edit failed!",
+    "COPY_SUCCESS": "Copying started…",
+    "COPY_SUCCESS_DESCRIPTION": "Please wait a moment…",
+    "GENERIC_ERROR": "Error: {{message}}",
+    "DELETION_SUCCESS": "Event deletion successful",
+    "DELETION_SUCCESS_DESCRIPTION": "The event will be removed from the list in a few moments…",
+    "EVENT_LOCKED": "The event is currently being worked on. Please wait until making further changes…",
+    "DELETION_FAILURE": "Event deletion failed",
+    "DELETION_FAILURE_DESCRIPTION": "Please try again later…",
+    "RESULT_HEADING": "Results {{range.begin}}-{{range.end}} of {{total}}",
+    "CONFIRM_DELETION": "Really delete this event?",
+    "COPY_TO_SERIES": "Copy event to series",
+    "SELECT_COPY_TARGET": "Select destination series",
+    "COPY": "Copy",
+    "COPY_IN_PROGRESS": "Starting copy…",
+    "CREATOR": "by {{creator}}"
+  },
+  "EVENTS": {
+    "EVENTS": {
+      "DETAILS": {
+        "METADATA": {
+          "LANGUAGE": "Language",
+          "LICENSE": "License",
+          "PRESENTERS": "Presenter(s)",
+          "TITLE": "Title"
+        }
+      }
+    }
+  }
+}

--- a/modules/lti/src/i18n/lang-en_US.json
+++ b/modules/lti/src/i18n/lang-en_US.json
@@ -1,0 +1,58 @@
+{
+  "LTI": {
+    "ERROR_LOADING_METADATA": "Error loading event metadata. Please try again later.",
+    "SERIES_TITLE": "View Series",
+    "UPLOAD_TITLE": "Upload event",
+    "LOADING": "Loading…",
+    "NEW_UPLOAD": "Upload new event",
+    "EDIT_UPLOAD": "Edit event",
+    "CURRENT_JOBS": "Today's jobs",
+    "PRESENTER": "Presenter",
+    "PRESENTER_DESCRIPTION": "Video file for the presenter track",
+    "VIDEOFILE": "Videofile",
+    "VIDEOFILE_DESCRIPTION": "Video file for upload",
+    "CAPTION": "Captions",
+    "CAPTION_DESCRIPTION": "Caption file in VTT format",
+    "UPLOAD": "Upload",
+    "UPLOADING": "Uploading",
+    "EDIT": "Save",
+    "EDIT_TITLE": "Edit event",
+    "NO_OPTION_SELECTED": "No option selected",
+    "EDITING": "Saving…",
+    "SELECT_OPTION": "Select option",
+    "JOB_TITLE": "Title",
+    "JOB_STATUS": "Status",
+    "UPLOAD_SUCCESS": "Upload succeeded!",
+    "UPLOAD_FAILURE": "Upload failed!",
+    "UPLOAD_FAILURE_DESCRIPTION": "Please try again later.",
+    "EDIT_SUCCESS": "Edit succeeded, beginning republishing.",
+    "EDIT_FAILURE": "Edit failed!",
+    "COPY_SUCCESS": "Copying started…",
+    "COPY_SUCCESS_DESCRIPTION": "Please wait a moment…",
+    "GENERIC_ERROR": "Error: {{message}}",
+    "DELETION_SUCCESS": "Event deletion successful",
+    "DELETION_SUCCESS_DESCRIPTION": "The event will be removed from the list in a few moments…",
+    "EVENT_LOCKED": "The event is currently being worked on. Please wait until making further changes…",
+    "DELETION_FAILURE": "Event deletion failed",
+    "DELETION_FAILURE_DESCRIPTION": "Please try again later…",
+    "RESULT_HEADING": "Results {{range.begin}}-{{range.end}} of {{total}}",
+    "CONFIRM_DELETION": "Really delete this event?",
+    "COPY_TO_SERIES": "Copy event to series",
+    "SELECT_COPY_TARGET": "Select destination series",
+    "COPY": "Copy",
+    "COPY_IN_PROGRESS": "Starting copy…",
+    "CREATOR": "by {{creator}}"
+  },
+  "EVENTS": {
+    "EVENTS": {
+      "DETAILS": {
+        "METADATA": {
+          "LANGUAGE": "Language",
+          "LICENSE": "License",
+          "PRESENTERS": "Presenter(s)",
+          "TITLE": "Title"
+        }
+      }
+    }
+  }
+}

--- a/modules/lti/src/i18n/lang-es_ES.json
+++ b/modules/lti/src/i18n/lang-es_ES.json
@@ -1,0 +1,58 @@
+{
+  "LTI": {
+    "ERROR_LOADING_METADATA": "Error loading event metadata. Please try again later.",
+    "SERIES_TITLE": "View Series",
+    "UPLOAD_TITLE": "Upload event",
+    "LOADING": "Loading…",
+    "NEW_UPLOAD": "Upload new event",
+    "EDIT_UPLOAD": "Edit event",
+    "CURRENT_JOBS": "Today's jobs",
+    "PRESENTER": "Presenter",
+    "PRESENTER_DESCRIPTION": "Video file for the presenter track",
+    "VIDEOFILE": "Videofile",
+    "VIDEOFILE_DESCRIPTION": "Video file for upload",
+    "CAPTION": "Captions",
+    "CAPTION_DESCRIPTION": "Caption file in VTT format",
+    "UPLOAD": "Upload",
+    "UPLOADING": "Uploading",
+    "EDIT": "Save",
+    "EDIT_TITLE": "Edit event",
+    "NO_OPTION_SELECTED": "No option selected",
+    "EDITING": "Saving…",
+    "SELECT_OPTION": "Select option",
+    "JOB_TITLE": "Title",
+    "JOB_STATUS": "Status",
+    "UPLOAD_SUCCESS": "Upload succeeded!",
+    "UPLOAD_FAILURE": "Upload failed!",
+    "UPLOAD_FAILURE_DESCRIPTION": "Please try again later.",
+    "EDIT_SUCCESS": "Edit succeeded, beginning republishing.",
+    "EDIT_FAILURE": "Edit failed!",
+    "COPY_SUCCESS": "Copying started…",
+    "COPY_SUCCESS_DESCRIPTION": "Please wait a moment…",
+    "GENERIC_ERROR": "Error: {{message}}",
+    "DELETION_SUCCESS": "Event deletion successful",
+    "DELETION_SUCCESS_DESCRIPTION": "The event will be removed from the list in a few moments…",
+    "EVENT_LOCKED": "The event is currently being worked on. Please wait until making further changes…",
+    "DELETION_FAILURE": "Event deletion failed",
+    "DELETION_FAILURE_DESCRIPTION": "Please try again later…",
+    "RESULT_HEADING": "Results {{range.begin}}-{{range.end}} of {{total}}",
+    "CONFIRM_DELETION": "Really delete this event?",
+    "COPY_TO_SERIES": "Copy event to series",
+    "SELECT_COPY_TARGET": "Select destination series",
+    "COPY": "Copy",
+    "COPY_IN_PROGRESS": "Starting copy…",
+    "CREATOR": "by {{creator}}"
+  },
+  "EVENTS": {
+    "EVENTS": {
+      "DETAILS": {
+        "METADATA": {
+          "LANGUAGE": "Language",
+          "LICENSE": "License",
+          "PRESENTERS": "Presenter(s)",
+          "TITLE": "Title"
+        }
+      }
+    }
+  }
+}

--- a/modules/lti/src/i18n/lang-fr_FR.json
+++ b/modules/lti/src/i18n/lang-fr_FR.json
@@ -1,0 +1,58 @@
+{
+  "LTI": {
+    "ERROR_LOADING_METADATA": "Error loading event metadata. Please try again later.",
+    "SERIES_TITLE": "View Series",
+    "UPLOAD_TITLE": "Upload event",
+    "LOADING": "Loading…",
+    "NEW_UPLOAD": "Upload new event",
+    "EDIT_UPLOAD": "Edit event",
+    "CURRENT_JOBS": "Today's jobs",
+    "PRESENTER": "Presenter",
+    "PRESENTER_DESCRIPTION": "Video file for the presenter track",
+    "VIDEOFILE": "Videofile",
+    "VIDEOFILE_DESCRIPTION": "Video file for upload",
+    "CAPTION": "Captions",
+    "CAPTION_DESCRIPTION": "Caption file in VTT format",
+    "UPLOAD": "Upload",
+    "UPLOADING": "Uploading",
+    "EDIT": "Save",
+    "EDIT_TITLE": "Edit event",
+    "NO_OPTION_SELECTED": "No option selected",
+    "EDITING": "Saving…",
+    "SELECT_OPTION": "Select option",
+    "JOB_TITLE": "Title",
+    "JOB_STATUS": "Status",
+    "UPLOAD_SUCCESS": "Upload succeeded!",
+    "UPLOAD_FAILURE": "Upload failed!",
+    "UPLOAD_FAILURE_DESCRIPTION": "Please try again later.",
+    "EDIT_SUCCESS": "Edit succeeded, beginning republishing.",
+    "EDIT_FAILURE": "Edit failed!",
+    "COPY_SUCCESS": "Copying started…",
+    "COPY_SUCCESS_DESCRIPTION": "Please wait a moment…",
+    "GENERIC_ERROR": "Error: {{message}}",
+    "DELETION_SUCCESS": "Event deletion successful",
+    "DELETION_SUCCESS_DESCRIPTION": "The event will be removed from the list in a few moments…",
+    "EVENT_LOCKED": "The event is currently being worked on. Please wait until making further changes…",
+    "DELETION_FAILURE": "Event deletion failed",
+    "DELETION_FAILURE_DESCRIPTION": "Please try again later…",
+    "RESULT_HEADING": "Results {{range.begin}}-{{range.end}} of {{total}}",
+    "CONFIRM_DELETION": "Really delete this event?",
+    "COPY_TO_SERIES": "Copy event to series",
+    "SELECT_COPY_TARGET": "Select destination series",
+    "COPY": "Copy",
+    "COPY_IN_PROGRESS": "Starting copy…",
+    "CREATOR": "by {{creator}}"
+  },
+  "EVENTS": {
+    "EVENTS": {
+      "DETAILS": {
+        "METADATA": {
+          "LANGUAGE": "Language",
+          "LICENSE": "License",
+          "PRESENTERS": "Presenter(s)",
+          "TITLE": "Title"
+        }
+      }
+    }
+  }
+}

--- a/modules/lti/src/i18n/lang-gl_ES.json
+++ b/modules/lti/src/i18n/lang-gl_ES.json
@@ -1,0 +1,58 @@
+{
+  "LTI": {
+    "ERROR_LOADING_METADATA": "Error loading event metadata. Please try again later.",
+    "SERIES_TITLE": "View Series",
+    "UPLOAD_TITLE": "Upload event",
+    "LOADING": "Loading…",
+    "NEW_UPLOAD": "Upload new event",
+    "EDIT_UPLOAD": "Edit event",
+    "CURRENT_JOBS": "Today's jobs",
+    "PRESENTER": "Presenter",
+    "PRESENTER_DESCRIPTION": "Video file for the presenter track",
+    "VIDEOFILE": "Videofile",
+    "VIDEOFILE_DESCRIPTION": "Video file for upload",
+    "CAPTION": "Captions",
+    "CAPTION_DESCRIPTION": "Caption file in VTT format",
+    "UPLOAD": "Upload",
+    "UPLOADING": "Uploading",
+    "EDIT": "Save",
+    "EDIT_TITLE": "Edit event",
+    "NO_OPTION_SELECTED": "No option selected",
+    "EDITING": "Saving…",
+    "SELECT_OPTION": "Select option",
+    "JOB_TITLE": "Title",
+    "JOB_STATUS": "Status",
+    "UPLOAD_SUCCESS": "Upload succeeded!",
+    "UPLOAD_FAILURE": "Upload failed!",
+    "UPLOAD_FAILURE_DESCRIPTION": "Please try again later.",
+    "EDIT_SUCCESS": "Edit succeeded, beginning republishing.",
+    "EDIT_FAILURE": "Edit failed!",
+    "COPY_SUCCESS": "Copying started…",
+    "COPY_SUCCESS_DESCRIPTION": "Please wait a moment…",
+    "GENERIC_ERROR": "Error: {{message}}",
+    "DELETION_SUCCESS": "Event deletion successful",
+    "DELETION_SUCCESS_DESCRIPTION": "The event will be removed from the list in a few moments…",
+    "EVENT_LOCKED": "The event is currently being worked on. Please wait until making further changes…",
+    "DELETION_FAILURE": "Event deletion failed",
+    "DELETION_FAILURE_DESCRIPTION": "Please try again later…",
+    "RESULT_HEADING": "Results {{range.begin}}-{{range.end}} of {{total}}",
+    "CONFIRM_DELETION": "Really delete this event?",
+    "COPY_TO_SERIES": "Copy event to series",
+    "SELECT_COPY_TARGET": "Select destination series",
+    "COPY": "Copy",
+    "COPY_IN_PROGRESS": "Starting copy…",
+    "CREATOR": "by {{creator}}"
+  },
+  "EVENTS": {
+    "EVENTS": {
+      "DETAILS": {
+        "METADATA": {
+          "LANGUAGE": "Language",
+          "LICENSE": "License",
+          "PRESENTERS": "Presenter(s)",
+          "TITLE": "Title"
+        }
+      }
+    }
+  }
+}

--- a/modules/lti/src/i18n/lang-he_IL.json
+++ b/modules/lti/src/i18n/lang-he_IL.json
@@ -1,0 +1,58 @@
+{
+  "LTI": {
+    "ERROR_LOADING_METADATA": "Error loading event metadata. Please try again later.",
+    "SERIES_TITLE": "View Series",
+    "UPLOAD_TITLE": "Upload event",
+    "LOADING": "Loading…",
+    "NEW_UPLOAD": "Upload new event",
+    "EDIT_UPLOAD": "Edit event",
+    "CURRENT_JOBS": "Today's jobs",
+    "PRESENTER": "Presenter",
+    "PRESENTER_DESCRIPTION": "Video file for the presenter track",
+    "VIDEOFILE": "Videofile",
+    "VIDEOFILE_DESCRIPTION": "Video file for upload",
+    "CAPTION": "Captions",
+    "CAPTION_DESCRIPTION": "Caption file in VTT format",
+    "UPLOAD": "Upload",
+    "UPLOADING": "Uploading",
+    "EDIT": "Save",
+    "EDIT_TITLE": "Edit event",
+    "NO_OPTION_SELECTED": "No option selected",
+    "EDITING": "Saving…",
+    "SELECT_OPTION": "Select option",
+    "JOB_TITLE": "Title",
+    "JOB_STATUS": "Status",
+    "UPLOAD_SUCCESS": "Upload succeeded!",
+    "UPLOAD_FAILURE": "Upload failed!",
+    "UPLOAD_FAILURE_DESCRIPTION": "Please try again later.",
+    "EDIT_SUCCESS": "Edit succeeded, beginning republishing.",
+    "EDIT_FAILURE": "Edit failed!",
+    "COPY_SUCCESS": "Copying started…",
+    "COPY_SUCCESS_DESCRIPTION": "Please wait a moment…",
+    "GENERIC_ERROR": "Error: {{message}}",
+    "DELETION_SUCCESS": "Event deletion successful",
+    "DELETION_SUCCESS_DESCRIPTION": "The event will be removed from the list in a few moments…",
+    "EVENT_LOCKED": "The event is currently being worked on. Please wait until making further changes…",
+    "DELETION_FAILURE": "Event deletion failed",
+    "DELETION_FAILURE_DESCRIPTION": "Please try again later…",
+    "RESULT_HEADING": "Results {{range.begin}}-{{range.end}} of {{total}}",
+    "CONFIRM_DELETION": "Really delete this event?",
+    "COPY_TO_SERIES": "Copy event to series",
+    "SELECT_COPY_TARGET": "Select destination series",
+    "COPY": "Copy",
+    "COPY_IN_PROGRESS": "Starting copy…",
+    "CREATOR": "by {{creator}}"
+  },
+  "EVENTS": {
+    "EVENTS": {
+      "DETAILS": {
+        "METADATA": {
+          "LANGUAGE": "Language",
+          "LICENSE": "License",
+          "PRESENTERS": "Presenter(s)",
+          "TITLE": "Title"
+        }
+      }
+    }
+  }
+}

--- a/modules/lti/src/i18n/lang-it_IT.json
+++ b/modules/lti/src/i18n/lang-it_IT.json
@@ -1,0 +1,58 @@
+{
+  "LTI": {
+    "ERROR_LOADING_METADATA": "Error loading event metadata. Please try again later.",
+    "SERIES_TITLE": "View Series",
+    "UPLOAD_TITLE": "Upload event",
+    "LOADING": "Loading…",
+    "NEW_UPLOAD": "Upload new event",
+    "EDIT_UPLOAD": "Edit event",
+    "CURRENT_JOBS": "Today's jobs",
+    "PRESENTER": "Presenter",
+    "PRESENTER_DESCRIPTION": "Video file for the presenter track",
+    "VIDEOFILE": "Videofile",
+    "VIDEOFILE_DESCRIPTION": "Video file for upload",
+    "CAPTION": "Captions",
+    "CAPTION_DESCRIPTION": "Caption file in VTT format",
+    "UPLOAD": "Upload",
+    "UPLOADING": "Uploading",
+    "EDIT": "Save",
+    "EDIT_TITLE": "Edit event",
+    "NO_OPTION_SELECTED": "No option selected",
+    "EDITING": "Saving…",
+    "SELECT_OPTION": "Select option",
+    "JOB_TITLE": "Title",
+    "JOB_STATUS": "Status",
+    "UPLOAD_SUCCESS": "Upload succeeded!",
+    "UPLOAD_FAILURE": "Upload failed!",
+    "UPLOAD_FAILURE_DESCRIPTION": "Please try again later.",
+    "EDIT_SUCCESS": "Edit succeeded, beginning republishing.",
+    "EDIT_FAILURE": "Edit failed!",
+    "COPY_SUCCESS": "Copying started…",
+    "COPY_SUCCESS_DESCRIPTION": "Please wait a moment…",
+    "GENERIC_ERROR": "Error: {{message}}",
+    "DELETION_SUCCESS": "Event deletion successful",
+    "DELETION_SUCCESS_DESCRIPTION": "The event will be removed from the list in a few moments…",
+    "EVENT_LOCKED": "The event is currently being worked on. Please wait until making further changes…",
+    "DELETION_FAILURE": "Event deletion failed",
+    "DELETION_FAILURE_DESCRIPTION": "Please try again later…",
+    "RESULT_HEADING": "Results {{range.begin}}-{{range.end}} of {{total}}",
+    "CONFIRM_DELETION": "Really delete this event?",
+    "COPY_TO_SERIES": "Copy event to series",
+    "SELECT_COPY_TARGET": "Select destination series",
+    "COPY": "Copy",
+    "COPY_IN_PROGRESS": "Starting copy…",
+    "CREATOR": "by {{creator}}"
+  },
+  "EVENTS": {
+    "EVENTS": {
+      "DETAILS": {
+        "METADATA": {
+          "LANGUAGE": "Language",
+          "LICENSE": "License",
+          "PRESENTERS": "Presenter(s)",
+          "TITLE": "Title"
+        }
+      }
+    }
+  }
+}

--- a/modules/lti/src/i18n/lang-nl_NL.json
+++ b/modules/lti/src/i18n/lang-nl_NL.json
@@ -1,0 +1,58 @@
+{
+  "LTI": {
+    "ERROR_LOADING_METADATA": "Error loading event metadata. Please try again later.",
+    "SERIES_TITLE": "View Series",
+    "UPLOAD_TITLE": "Upload event",
+    "LOADING": "Loading…",
+    "NEW_UPLOAD": "Upload new event",
+    "EDIT_UPLOAD": "Edit event",
+    "CURRENT_JOBS": "Today's jobs",
+    "PRESENTER": "Presenter",
+    "PRESENTER_DESCRIPTION": "Video file for the presenter track",
+    "VIDEOFILE": "Videofile",
+    "VIDEOFILE_DESCRIPTION": "Video file for upload",
+    "CAPTION": "Captions",
+    "CAPTION_DESCRIPTION": "Caption file in VTT format",
+    "UPLOAD": "Upload",
+    "UPLOADING": "Uploading",
+    "EDIT": "Save",
+    "EDIT_TITLE": "Edit event",
+    "NO_OPTION_SELECTED": "No option selected",
+    "EDITING": "Saving…",
+    "SELECT_OPTION": "Select option",
+    "JOB_TITLE": "Title",
+    "JOB_STATUS": "Status",
+    "UPLOAD_SUCCESS": "Upload succeeded!",
+    "UPLOAD_FAILURE": "Upload failed!",
+    "UPLOAD_FAILURE_DESCRIPTION": "Please try again later.",
+    "EDIT_SUCCESS": "Edit succeeded, beginning republishing.",
+    "EDIT_FAILURE": "Edit failed!",
+    "COPY_SUCCESS": "Copying started…",
+    "COPY_SUCCESS_DESCRIPTION": "Please wait a moment…",
+    "GENERIC_ERROR": "Error: {{message}}",
+    "DELETION_SUCCESS": "Event deletion successful",
+    "DELETION_SUCCESS_DESCRIPTION": "The event will be removed from the list in a few moments…",
+    "EVENT_LOCKED": "The event is currently being worked on. Please wait until making further changes…",
+    "DELETION_FAILURE": "Event deletion failed",
+    "DELETION_FAILURE_DESCRIPTION": "Please try again later…",
+    "RESULT_HEADING": "Results {{range.begin}}-{{range.end}} of {{total}}",
+    "CONFIRM_DELETION": "Really delete this event?",
+    "COPY_TO_SERIES": "Copy event to series",
+    "SELECT_COPY_TARGET": "Select destination series",
+    "COPY": "Copy",
+    "COPY_IN_PROGRESS": "Starting copy…",
+    "CREATOR": "by {{creator}}"
+  },
+  "EVENTS": {
+    "EVENTS": {
+      "DETAILS": {
+        "METADATA": {
+          "LANGUAGE": "Language",
+          "LICENSE": "License",
+          "PRESENTERS": "Presenter(s)",
+          "TITLE": "Title"
+        }
+      }
+    }
+  }
+}

--- a/modules/lti/src/i18n/lang-pl_PL.json
+++ b/modules/lti/src/i18n/lang-pl_PL.json
@@ -1,0 +1,58 @@
+{
+  "LTI": {
+    "ERROR_LOADING_METADATA": "Error loading event metadata. Please try again later.",
+    "SERIES_TITLE": "View Series",
+    "UPLOAD_TITLE": "Upload event",
+    "LOADING": "Loading…",
+    "NEW_UPLOAD": "Upload new event",
+    "EDIT_UPLOAD": "Edit event",
+    "CURRENT_JOBS": "Today's jobs",
+    "PRESENTER": "Presenter",
+    "PRESENTER_DESCRIPTION": "Video file for the presenter track",
+    "VIDEOFILE": "Videofile",
+    "VIDEOFILE_DESCRIPTION": "Video file for upload",
+    "CAPTION": "Captions",
+    "CAPTION_DESCRIPTION": "Caption file in VTT format",
+    "UPLOAD": "Upload",
+    "UPLOADING": "Uploading",
+    "EDIT": "Save",
+    "EDIT_TITLE": "Edit event",
+    "NO_OPTION_SELECTED": "No option selected",
+    "EDITING": "Saving…",
+    "SELECT_OPTION": "Select option",
+    "JOB_TITLE": "Title",
+    "JOB_STATUS": "Status",
+    "UPLOAD_SUCCESS": "Upload succeeded!",
+    "UPLOAD_FAILURE": "Upload failed!",
+    "UPLOAD_FAILURE_DESCRIPTION": "Please try again later.",
+    "EDIT_SUCCESS": "Edit succeeded, beginning republishing.",
+    "EDIT_FAILURE": "Edit failed!",
+    "COPY_SUCCESS": "Copying started…",
+    "COPY_SUCCESS_DESCRIPTION": "Please wait a moment…",
+    "GENERIC_ERROR": "Error: {{message}}",
+    "DELETION_SUCCESS": "Event deletion successful",
+    "DELETION_SUCCESS_DESCRIPTION": "The event will be removed from the list in a few moments…",
+    "EVENT_LOCKED": "The event is currently being worked on. Please wait until making further changes…",
+    "DELETION_FAILURE": "Event deletion failed",
+    "DELETION_FAILURE_DESCRIPTION": "Please try again later…",
+    "RESULT_HEADING": "Results {{range.begin}}-{{range.end}} of {{total}}",
+    "CONFIRM_DELETION": "Really delete this event?",
+    "COPY_TO_SERIES": "Copy event to series",
+    "SELECT_COPY_TARGET": "Select destination series",
+    "COPY": "Copy",
+    "COPY_IN_PROGRESS": "Starting copy…",
+    "CREATOR": "by {{creator}}"
+  },
+  "EVENTS": {
+    "EVENTS": {
+      "DETAILS": {
+        "METADATA": {
+          "LANGUAGE": "Language",
+          "LICENSE": "License",
+          "PRESENTERS": "Presenter(s)",
+          "TITLE": "Title"
+        }
+      }
+    }
+  }
+}

--- a/modules/lti/src/i18n/lang-sl_SI.json
+++ b/modules/lti/src/i18n/lang-sl_SI.json
@@ -1,0 +1,58 @@
+{
+  "LTI": {
+    "ERROR_LOADING_METADATA": "Error loading event metadata. Please try again later.",
+    "SERIES_TITLE": "View Series",
+    "UPLOAD_TITLE": "Upload event",
+    "LOADING": "Loading…",
+    "NEW_UPLOAD": "Upload new event",
+    "EDIT_UPLOAD": "Edit event",
+    "CURRENT_JOBS": "Today's jobs",
+    "PRESENTER": "Presenter",
+    "PRESENTER_DESCRIPTION": "Video file for the presenter track",
+    "VIDEOFILE": "Videofile",
+    "VIDEOFILE_DESCRIPTION": "Video file for upload",
+    "CAPTION": "Captions",
+    "CAPTION_DESCRIPTION": "Caption file in VTT format",
+    "UPLOAD": "Upload",
+    "UPLOADING": "Uploading",
+    "EDIT": "Save",
+    "EDIT_TITLE": "Edit event",
+    "NO_OPTION_SELECTED": "No option selected",
+    "EDITING": "Saving…",
+    "SELECT_OPTION": "Select option",
+    "JOB_TITLE": "Title",
+    "JOB_STATUS": "Status",
+    "UPLOAD_SUCCESS": "Upload succeeded!",
+    "UPLOAD_FAILURE": "Upload failed!",
+    "UPLOAD_FAILURE_DESCRIPTION": "Please try again later.",
+    "EDIT_SUCCESS": "Edit succeeded, beginning republishing.",
+    "EDIT_FAILURE": "Edit failed!",
+    "COPY_SUCCESS": "Copying started…",
+    "COPY_SUCCESS_DESCRIPTION": "Please wait a moment…",
+    "GENERIC_ERROR": "Error: {{message}}",
+    "DELETION_SUCCESS": "Event deletion successful",
+    "DELETION_SUCCESS_DESCRIPTION": "The event will be removed from the list in a few moments…",
+    "EVENT_LOCKED": "The event is currently being worked on. Please wait until making further changes…",
+    "DELETION_FAILURE": "Event deletion failed",
+    "DELETION_FAILURE_DESCRIPTION": "Please try again later…",
+    "RESULT_HEADING": "Results {{range.begin}}-{{range.end}} of {{total}}",
+    "CONFIRM_DELETION": "Really delete this event?",
+    "COPY_TO_SERIES": "Copy event to series",
+    "SELECT_COPY_TARGET": "Select destination series",
+    "COPY": "Copy",
+    "COPY_IN_PROGRESS": "Starting copy…",
+    "CREATOR": "by {{creator}}"
+  },
+  "EVENTS": {
+    "EVENTS": {
+      "DETAILS": {
+        "METADATA": {
+          "LANGUAGE": "Language",
+          "LICENSE": "License",
+          "PRESENTERS": "Presenter(s)",
+          "TITLE": "Title"
+        }
+      }
+    }
+  }
+}

--- a/modules/lti/src/i18n/lang-sv_SE.json
+++ b/modules/lti/src/i18n/lang-sv_SE.json
@@ -1,0 +1,58 @@
+{
+  "LTI": {
+    "ERROR_LOADING_METADATA": "Error loading event metadata. Please try again later.",
+    "SERIES_TITLE": "View Series",
+    "UPLOAD_TITLE": "Upload event",
+    "LOADING": "Loading…",
+    "NEW_UPLOAD": "Upload new event",
+    "EDIT_UPLOAD": "Edit event",
+    "CURRENT_JOBS": "Today's jobs",
+    "PRESENTER": "Presenter",
+    "PRESENTER_DESCRIPTION": "Video file for the presenter track",
+    "VIDEOFILE": "Videofile",
+    "VIDEOFILE_DESCRIPTION": "Video file for upload",
+    "CAPTION": "Captions",
+    "CAPTION_DESCRIPTION": "Caption file in VTT format",
+    "UPLOAD": "Upload",
+    "UPLOADING": "Uploading",
+    "EDIT": "Save",
+    "EDIT_TITLE": "Edit event",
+    "NO_OPTION_SELECTED": "No option selected",
+    "EDITING": "Saving…",
+    "SELECT_OPTION": "Select option",
+    "JOB_TITLE": "Title",
+    "JOB_STATUS": "Status",
+    "UPLOAD_SUCCESS": "Upload succeeded!",
+    "UPLOAD_FAILURE": "Upload failed!",
+    "UPLOAD_FAILURE_DESCRIPTION": "Please try again later.",
+    "EDIT_SUCCESS": "Edit succeeded, beginning republishing.",
+    "EDIT_FAILURE": "Edit failed!",
+    "COPY_SUCCESS": "Copying started…",
+    "COPY_SUCCESS_DESCRIPTION": "Please wait a moment…",
+    "GENERIC_ERROR": "Error: {{message}}",
+    "DELETION_SUCCESS": "Event deletion successful",
+    "DELETION_SUCCESS_DESCRIPTION": "The event will be removed from the list in a few moments…",
+    "EVENT_LOCKED": "The event is currently being worked on. Please wait until making further changes…",
+    "DELETION_FAILURE": "Event deletion failed",
+    "DELETION_FAILURE_DESCRIPTION": "Please try again later…",
+    "RESULT_HEADING": "Results {{range.begin}}-{{range.end}} of {{total}}",
+    "CONFIRM_DELETION": "Really delete this event?",
+    "COPY_TO_SERIES": "Copy event to series",
+    "SELECT_COPY_TARGET": "Select destination series",
+    "COPY": "Copy",
+    "COPY_IN_PROGRESS": "Starting copy…",
+    "CREATOR": "by {{creator}}"
+  },
+  "EVENTS": {
+    "EVENTS": {
+      "DETAILS": {
+        "METADATA": {
+          "LANGUAGE": "Language",
+          "LICENSE": "License",
+          "PRESENTERS": "Presenter(s)",
+          "TITLE": "Title"
+        }
+      }
+    }
+  }
+}

--- a/modules/lti/src/i18n/lang-tr_TR.json
+++ b/modules/lti/src/i18n/lang-tr_TR.json
@@ -1,0 +1,58 @@
+{
+  "LTI": {
+    "ERROR_LOADING_METADATA": "Error loading event metadata. Please try again later.",
+    "SERIES_TITLE": "View Series",
+    "UPLOAD_TITLE": "Upload event",
+    "LOADING": "Loading…",
+    "NEW_UPLOAD": "Upload new event",
+    "EDIT_UPLOAD": "Edit event",
+    "CURRENT_JOBS": "Today's jobs",
+    "PRESENTER": "Presenter",
+    "PRESENTER_DESCRIPTION": "Video file for the presenter track",
+    "VIDEOFILE": "Videofile",
+    "VIDEOFILE_DESCRIPTION": "Video file for upload",
+    "CAPTION": "Captions",
+    "CAPTION_DESCRIPTION": "Caption file in VTT format",
+    "UPLOAD": "Upload",
+    "UPLOADING": "Uploading",
+    "EDIT": "Save",
+    "EDIT_TITLE": "Edit event",
+    "NO_OPTION_SELECTED": "No option selected",
+    "EDITING": "Saving…",
+    "SELECT_OPTION": "Select option",
+    "JOB_TITLE": "Title",
+    "JOB_STATUS": "Status",
+    "UPLOAD_SUCCESS": "Upload succeeded!",
+    "UPLOAD_FAILURE": "Upload failed!",
+    "UPLOAD_FAILURE_DESCRIPTION": "Please try again later.",
+    "EDIT_SUCCESS": "Edit succeeded, beginning republishing.",
+    "EDIT_FAILURE": "Edit failed!",
+    "COPY_SUCCESS": "Copying started…",
+    "COPY_SUCCESS_DESCRIPTION": "Please wait a moment…",
+    "GENERIC_ERROR": "Error: {{message}}",
+    "DELETION_SUCCESS": "Event deletion successful",
+    "DELETION_SUCCESS_DESCRIPTION": "The event will be removed from the list in a few moments…",
+    "EVENT_LOCKED": "The event is currently being worked on. Please wait until making further changes…",
+    "DELETION_FAILURE": "Event deletion failed",
+    "DELETION_FAILURE_DESCRIPTION": "Please try again later…",
+    "RESULT_HEADING": "Results {{range.begin}}-{{range.end}} of {{total}}",
+    "CONFIRM_DELETION": "Really delete this event?",
+    "COPY_TO_SERIES": "Copy event to series",
+    "SELECT_COPY_TARGET": "Select destination series",
+    "COPY": "Copy",
+    "COPY_IN_PROGRESS": "Starting copy…",
+    "CREATOR": "by {{creator}}"
+  },
+  "EVENTS": {
+    "EVENTS": {
+      "DETAILS": {
+        "METADATA": {
+          "LANGUAGE": "Language",
+          "LICENSE": "License",
+          "PRESENTERS": "Presenter(s)",
+          "TITLE": "Title"
+        }
+      }
+    }
+  }
+}

--- a/modules/lti/src/i18n/lang-zh_CN.json
+++ b/modules/lti/src/i18n/lang-zh_CN.json
@@ -1,0 +1,58 @@
+{
+  "LTI": {
+    "ERROR_LOADING_METADATA": "Error loading event metadata. Please try again later.",
+    "SERIES_TITLE": "View Series",
+    "UPLOAD_TITLE": "Upload event",
+    "LOADING": "Loading…",
+    "NEW_UPLOAD": "Upload new event",
+    "EDIT_UPLOAD": "Edit event",
+    "CURRENT_JOBS": "Today's jobs",
+    "PRESENTER": "Presenter",
+    "PRESENTER_DESCRIPTION": "Video file for the presenter track",
+    "VIDEOFILE": "Videofile",
+    "VIDEOFILE_DESCRIPTION": "Video file for upload",
+    "CAPTION": "Captions",
+    "CAPTION_DESCRIPTION": "Caption file in VTT format",
+    "UPLOAD": "Upload",
+    "UPLOADING": "Uploading",
+    "EDIT": "Save",
+    "EDIT_TITLE": "Edit event",
+    "NO_OPTION_SELECTED": "No option selected",
+    "EDITING": "Saving…",
+    "SELECT_OPTION": "Select option",
+    "JOB_TITLE": "Title",
+    "JOB_STATUS": "Status",
+    "UPLOAD_SUCCESS": "Upload succeeded!",
+    "UPLOAD_FAILURE": "Upload failed!",
+    "UPLOAD_FAILURE_DESCRIPTION": "Please try again later.",
+    "EDIT_SUCCESS": "Edit succeeded, beginning republishing.",
+    "EDIT_FAILURE": "Edit failed!",
+    "COPY_SUCCESS": "Copying started…",
+    "COPY_SUCCESS_DESCRIPTION": "Please wait a moment…",
+    "GENERIC_ERROR": "Error: {{message}}",
+    "DELETION_SUCCESS": "Event deletion successful",
+    "DELETION_SUCCESS_DESCRIPTION": "The event will be removed from the list in a few moments…",
+    "EVENT_LOCKED": "The event is currently being worked on. Please wait until making further changes…",
+    "DELETION_FAILURE": "Event deletion failed",
+    "DELETION_FAILURE_DESCRIPTION": "Please try again later…",
+    "RESULT_HEADING": "Results {{range.begin}}-{{range.end}} of {{total}}",
+    "CONFIRM_DELETION": "Really delete this event?",
+    "COPY_TO_SERIES": "Copy event to series",
+    "SELECT_COPY_TARGET": "Select destination series",
+    "COPY": "Copy",
+    "COPY_IN_PROGRESS": "Starting copy…",
+    "CREATOR": "by {{creator}}"
+  },
+  "EVENTS": {
+    "EVENTS": {
+      "DETAILS": {
+        "METADATA": {
+          "LANGUAGE": "Language",
+          "LICENSE": "License",
+          "PRESENTERS": "Presenter(s)",
+          "TITLE": "Title"
+        }
+      }
+    }
+  }
+}

--- a/modules/lti/src/i18n/lang-zh_TW.json
+++ b/modules/lti/src/i18n/lang-zh_TW.json
@@ -1,0 +1,58 @@
+{
+  "LTI": {
+    "ERROR_LOADING_METADATA": "Error loading event metadata. Please try again later.",
+    "SERIES_TITLE": "View Series",
+    "UPLOAD_TITLE": "Upload event",
+    "LOADING": "Loading…",
+    "NEW_UPLOAD": "Upload new event",
+    "EDIT_UPLOAD": "Edit event",
+    "CURRENT_JOBS": "Today's jobs",
+    "PRESENTER": "Presenter",
+    "PRESENTER_DESCRIPTION": "Video file for the presenter track",
+    "VIDEOFILE": "Videofile",
+    "VIDEOFILE_DESCRIPTION": "Video file for upload",
+    "CAPTION": "Captions",
+    "CAPTION_DESCRIPTION": "Caption file in VTT format",
+    "UPLOAD": "Upload",
+    "UPLOADING": "Uploading",
+    "EDIT": "Save",
+    "EDIT_TITLE": "Edit event",
+    "NO_OPTION_SELECTED": "No option selected",
+    "EDITING": "Saving…",
+    "SELECT_OPTION": "Select option",
+    "JOB_TITLE": "Title",
+    "JOB_STATUS": "Status",
+    "UPLOAD_SUCCESS": "Upload succeeded!",
+    "UPLOAD_FAILURE": "Upload failed!",
+    "UPLOAD_FAILURE_DESCRIPTION": "Please try again later.",
+    "EDIT_SUCCESS": "Edit succeeded, beginning republishing.",
+    "EDIT_FAILURE": "Edit failed!",
+    "COPY_SUCCESS": "Copying started…",
+    "COPY_SUCCESS_DESCRIPTION": "Please wait a moment…",
+    "GENERIC_ERROR": "Error: {{message}}",
+    "DELETION_SUCCESS": "Event deletion successful",
+    "DELETION_SUCCESS_DESCRIPTION": "The event will be removed from the list in a few moments…",
+    "EVENT_LOCKED": "The event is currently being worked on. Please wait until making further changes…",
+    "DELETION_FAILURE": "Event deletion failed",
+    "DELETION_FAILURE_DESCRIPTION": "Please try again later…",
+    "RESULT_HEADING": "Results {{range.begin}}-{{range.end}} of {{total}}",
+    "CONFIRM_DELETION": "Really delete this event?",
+    "COPY_TO_SERIES": "Copy event to series",
+    "SELECT_COPY_TARGET": "Select destination series",
+    "COPY": "Copy",
+    "COPY_IN_PROGRESS": "Starting copy…",
+    "CREATOR": "by {{creator}}"
+  },
+  "EVENTS": {
+    "EVENTS": {
+      "DETAILS": {
+        "METADATA": {
+          "LANGUAGE": "Language",
+          "LICENSE": "License",
+          "PRESENTERS": "Presenter(s)",
+          "TITLE": "Title"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The LTI tool was always a bit broken in the sense that it was copying internal translations from the admin interface with no check if they are actually valid or if they changed. This was always dangerous and could easily break but will now definitely break when we remove the old admin interface.

That is why this patch is finally transferring the relevant translation keys to the LTI module itself.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
