### PR TITLE
Fix incorrect language parameter for Whisper

### DIFF
--- a/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/WhisperEngine.java
+++ b/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/WhisperEngine.java
@@ -106,6 +106,9 @@ public class WhisperEngine implements SpeechToTextEngine {
   /** Map to get ISO 639 language code for language name in English */
   private Map<String, String> languageMap = new HashMap<>();
 
+  /** Map to get ISO 639 language code for 3-letter language code */
+  private Map<String, String> languageISO3to2Map = new HashMap<>();
+
   @Override
   public String getEngineName() {
     return engineName;
@@ -136,6 +139,8 @@ public class WhisperEngine implements SpeechToTextEngine {
       Locale locale = new Locale(languageCode);
       String languageName = locale.getDisplayLanguage(new Locale("en"));
       languageMap.put(languageName, languageCode);
+      String languageISO3 = locale.getISO3Language();
+      languageISO3to2Map.put(languageISO3, languageCode);
     }
     logger.debug("Filled language map.");
 
@@ -170,9 +175,15 @@ public class WhisperEngine implements SpeechToTextEngine {
     }
 
     if (!language.isBlank() && !translate) {
-      logger.debug("Using language {} from workflows", language);
-      transcriptionCommand.add("--language");
-      transcriptionCommand.add(language);
+      // get 2-letter language code
+      language = languageISO3to2Map.getOrDefault(language,"");
+      if (language.isBlank()) {
+        logger.warn("No 2-letter language code found, using language auto detection");
+      } else {
+        logger.debug("Using language {} from workflows", language);
+        transcriptionCommand.add("--language");
+        transcriptionCommand.add(language);
+      }
     }
 
     if (quantization != null) {
@@ -259,4 +270,3 @@ public class WhisperEngine implements SpeechToTextEngine {
     return new Result(language, output);
   }
 }
-


### PR DESCRIPTION
Fixes #5945

The whisper `--language` option only accepts 2-letter language codes. However, the language codes provided by Opencast are 3-letter codes. This fix converts the language codes before using them with whisper.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
