### PR TITLE
Replace aai spring junit class runner

### DIFF
--- a/modules/security-aai/pom.xml
+++ b/modules/security-aai/pom.xml
@@ -41,11 +41,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>jakarta.annotation</groupId>
-      <artifactId>jakarta.annotation-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -110,7 +105,6 @@
               <failOnWarning>true</failOnWarning>
               <ignoredUsedUndeclaredDependencies>
                 <ignoredUsedUndeclaredDependency>junit:junit</ignoredUsedUndeclaredDependency>
-                <ignoredUsedUndeclaredDependency>jakarta.annotation:jakarta.annotation-api</ignoredUsedUndeclaredDependency>
                 <ignoredUsedUndeclaredDependency>org.springframework:spring-expression</ignoredUsedUndeclaredDependency>
                 <ignoredUsedUndeclaredDependency>org.springframework:spring-core</ignoredUsedUndeclaredDependency>
                 <ignoredUsedUndeclaredDependency>org.springframework.security:spring-security-core</ignoredUsedUndeclaredDependency>

--- a/modules/security-aai/src/test/java/org/opencastporject/security/aai/utils/AttributeMapperTest.java
+++ b/modules/security-aai/src/test/java/org/opencastporject/security/aai/utils/AttributeMapperTest.java
@@ -27,25 +27,25 @@ import static org.junit.Assert.assertTrue;
 
 import org.opencastproject.security.aai.api.AttributeMapper;
 
+import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.util.CollectionUtils;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Resource;
-
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:attributemapper.xml"})
 public class AttributeMapperTest {
 
-  @Resource(name = "attributeMapper")
   protected AttributeMapper attributeMapper;
+
+  @Before
+  public void setUp() throws Exception {
+    ClassPathXmlApplicationContext ctx = new ClassPathXmlApplicationContext("attributemapper.xml");
+    attributeMapper = (AttributeMapper) ctx.getBean("attributeMapper");
+  }
 
   @Test
   public void testAttributeMapping() {


### PR DESCRIPTION
This removes the spring junit4 class runner and replaces it with loading the application context without magic. This is necessary as the spring library is too old, and the ASM version does not work with JDK 17+.

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
