### PR TITLE
State mapping for fast workflow

### DIFF
--- a/etc/workflows/fast.yaml
+++ b/etc/workflows/fast.yaml
@@ -143,9 +143,3 @@ operations:
     configurations:
       - delete-external: true
       - preserve-flavors: "security/*"
-
-state-mappings:
-  - state: "running"
-    value: EVENTS.EVENTS.STATE_MAPPING.IMPORTING
-  - state: "failing"
-    value: EVENTS.EVENTS.STATE_MAPPING.IMPORTING


### PR DESCRIPTION
The fast workflow usually processes and publishes videos. It's strange to label the running state “Importing”. Even weirder to do that when the workflow is failing.

Maybe this is something no one noticed since we migrated to YAML workflows as the state mapping is broken for a while now.

In any case, a generic “Running” fits the workflow definitely better.


![Screenshot from 2024-07-01 18-00-38](https://github.com/opencast/opencast/assets/1008395/80f727a6-fa13-4cda-80df-5a5391de8632)
*Weird state mapping while publishing videos*

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
