### PR TITLE
URL encode username in Stud.IP user provider

### DIFF
--- a/modules/userdirectory-studip/src/main/java/org/opencastproject/userdirectory/studip/StudipUserProviderFactory.java
+++ b/modules/userdirectory-studip/src/main/java/org/opencastproject/userdirectory/studip/StudipUserProviderFactory.java
@@ -40,6 +40,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.management.ManagementFactory;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Dictionary;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -133,8 +135,13 @@ public class StudipUserProviderFactory implements ManagedServiceFactory {
       throw new ConfigurationException(ORGANIZATION_KEY, "is not set");
     }
 
-    String url = (String) properties.get(STUDIP_URL_KEY);
-    if (StringUtils.isBlank(url)) {
+    URI url = null;
+    try {
+      url = new URI((String) properties.get(STUDIP_URL_KEY));
+    } catch (URISyntaxException e) {
+      throw new ConfigurationException(STUDIP_URL_KEY, "URI is invalid", e);
+    }
+    if (StringUtils.isBlank(url.toString())) {
       throw new ConfigurationException(STUDIP_URL_KEY, "is not set");
     }
 

--- a/modules/userdirectory-studip/src/main/java/org/opencastproject/userdirectory/studip/StudipUserProviderInstance.java
+++ b/modules/userdirectory-studip/src/main/java/org/opencastproject/userdirectory/studip/StudipUserProviderInstance.java
@@ -54,6 +54,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.management.ManagementFactory;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -99,7 +100,7 @@ public class StudipUserProviderInstance implements UserProvider, RoleProvider, C
   protected Object nullToken = new Object();
 
   /** The URL of the Studip instance */
-  private String studipUrl = null;
+  private URI studipUrl;
 
   /** The URL of the Studip instance */
   private String studipToken = null;
@@ -123,7 +124,7 @@ public class StudipUserProviderInstance implements UserProvider, RoleProvider, C
   public StudipUserProviderInstance(
       String pid,
       Organization organization,
-      String url,
+      URI url,
       String token,
 
       int cacheSize,
@@ -298,11 +299,14 @@ public class StudipUserProviderInstance implements UserProvider, RoleProvider, C
    */
   private JSONObject getStudipUser(String uid) throws URISyntaxException, IOException, ParseException {
     // Build URL
-    URIBuilder url = new URIBuilder(studipUrl + "opencast/user/" + uid);
-    url.addParameter("token", studipToken);
+    var apiPath = new URIBuilder().setPathSegments("opencast", "user", uid).getPath();
+    var url = new URIBuilder(studipUrl)
+        .setPath(studipUrl.getPath().replaceAll("/*$", "") + apiPath)
+        .addParameter("token", studipToken)
+        .build();
 
     // Execute request
-    HttpGet get = new HttpGet(url.build());
+    HttpGet get = new HttpGet(url);
     get.setHeader("User-Agent", OC_USERAGENT);
 
     try (CloseableHttpClient client = HttpClients.createDefault()) {


### PR DESCRIPTION
This patch ensures that the username included in URLs is properly encoded in the Stud.IP user provider. Before, characters like a space would result in an exception.

This fixes #5969

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
