### PR TITLE
Remove redundant `groupId` declarations

### DIFF
--- a/modules/crop-api/pom.xml
+++ b/modules/crop-api/pom.xml
@@ -1,6 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.opencastproject</groupId>
   <artifactId>opencast-crop-api</artifactId>
   <packaging>bundle</packaging>
   <name>Opencast :: crop-api</name>

--- a/modules/crop-ffmpeg/pom.xml
+++ b/modules/crop-ffmpeg/pom.xml
@@ -1,6 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.opencastproject</groupId>
   <artifactId>opencast-crop-ffmpeg</artifactId>
   <packaging>bundle</packaging>
   <name>Opencast :: crop-ffmpeg</name>

--- a/modules/crop-remote/pom.xml
+++ b/modules/crop-remote/pom.xml
@@ -3,7 +3,6 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.opencastproject</groupId>
   <artifactId>opencast-crop-remote</artifactId>
   <packaging>bundle</packaging>
   <name>Opencast :: crop-remote</name>

--- a/modules/crop-workflowoperation/pom.xml
+++ b/modules/crop-workflowoperation/pom.xml
@@ -1,6 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.opencastproject</groupId>
   <artifactId>opencast-crop-workflowoperation</artifactId>
   <packaging>bundle</packaging>
   <name>Opencast :: crop-workflowoperation</name>

--- a/modules/dictionary-hunspell/pom.xml
+++ b/modules/dictionary-hunspell/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.opencastproject</groupId>
   <artifactId>opencast-dictionary-hunspell</artifactId>
   <packaging>bundle</packaging>
   <name>Opencast :: dictionary-hunspell</name>

--- a/modules/dictionary-none/pom.xml
+++ b/modules/dictionary-none/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.opencastproject</groupId>
   <artifactId>opencast-dictionary-none</artifactId>
   <packaging>bundle</packaging>
   <name>Opencast :: dictionary-none</name>

--- a/modules/dictionary-regexp/pom.xml
+++ b/modules/dictionary-regexp/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.opencastproject</groupId>
   <artifactId>opencast-dictionary-regexp</artifactId>
   <packaging>bundle</packaging>
   <name>Opencast :: dictionary-regexp</name>

--- a/modules/execute-api/pom.xml
+++ b/modules/execute-api/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.opencastproject</groupId>
   <artifactId>opencast-execute-api</artifactId>
   <packaging>bundle</packaging>
   <name>Opencast :: execute-api</name>

--- a/modules/execute-impl/pom.xml
+++ b/modules/execute-impl/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.opencastproject</groupId>
   <artifactId>opencast-execute-impl</artifactId>
   <packaging>bundle</packaging>
   <name>Opencast :: execute-impl</name>

--- a/modules/execute-remote/pom.xml
+++ b/modules/execute-remote/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.opencastproject</groupId>
   <artifactId>opencast-execute-remote</artifactId>
   <packaging>bundle</packaging>
   <name>Opencast :: execute-remote</name>

--- a/modules/execute-workflowoperation/pom.xml
+++ b/modules/execute-workflowoperation/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.opencastproject</groupId>
   <artifactId>opencast-execute-workflowoperation</artifactId>
   <packaging>bundle</packaging>
   <name>Opencast :: execute-workflowoperation</name>

--- a/modules/ingest-download-service-api/pom.xml
+++ b/modules/ingest-download-service-api/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.opencastproject</groupId>
   <artifactId>opencast-ingest-download-service-api</artifactId>
   <packaging>bundle</packaging>
   <name>Opencast :: ingest-download-service-api</name>

--- a/modules/ingest-download-service-remote/pom.xml
+++ b/modules/ingest-download-service-remote/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.opencastproject</groupId>
   <artifactId>opencast-ingest-download-service-remote</artifactId>
   <packaging>bundle</packaging>
   <name>Opencast :: ingestdownloadservice-remote</name>

--- a/modules/oaipmh-persistence/pom.xml
+++ b/modules/oaipmh-persistence/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.opencastproject</groupId>
   <artifactId>opencast-oaipmh-persistence</artifactId>
   <packaging>bundle</packaging>
   <name>Opencast :: oaipmh-persistence</name>

--- a/modules/presets/pom.xml
+++ b/modules/presets/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.opencastproject</groupId>
   <artifactId>opencast-presets</artifactId>
   <packaging>bundle</packaging>
   <name>Opencast :: presets</name>

--- a/modules/publication-service-configurable-remote/pom.xml
+++ b/modules/publication-service-configurable-remote/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.opencastproject</groupId>
   <artifactId>opencast-publication-service-configurable-remote</artifactId>
   <packaging>bundle</packaging>
   <name>Opencast :: publication-service-configurable-remote</name>

--- a/modules/publication-service-configurable/pom.xml
+++ b/modules/publication-service-configurable/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.opencastproject</groupId>
   <artifactId>opencast-publication-service-configurable</artifactId>
   <packaging>bundle</packaging>
   <name>Opencast :: publication-service-configurable</name>

--- a/modules/publication-service-oaipmh-remote/pom.xml
+++ b/modules/publication-service-oaipmh-remote/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.opencastproject</groupId>
   <artifactId>opencast-publication-service-oaipmh-remote</artifactId>
   <packaging>bundle</packaging>
   <name>Opencast :: publication-service-oaipmh-remote</name>

--- a/modules/publication-service-oaipmh/pom.xml
+++ b/modules/publication-service-oaipmh/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.opencastproject</groupId>
   <artifactId>opencast-publication-service-oaipmh</artifactId>
   <packaging>bundle</packaging>
   <name>Opencast :: publication-service-oaipmh</name>

--- a/modules/silencedetection-api/pom.xml
+++ b/modules/silencedetection-api/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.opencastproject</groupId>
   <artifactId>opencast-silencedetection-api</artifactId>
   <packaging>bundle</packaging>
   <name>Opencast :: silencedetection-api</name>

--- a/modules/silencedetection-impl/pom.xml
+++ b/modules/silencedetection-impl/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.opencastproject</groupId>
   <artifactId>opencast-silencedetection-impl</artifactId>
   <packaging>bundle</packaging>
   <name>Opencast :: silencedetection-impl</name>

--- a/modules/silencedetection-remote/pom.xml
+++ b/modules/silencedetection-remote/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.opencastproject</groupId>
   <artifactId>opencast-silencedetection-remote</artifactId>
   <packaging>bundle</packaging>
   <name>Opencast :: silencedetection-remote</name>

--- a/modules/sox-api/pom.xml
+++ b/modules/sox-api/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.opencastproject</groupId>
   <artifactId>opencast-sox-api</artifactId>
   <packaging>bundle</packaging>
   <name>Opencast :: sox-api</name>

--- a/modules/sox-impl/pom.xml
+++ b/modules/sox-impl/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.opencastproject</groupId>
   <artifactId>opencast-sox-impl</artifactId>
   <packaging>bundle</packaging>
   <name>Opencast :: sox-impl</name>

--- a/modules/sox-remote/pom.xml
+++ b/modules/sox-remote/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.opencastproject</groupId>
   <artifactId>opencast-sox-remote</artifactId>
   <packaging>bundle</packaging>
   <name>Opencast :: sox-remote</name>

--- a/modules/videoeditor-api/pom.xml
+++ b/modules/videoeditor-api/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.opencastproject</groupId>
   <artifactId>opencast-videoeditor-api</artifactId>
   <packaging>bundle</packaging>
   <name>Opencast :: videoeditor-api</name>

--- a/modules/videoeditor-remote/pom.xml
+++ b/modules/videoeditor-remote/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.opencastproject</groupId>
   <artifactId>opencast-videoeditor-remote</artifactId>
   <packaging>bundle</packaging>
   <name>Opencast :: videoeditor-remote</name>


### PR DESCRIPTION
We get these for free from the parent POM.
