### PR TITLE
Fix Tobira Harvest API (includesItemsUntil & hasMore)

### DIFF
--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Harvest.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Harvest.java
@@ -94,7 +94,7 @@ final class Harvest {
         .sort(SearchResult.MODIFIED_DATE, SortOrder.ASC)
         .size(preferredAmount + 1);
     final SearchResultList results = searchService.search(q);
-    final var hasMoreEvents = results.getTotalHits() == preferredAmount + 1;
+    final var hasMoreEvents = results.getHits().size() >= preferredAmount + 1;
 
     logger.debug("Retrieved {} events from the index during harvest", results.getHits().size());
 
@@ -114,7 +114,7 @@ final class Harvest {
         Optional.of(includesItemsUntilRaw),
         preferredAmount + 1
     );
-    final var hasMoreSeriesInRange = rawSeries.size() == preferredAmount + 1;
+    final var hasMoreSeriesInRange = rawSeries.size() >= preferredAmount + 1;
     logger.debug("Retrieved {} series from the database during harvest", rawSeries.size());
 
     if (hasMoreSeriesInRange) {
@@ -131,7 +131,7 @@ final class Harvest {
         includesItemsUntilRaw,
         preferredAmount + 1
     );
-    final var hasMorePlaylistsInRange = rawPlaylists.size() == preferredAmount + 1;
+    final var hasMorePlaylistsInRange = rawPlaylists.size() >= preferredAmount + 1;
     logger.debug("Retrieved {} playlists from the database during harvest", rawPlaylists.size());
 
     if (hasMorePlaylistsInRange) {


### PR DESCRIPTION
This was badly broken when this was changed to use the new search service (5880526444317ea9396c97f4fa876480b83cd09d). There, `getTotalHits()` was accidentally used, which returns the total number of events still left. This of course basically never exactly equals `preferredAmount + 1`. (To be clear, I'm not assigning blame, I should have reviewed this carefully.) `.getHits().size()` is the correct number to use here. However, as a precaution, I changed all `==` to `>=` just in case something like this happens in the future again. The logic is still sane, no need to have this exact equality.

Without this patch, the harvest API is basically unusable. To test this: add some number of events, and then open `tobira/harvest?since=0&preferredAmount=5` where `5` should be at least 2 fewer than the number of events Opencast has. Assuming you have no series or playlists, the API will return some events (fewer than there are in total), but will also say `hasMore: false` and `includesItemsUntil: $basicallyNow`. That's incorrect. See on the test servers for example: https://stable.opencast.org/tobira/harvest?since=0&preferredAmount=5

With this patch, the same API request will return `hasMore: true` and an appropriate `includesItemsUntil`.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
