### PR TITLE
Fix Updating Engage for Non-Admins

### DIFF
--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
@@ -299,14 +299,14 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
 
   private void checkMPWritePermission(final String mediaPackageId) throws SearchException {
     try {
-      MediaPackage mp = persistence.getMediaPackage(mediaPackageId);
-      if (!authorizationService.hasPermission(mp, Permissions.Action.WRITE.toString())) {
+      AccessControlList acl = persistence.getAccessControlList(mediaPackageId);
+      if (!authorizationService.hasPermission(acl, Permissions.Action.WRITE.toString())) {
         boolean isAdmin = securityService.getUser().getRoles().stream()
             .map(Role::getName)
             .anyMatch(r -> r.equals(SecurityConstants.GLOBAL_ADMIN_ROLE));
         if (!isAdmin) {
           throw new UnauthorizedException(securityService.getUser(), "Write permission denied for " + mediaPackageId,
-              authorizationService.getActiveAcl(mp).getA());
+              acl);
         } else {
           logger.debug("Write for {} is not allowed by ACL, but user has {}",
               mediaPackageId, SecurityConstants.GLOBAL_ADMIN_ROLE);


### PR DESCRIPTION
...by using the ACL from the search database for the permission check instead of reading the referenced attachment because that file could already have been retracted. ('Could' because both those things happen asynchronously with jobs so it depends on the timing.)

_Bug found thanks to the University of Bamberg._
