### PR TITLE
Editor processing should be enabled if track selection isn't available

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/modules/events/subresources/controllers/toolsController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/subresources/controllers/toolsController.js
@@ -178,7 +178,8 @@ angular.module('adminNg.controllers')
           return true;
         }
       }
-      return false;
+      // If we don't have any tracks at all, selecting none is valid
+      return $scope.video.source_tracks.length === 0;
     };
 
     $scope.trackClicked = function(index, type) {


### PR DESCRIPTION
With track selection in the editor you want to disable processing if no tracks are selected. But if the track previews weren't generated, the user can't select any track. This will disable 'Save & Continue' button for further processing in the old editor. This behavior was added with commit 04df111 and should be soften in case of selection can't be done.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
