### PR TITLE
Add basic date validation check to ingest/addMediaPackage/{wfId}

### DIFF
--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
@@ -23,6 +23,10 @@ package org.opencastproject.ingest.endpoint;
 
 import static org.apache.commons.lang3.StringUtils.trimToNull;
 import static org.opencastproject.mediapackage.MediaPackageElements.XACML_POLICY_EPISODE;
+import static org.opencastproject.metadata.dublincore.DublinCore.PROPERTY_CREATED;
+import static org.opencastproject.metadata.dublincore.DublinCore.PROPERTY_DATE;
+import static org.opencastproject.metadata.dublincore.DublinCore.PROPERTY_IDENTIFIER;
+import static org.opencastproject.metadata.dublincore.DublinCore.PROPERTY_TEMPORAL;
 
 import org.opencastproject.authorization.xacml.XACMLUtils;
 import org.opencastproject.capture.CaptureParameters;
@@ -767,7 +771,9 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
             String fieldName = item.getFieldName();
             String value = Streams.asString(item.openStream(), StandardCharsets.UTF_8.toString());
             if (dcterms.contains(fieldName)) {
-              if ("created".equals(fieldName) || "date".equals(fieldName) || "temporal".equals(fieldName)) {
+              if (PROPERTY_CREATED.getLocalName().equals(fieldName)
+                  || PROPERTY_DATE.getLocalName().equals(fieldName)
+                  || PROPERTY_TEMPORAL.getLocalName().equals(fieldName)) {
                 try {
                   OpencastMetadataCodec.decodeDate(value);
                 } catch (IllegalArgumentException e) {
@@ -802,7 +808,7 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
               tags.add(value);
               /* Fields for DC catalog */
             } else if (dcterms.contains(fieldName)) {
-              if ("identifier".equals(fieldName)) {
+              if (PROPERTY_IDENTIFIER.getLocalName().equals(fieldName)) {
                 /* Use the identifier for the mediapackage */
                 mp.setIdentifier(new IdImpl(value));
               }

--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
@@ -45,6 +45,7 @@ import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalogService;
 import org.opencastproject.metadata.dublincore.DublinCoreXmlFormat;
 import org.opencastproject.metadata.dublincore.DublinCores;
+import org.opencastproject.metadata.dublincore.OpencastMetadataCodec;
 import org.opencastproject.rest.AbstractJobProducerEndpoint;
 import org.opencastproject.scheduler.api.SchedulerConflictException;
 import org.opencastproject.scheduler.api.SchedulerException;
@@ -786,6 +787,13 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
               if ("identifier".equals(fieldName)) {
                 /* Use the identifier for the mediapackage */
                 mp.setIdentifier(new IdImpl(value));
+              }
+              if ("created".equals(fieldName) || "date".equals(fieldName) || "temporal".equals(fieldName)) {
+                try {
+                  OpencastMetadataCodec.decodeDate(value);
+                } catch (IllegalArgumentException e) {
+                  return badRequest("Provided dates were not well formatted", e);
+                }
               }
               if (dcc == null) {
                 dcc = dublinCoreService.newInstance();

--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
@@ -505,7 +505,7 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
         String fieldName = item.getFieldName();
         if (item.isFormField()) {
           if ("flavor".equals(fieldName)) {
-            String flavorString = Streams.asString(item.openStream(), "UTF-8");
+            String flavorString = Streams.asString(item.openStream(), StandardCharsets.UTF_8.toString());
             logger.trace("flavor: {}", flavorString);
             if (flavorString != null) {
               try {
@@ -517,12 +517,12 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
               }
             }
           } else if ("tags".equals(fieldName)) {
-            String tagsString = Streams.asString(item.openStream(), "UTF-8");
+            String tagsString = Streams.asString(item.openStream(), StandardCharsets.UTF_8.toString());
             logger.trace("tags: {}", tagsString);
             tags = tagsString.split(",");
           } else if ("mediaPackage".equals(fieldName)) {
             try {
-              String mediaPackageString = Streams.asString(item.openStream(), "UTF-8");
+              String mediaPackageString = Streams.asString(item.openStream(), StandardCharsets.UTF_8.toString());
               logger.trace("mediaPackage: {}", mediaPackageString);
               mp = MP_FACTORY.newMediaPackageBuilder().loadFromXml(mediaPackageString);
             } catch (MediaPackageException e) {
@@ -530,7 +530,7 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
               return Response.serverError().status(Status.BAD_REQUEST).build();
             }
           } else if ("startTime".equals(fieldName) && "/addPartialTrack".equals(request.getPathInfo())) {
-            String startTimeString = Streams.asString(item.openStream(), "UTF-8");
+            String startTimeString = Streams.asString(item.openStream(), StandardCharsets.UTF_8.toString());
             logger.trace("startTime: {}", startTime);
             try {
               startTime = Long.parseLong(startTimeString);
@@ -765,7 +765,7 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
           FileItemStream item = iter.next();
           if (item.isFormField()) {
             String fieldName = item.getFieldName();
-            String value = Streams.asString(item.openStream(), "UTF-8");
+            String value = Streams.asString(item.openStream(), StandardCharsets.UTF_8.toString());
             if (dcterms.contains(fieldName)) {
               if ("created".equals(fieldName) || "date".equals(fieldName) || "temporal".equals(fieldName)) {
                 try {
@@ -782,7 +782,7 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
           FileItemStream item = iter.next();
           if (item.isFormField()) {
             String fieldName = item.getFieldName();
-            String value = Streams.asString(item.openStream(), "UTF-8");
+            String value = Streams.asString(item.openStream(), StandardCharsets.UTF_8.toString());
             logger.trace("form field {}: {}", fieldName, value);
             /* Ignore empty fields */
             if ("".equals(value)) {
@@ -1072,7 +1072,7 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
           FileItemStream item = iter.next();
           if (item.isFormField()) {
             String fieldName = item.getFieldName();
-            String value = Streams.asString(item.openStream(), "UTF-8");
+            String value = Streams.asString(item.openStream(), StandardCharsets.UTF_8.toString());
             logger.trace("{}: {}", fieldName, value);
             if (WORKFLOW_INSTANCE_ID_PARAM.equals(fieldName)) {
               workflowIdAsString = value;
@@ -1202,7 +1202,7 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
         for (FileItemIterator iter = new ServletFileUpload().getItemIterator(request); iter.hasNext();) {
           FileItemStream item = iter.next();
           if (item.isFormField()) {
-            final String value = Streams.asString(item.openStream(), "UTF-8");
+            final String value = Streams.asString(item.openStream(), StandardCharsets.UTF_8.toString());
             formData.putSingle(item.getFieldName(), value);
           }
         }
@@ -1393,7 +1393,7 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
       return Response.status(Status.BAD_REQUEST).entity(e.getMessage()).build();
     }
 
-    try (InputStream in = IOUtils.toInputStream(dc, "UTF-8")) {
+    try (InputStream in = IOUtils.toInputStream(dc, StandardCharsets.UTF_8.toString())) {
       mediaPackage = ingestService.addCatalog(in, "dublincore.xml", dcFlavor, mediaPackage);
     } catch (MediaPackageException e) {
       return Response.serverError().status(Status.BAD_REQUEST).entity(e.getMessage()).build();


### PR DESCRIPTION
Attempts to fix #5954, by parsing date fields in the IngestRestService method and returning 400 if an exception occurs.

Arguably there should be a full on metadata validation function we could make use of here, but I could not find one and did not feel like writing one myself.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
