### PR TITLE
Rescue admin interface settings from deprecated section

### DIFF
--- a/etc/org.opencastproject.organization-mh_default_org.cfg
+++ b/etc/org.opencastproject.organization-mh_default_org.cfg
@@ -168,6 +168,22 @@ prop.org.opencastproject.admin.mediamodule.url=${prop.org.opencastproject.engage
 # Default: /paella7/ui/watch.html?id=#{id}
 #prop.player=/paella7/ui/watch.html?id=#{id}
 
+# Whether the ACL of a new event is initialized with the ACL of its series.
+#
+# Format: Boolean
+# Default: true
+#prop.admin.init.event.acl.with.series.acl=true
+
+# Enable themes in the admin interface.
+# Format: boolean
+# Default: true
+prop.admin.themes.enabled=false
+
+# Enable the sttatistics views in the admin intterface.
+# Format: boolean
+# Default: false
+#prop.admin.statistics.enabled=false
+
 
 ###
 # ⚠️ Settings specific to the old admin interface
@@ -325,12 +341,6 @@ prop.admin.shortcut.add_media.previous_tab=shift+alt+left
 # Default: optional
 #prop.admin.series.acl.event.update.mode=optional
 
-# Whether the ACL of a new event is initialized with the ACL of its series.
-#
-# Format: Boolean
-# Default: true
-#prop.admin.init.event.acl.with.series.acl=true
-
 # Default values for  trim segment in the editor.
 # Default: In milliseconds
 #
@@ -364,13 +374,3 @@ prop.admin.shortcut.add_media.previous_tab=shift+alt+left
 #   The external editing tool: /editor-ui/index.html?id=$id
 # Default: /editor-ui/index.html?id=$id
 #prop.admin.editor.url=/editor-ui/index.html?id=$id
-
-# Enable themes in the admin interface.
-# Format: boolean
-# Default: true
-prop.admin.themes.enabled=false
-
-# Enable the sttatistics views in the admin intterface.
-# Format: boolean
-# Default: false
-#prop.admin.statistics.enabled=false


### PR DESCRIPTION
Some setting which shouldn't have ended up in the section of deprecated admin interface properties due to merges while another has been re-implemented, but was never moved up again. This patch fixes that issue.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
