### PR TITLE
Refactor Activator.java to improve database connection handling

### DIFF
--- a/modules/db/src/main/java/org/opencastproject/db/Activator.java
+++ b/modules/db/src/main/java/org/opencastproject/db/Activator.java
@@ -217,9 +217,8 @@ public class Activator implements BundleActivator {
           connectionEstablished = connection != null && !connection.isClosed();
         } catch (SQLInvalidAuthorizationSpecException e) {
           // Invalid credentials
-          String errorMsg = "Couldn't connect to database. Probably invalid database credentials. Check you config.";
-          logger.error(errorMsg);
-          throw new RuntimeException(errorMsg, e);
+          throw new RuntimeException(
+              "Couldn't connect to database. Probably invalid database credentials. " + "Check you config.", e);
         } catch (SQLNonTransientConnectionException e) {
           // Connection failed, database is not reachable (yet? maybe its just starting up, so we wait)
           logger.error("Database connection attempt failed, message: {}", e.getMessage());

--- a/modules/db/src/main/java/org/opencastproject/db/Activator.java
+++ b/modules/db/src/main/java/org/opencastproject/db/Activator.java
@@ -32,8 +32,11 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.sql.Connection;
+import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLInvalidAuthorizationSpecException;
+import java.sql.SQLNonTransientConnectionException;
 import java.sql.Statement;
 import java.util.Hashtable;
 
@@ -149,21 +152,11 @@ public class Activator implements BundleActivator {
       pooledDataSource.setIdleConnectionTestPeriod(idleConnectionTestPeriod);
     }
 
-    Connection connection = null;
-    try {
-      logger.info("Testing connectivity to database at {}", jdbcUrl);
-      connection = pooledDataSource.getConnection();
-      Hashtable<String, String> dsProps = new Hashtable<>();
-      dsProps.put("osgi.jndi.service.name", "jdbc/opencast");
-      datasourceRegistration = bundleContext.registerService(DataSource.class.getName(), pooledDataSource, dsProps);
-    } catch (SQLException e) {
-      logger.error("Connection attempt to {} failed", jdbcUrl, e);
-      throw e;
-    } finally {
-      if (connection != null) {
-        connection.close();
-      }
-    }
+    // Tests database connection and retry until database is available
+    waitUntilDatabaseIsAvailable(jdbcDriver, jdbcUrl, jdbcUser, jdbcPass);
+    Hashtable<String, String> dsProps = new Hashtable<>();
+    dsProps.put("osgi.jndi.service.name", "jdbc/opencast");
+    datasourceRegistration = bundleContext.registerService(DataSource.class.getName(), pooledDataSource, dsProps);
 
     logger.info("Database connection pool established at {}", jdbcUrl);
     logger.info("Database connection pool parameters: max.size={}, min.size={}, max.idle.time={}",
@@ -196,6 +189,50 @@ public class Activator implements BundleActivator {
       }
     }
 
+  }
+
+  /**
+   * Attempts to establish a simple connection to the database. This method will retry if the connection attempt fails.
+   *
+   * @param jdbcDriver The JDBC driver class
+   * @param jdbcUrl The JDBC URL
+   * @param jdbcUser The JDBC user
+   * @param jdbcPass The JDBC password
+   */
+  private void waitUntilDatabaseIsAvailable(String jdbcDriver, String jdbcUrl, String jdbcUser, String jdbcPass) {
+    logger.info("Testing connectivity to database at {}", jdbcUrl);
+
+    // Load the JDBC driver for our basic connection test
+    try {
+      Class.forName(jdbcDriver);
+    } catch (ClassNotFoundException e) {
+      logger.error("Couldn't load JDBC Driver {} for initial connection test", jdbcDriver);
+      throw new RuntimeException(e);
+    }
+
+    boolean connectionEstablished = false;
+    try {
+      while (!connectionEstablished) {
+        try (Connection connection = DriverManager.getConnection(jdbcUrl, jdbcUser, jdbcPass)) {
+          connectionEstablished = connection != null && !connection.isClosed();
+        } catch (SQLInvalidAuthorizationSpecException e) {
+          // Invalid credentials
+          String errorMsg = "Couldn't connect to database. Probably invalid database credentials. Check you config.";
+          logger.error(errorMsg);
+          throw new RuntimeException(errorMsg, e);
+        } catch (SQLNonTransientConnectionException e) {
+          // Connection failed, database is not reachable (yet? maybe its just starting up, so we wait)
+          logger.error("Database connection attempt failed, message: {}", e.getMessage());
+          logger.error("Retrying to connect to database in 10 seconds...");
+          Thread.sleep(10000);
+        } catch (SQLException e) {
+          // Unexpected exception
+          throw new RuntimeException("Unexpected SQL exception while connecting to the database", e);
+        }
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Unexpected exception while connecting to the database", e);
+    }
   }
 
   private void runUpdate(Statement statement, String sql) throws RuntimeException, SQLException {


### PR DESCRIPTION
Fixes #5952

### Description

Implemented a wait mechanism to ensure database availability before starting the application. This resolves issues where the application fails to start if the database is not yet available.

### To test this:

1. Make sure the database is not running
2. Start opencast
3. Observe the log, you should see, that Opencast retries to connect to the database
4. Start the Database
5. Observe the log, Opencast should continue the startup process without errors

### Test Scenario 2:

I also included a check for credentials, to test this, do the following:

1. Configure a wrong username or password in the `custom.properties` file
2. Make sure the database is not running
3. Start opencast
4. Observe the log: The startup of Opencast should fail with clear logging
