### PR TITLE
Request user data only if necessary

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -1056,9 +1056,8 @@ public class IndexServiceImpl implements IndexService {
     MetadataField presentersMetadataField = eventMetadata.getOutputFields()
             .get(DublinCore.PROPERTY_CREATOR.getLocalName());
     if (presentersMetadataField.isUpdated()) {
-      Set<String> presenterUsernames = new HashSet<>();
       Tuple<List<String>, Set<String>> updatedPresenters = getTechnicalPresenters(eventMetadata);
-      presenterUsernames = updatedPresenters.getB();
+      Set<String> presenterUsernames = updatedPresenters.getB();
       eventMetadata.removeField(presentersMetadataField);
       MetadataField newPresentersMetadataField = new MetadataField(presentersMetadataField);
       newPresentersMetadataField.setValue(updatedPresenters.getA());
@@ -1329,11 +1328,6 @@ public class IndexServiceImpl implements IndexService {
 
     Event event = optEvent.get();
     MediaPackage mediaPackage = getEventMediapackage(event);
-    Opt<Set<String>> presenters = Opt.none();
-    DublinCoreMetadataCollection eventCatalog = metadataList.getMetadataByAdapter(getCommonEventCatalogUIAdapter());
-    if (eventCatalog != null) {
-      presenters = updatePresenters(eventCatalog);
-    }
     updateMediaPackageMetadata(mediaPackage, metadataList);
     switch (getEventSource(event)) {
       case WORKFLOW:
@@ -1355,6 +1349,8 @@ public class IndexServiceImpl implements IndexService {
         assetManager.takeSnapshot(mediaPackage);
         break;
       case SCHEDULE:
+        DublinCoreMetadataCollection eventCatalog = metadataList.getMetadataByAdapter(getCommonEventCatalogUIAdapter());
+        Opt<Set<String>> presenters = eventCatalog == null ? Opt.none() : updatePresenters(eventCatalog);
         try {
           schedulerService.updateEvent(id, Opt.none(), Opt.none(), Opt.none(), presenters, Opt.some(mediaPackage),
               Opt.none(), Opt.none());


### PR DESCRIPTION
The index service tries to look up users by what is listed in the presenter field every time an event is created or updated via the service. But the user information is used only when dealing with scheduled events. Otherwise, the information is just discarded.

That doesn't really make sense and so, this patch changes the mechanism for updating events to only get the user information if we are dealing with a scheduled event.

This is the “safe” option not changing the behavior, although I'm reasonably sure that the whole mechanism is superfluous and never actually used for anything. This is supported by checking two production systems which both gathered no user data at all through this mechanism. Still, this is already an improvement and far less intrusive.

The mechanism is also the reason for e.g. #5969 appearing during a metadata update.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
