### PR TITLE
Revert java version change in security-aai

### DIFF
--- a/modules/security-aai/pom.xml
+++ b/modules/security-aai/pom.xml
@@ -13,6 +13,7 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
+    <java.release>8</java.release>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
This PR reverts the recent minimum java version change in the security-aai pom file.  This resolves the build issue, but is untested in terms of actual usage since I don't have an AAI related setup to test with.

The issue stems from Spring's repackaging of their ASM library, which doesn't deal with JDK17+ properly.  Unfortuantely, that library dead ends with release 3.1.4 in 2013, so updating the library isn't immediately easily done.

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
