### PR TITLE
Use current docker images for development

### DIFF
--- a/docs/scripts/devel-dependency-containers/docker-compose-all-sql.yml
+++ b/docs/scripts/devel-dependency-containers/docker-compose-all-sql.yml
@@ -16,7 +16,7 @@ services:
       - "discovery.type=single-node" # disables bootstrap checks that are enabled when network.host is set to a non-loopback address
   postgresql:
     container_name: opencast-postgresql
-    image: docker.io/library/postgres:13.2
+    image: docker.io/library/postgres:13
     ports:
       - 127.0.0.1:5432:5432
     environment:
@@ -25,7 +25,7 @@ services:
       POSTGRES_DB: opencast
   mariadb:
     container_name: opencast-mariadb
-    image: docker.io/library/mariadb:10.5.9
+    image: docker.io/library/mariadb:10
     ports:
       - 127.0.0.1:3306:3306
     environment:

--- a/docs/scripts/devel-dependency-containers/docker-compose-mariadb.yml
+++ b/docs/scripts/devel-dependency-containers/docker-compose-mariadb.yml
@@ -16,7 +16,7 @@ services:
       - "discovery.type=single-node" # disables bootstrap checks that are enabled when network.host is set to a non-loopback address
   mariadb:
     container_name: opencast-mariadb
-    image: docker.io/library/mariadb:10.5.9
+    image: docker.io/library/mariadb:10
     ports:
       - 127.0.0.1:3306:3306
     environment:

--- a/docs/scripts/devel-dependency-containers/docker-compose-postgresql.yml
+++ b/docs/scripts/devel-dependency-containers/docker-compose-postgresql.yml
@@ -16,7 +16,7 @@ services:
       - "discovery.type=single-node" # disables bootstrap checks that are enabled when network.host is set to a non-loopback address
   postgresql:
     container_name: opencast-postgresql
-    image: docker.io/library/postgres:13.2
+    image: docker.io/library/postgres:13
     ports:
       - 127.0.0.1:5432:5432
     environment:


### PR DESCRIPTION
This PR drops the specific point revisions in the docker images in favour of the more recent major version tags.  No functional change, aside from a much more recent database image being tested.

### Your pull request should…

* [x] have a concise title
* [x] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
