### PR TITLE
Display state mappings in the status column again

### DIFF
--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -1267,10 +1267,11 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
           // Collect necessary information only for index update
           long id = workflowInstance.getId();
           int state = workflowInstance.getState().ordinal();
+          var template = workflowInstance.getTemplate();
           String mpId = workflowInstance.getMediaPackage().getIdentifier().toString();
           String orgId = workflowInstance.getOrganizationId();
 
-          updateWorkflowInstanceInIndex(id, state, mpId, orgId);
+          updateWorkflowInstanceInIndex(id, state, template, mpId, orgId);
         }
       } catch (ServiceRegistryException e) {
         throw new WorkflowDatabaseException("Update of workflow job " + workflowInstance.getId()
@@ -2342,7 +2343,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
    * @param orgId
    *         workflow organization id
    */
-  private void updateWorkflowInstanceInIndex(long id, int state, String mpId, String orgId) {
+  private void updateWorkflowInstanceInIndex(long id, int state, String wfDefId, String mpId, String orgId) {
     final WorkflowState workflowState = WorkflowState.values()[state];
     final User user = securityService.getUser();
 
@@ -2352,6 +2353,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
       Event event = eventOpt.orElse(new Event(mpId, orgId));
       event.setWorkflowId(id);
       event.setWorkflowState(workflowState);
+      event.setWorkflowDefinitionId(wfDefId);
       return Optional.of(event);
     };
 


### PR DESCRIPTION
The events table in the admin ui has a status column that informs users about the current state of the latest workflow. A workflow can define "state mappings" to overwrite what is usually displayed. For example, a delete workflow may overwrite the usual "Running" with "Deleting". This has probably been broken since Opencast 12-ish, and this commit should fix it.

Example:
![Bildschirmfoto vom 2024-06-28 14-59-10](https://github.com/opencast/opencast/assets/14070005/09ba953d-b381-42cf-a730-493207850f25)

Fixes https://github.com/opencast/opencast-admin-interface/issues/402.