### PR TITLE
First steps towards java 21

### DIFF
--- a/modules/asset-manager-impl/pom.xml
+++ b/modules/asset-manager-impl/pom.xml
@@ -179,11 +179,10 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-reload4j</artifactId>
     </dependency>
-    <!-- https://github.com/MutabilityDetector/MutabilityDetector -->
     <dependency>
-      <groupId>org.mutabilitydetector</groupId>
-      <artifactId>MutabilityDetector</artifactId>
-      <version>0.10.6</version>
+      <groupId>com.tngtech.archunit</groupId>
+      <artifactId>archunit</artifactId>
+      <version>1.3.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/ImmutabilityTest.java
+++ b/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/ImmutabilityTest.java
@@ -20,21 +20,30 @@
  */
 package org.opencastproject.assetmanager.impl;
 
-import static org.mutabilitydetector.unittesting.MutabilityAssert.assertImmutable;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 
-import org.opencastproject.assetmanager.api.PropertyId;
-import org.opencastproject.assetmanager.api.PropertyName;
-import org.opencastproject.assetmanager.api.Value;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.lang.ArchRule;
 
 import org.junit.Test;
 
+import javax.annotation.concurrent.Immutable;
+
 public class ImmutabilityTest {
+
   @Test
   public void testImmutability() {
-    assertImmutable(PropertyId.class);
-    assertImmutable(PropertyName.class);
-    assertImmutable(Value.BooleanValue.class);
-    assertImmutable(Value.LongValue.class);
-    assertImmutable(Value.StringValue.class);
+    final JavaClasses valueObjects = new ClassFileImporter().importPackages("org.opencastproject.assetmanager.api");
+
+    final ArchRule fieldsAreImmutable = fields()
+        .that()
+        .areDeclaredInClassesThat()
+        .areAnnotatedWith(Immutable.class)
+        .should()
+        .beFinal();
+
+    fieldsAreImmutable.check(valueObjects);
+
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1154,7 +1154,7 @@
       <dependency>
         <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
-        <version>5.1.0</version>
+        <version>5.3.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
This updates Easymock to version 5.3.0 and replaces the mutability detector with archunit.

> The Mutability detector has not been updated for two years and is
probably no longer compatible with Java version 21, hence the switch to
ArchUnit. The test is probably not equivalent, but it is a first
approximation.

> This updates easymock from version 5.1.0 to version 5.3.0

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
