### PR TITLE
Fix publication icon paths for new admin ui

### DIFF
--- a/etc/listproviders/publication.channels.properties
+++ b/etc/listproviders/publication.channels.properties
@@ -7,7 +7,9 @@ list.name=PUBLICATION.CHANNELS
 #   translation key.
 # - "icon" to configure which icon is displayed for the entry. This can be an URL
 #   (e.g. http://hostname/path/to/image.png) or a path to a resource on the webserver
-#   (e.g. ./img/video.png or ../staticfiles/file-id)
+#   (e.g. ./img/video.png or ../staticfiles/file-id).
+#   Paths differ between old and new admin ui. The correct path for the engage-player icon for the old admin ui is
+#   "img/engage_2x.png".
 # - "description" to configure which explanatory text is displayed for the entry. This can be a plain text or a
 #   translation key.
 # - "hide" to configure whether the entry is shown or not. If you set this to true, the entry is hidden. This is a
@@ -39,5 +41,5 @@ list.name=PUBLICATION.CHANNELS
 
 api={"label":"EVENTS.EVENTS.DETAILS.PUBLICATIONS.EXTERNAL_API", "order":1}
 oaipmh-default={"label":"Default OAI-PMH Repository", "order":2}
-engage-player={"icon":"img/engage_2x.png", "order":3}
-youtube={"icon":"img/youtube_2x.png", "order":4}
+engage-player={"icon":"/src/img/engage_2x.png", "order":3}
+youtube={"icon":"/src/img/youtube_2x.png", "order":4}


### PR DESCRIPTION
The paths for the icons specified per default in
listproviders/publication.channels.properties have changed for the new admin ui, so the icons do not
show up. This fixes that by correcting the path.

This inevitably will make the icons not show up
in the old admin ui though. I tried to mitigate that a bit by leaving a comment about the differences.
