### PR TITLE
Add waveform option filter mode

### DIFF
--- a/etc/org.opencastproject.waveform.ffmpeg.WaveformServiceImpl.cfg
+++ b/etc/org.opencastproject.waveform.ffmpeg.WaveformServiceImpl.cfg
@@ -20,6 +20,13 @@
 # default: lin
 #waveform.scale = lin
 
+# Set the filter mode.
+# Available values are:
+# 'average' Use average samples values for each drawn sample.
+# 'peak'    Use peak samples values for each drawn sample.
+# default: average
+#waveform.filter-mode = average
+
 # Advanced Configuration
 #
 # The waveform service uses the showwavespic ffmpeg filter to render the waveform image.

--- a/etc/org.opencastproject.waveform.ffmpeg.WaveformServiceImpl.cfg
+++ b/etc/org.opencastproject.waveform.ffmpeg.WaveformServiceImpl.cfg
@@ -24,8 +24,8 @@
 # Available values are:
 # 'average' Use average samples values for each drawn sample.
 # 'peak'    Use peak samples values for each drawn sample.
-# default: average
-#waveform.filter-mode = average
+# default: peak
+#waveform.filter-mode = peak
 
 # Advanced Configuration
 #

--- a/modules/waveform-ffmpeg/src/main/java/org/opencastproject/waveform/ffmpeg/WaveformServiceImpl.java
+++ b/modules/waveform-ffmpeg/src/main/java/org/opencastproject/waveform/ffmpeg/WaveformServiceImpl.java
@@ -117,7 +117,7 @@ public class WaveformServiceImpl extends AbstractJobProducer implements Waveform
   /** The key to look for in the service configuration file to override the DEFAULT_WAVEFORM_COLOR */
   public static final String WAVEFORM_COLOR_CONFIG_KEY = "waveform.color";
 
-  public static final String DEFAULT_WAVEFORM_FILTER_MODE = "average";
+  public static final String DEFAULT_WAVEFORM_FILTER_MODE = "peak";
 
   public static final String WAVEFORM_FILTER_MODE_CONFIG_KEY = "waveform.filter-mode";
 

--- a/modules/waveform-ffmpeg/src/test/java/org/opencastproject/waveform/ffmpeg/WaveformServiceImplTest.java
+++ b/modules/waveform-ffmpeg/src/test/java/org/opencastproject/waveform/ffmpeg/WaveformServiceImplTest.java
@@ -50,7 +50,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Dictionary;
 import java.util.Hashtable;
-import java.util.List;
+import java.util.Objects;
 
 /**
  * Test class for WaveformServiceImpl.
@@ -62,7 +62,7 @@ public class WaveformServiceImplTest {
   @BeforeClass
   public static void setUpClass() throws Exception {
     audioTrack = readTrackFromResource("/audio-track.xml");
-    audioTrack.setURI(WaveformServiceImplTest.class.getResource("/test.mp3").toURI());
+    audioTrack.setURI(Objects.requireNonNull(WaveformServiceImplTest.class.getResource("/test.mp3")).toURI());
     dummyTrack = readTrackFromResource("/dummy-track.xml");
   }
 
@@ -70,7 +70,7 @@ public class WaveformServiceImplTest {
     BufferedReader reader = null;
     try {
       reader = new BufferedReader(new InputStreamReader(
-              WaveformServiceImplTest.class.getResourceAsStream(resourceName)));
+          Objects.requireNonNull(WaveformServiceImplTest.class.getResourceAsStream(resourceName))));
       String line = reader.readLine();
       StringBuilder trackBuilder = new StringBuilder();
       while (line != null) {
@@ -97,7 +97,7 @@ public class WaveformServiceImplTest {
     properties.put(WaveformServiceImpl.WAVEFORM_FILTER_MODE_CONFIG_KEY, "peak");
 
     ServiceRegistry serviceRegistry = EasyMock.createNiceMock(ServiceRegistry.class);
-    EasyMock.expect(serviceRegistry.getHostRegistrations()).andReturn(new ArrayList());
+    EasyMock.expect(serviceRegistry.getHostRegistrations()).andReturn(new ArrayList<>());
     EasyMock.replay(serviceRegistry);
 
     WaveformServiceImpl instance = new WaveformServiceImpl();
@@ -120,7 +120,7 @@ public class WaveformServiceImplTest {
     EasyMock.expect(serviceRegistry.createJob(
             EasyMock.eq(WaveformServiceImpl.JOB_TYPE),
             EasyMock.eq(WaveformServiceImpl.Operation.Waveform.toString()),
-            (List<String>) EasyMock.anyObject(), EasyMock.anyFloat()))
+            EasyMock.anyObject(), EasyMock.anyFloat()))
             .andReturn(expectedJob);
     EasyMock.replay(serviceRegistry);
 

--- a/modules/waveform-ffmpeg/src/test/java/org/opencastproject/waveform/ffmpeg/WaveformServiceImplTest.java
+++ b/modules/waveform-ffmpeg/src/test/java/org/opencastproject/waveform/ffmpeg/WaveformServiceImplTest.java
@@ -94,6 +94,7 @@ public class WaveformServiceImplTest {
     properties.put(WaveformServiceImpl.WAVEFORM_COLOR_CONFIG_KEY, "blue green 0x2A2A2A 323232CC");
     properties.put(WaveformServiceImpl.WAVEFORM_SPLIT_CHANNELS_CONFIG_KEY, "false");
     properties.put(WaveformServiceImpl.WAVEFORM_SCALE_CONFIG_KEY, "lin");
+    properties.put(WaveformServiceImpl.WAVEFORM_FILTER_MODE_CONFIG_KEY, "peak");
 
     ServiceRegistry serviceRegistry = EasyMock.createNiceMock(ServiceRegistry.class);
     EasyMock.expect(serviceRegistry.getHostRegistrations()).andReturn(new ArrayList());


### PR DESCRIPTION
This adds a FFmpeg `showwavepics` filter option to change the filter mode from the default `average` to `peak`.

I didn't change the default value, but maybe it would make sense to make `peak` the default mode?

**Current default**
![default](https://github.com/user-attachments/assets/8d9a999e-adad-4ce5-8e81-48ed47384cfe)

**Current default + filter mode peak**
![default-draw-scale-filter-peak](https://github.com/user-attachments/assets/0302ecd1-fad9-48ca-9e96-23ce1fb6f418)

**Audacity**
![grafik](https://github.com/user-attachments/assets/37503653-8bc7-4018-bbf4-0de50dc28acf)
