### PR TITLE
Fix link to supported language codes

### DIFF
--- a/docs/guides/admin/docs/configuration/admin-ui/about.md
+++ b/docs/guides/admin/docs/configuration/admin-ui/about.md
@@ -9,7 +9,8 @@ imprint.%{language_code}.html
 privacy.%{language_code}.html
 ```
 
-The corresponding language codes can be found here: https://github.com/opencast/opencast-admin-interface/blob/admin-ui-picard/app/src/i18n/i18n.ts#L44
+Currently supported language codes can be found here: <https://github.com/opencast/opencast-admin-interface/blob/main/src/i18n/i18n.ts>.
+Also see available translations in the [Opencast Crowdin project](https://crowdin.com/project/opencast-community).
 
 If a language is not provided, the english version will be displayed.
 


### PR DESCRIPTION
The "Imprint and Privacy Statement" documentation has an outdated link to the supported language codes in the Admin UI source code. This updates the link and adds an additional remark concerning Crowdin.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
