### PR TITLE
Make in-place text substitution in the docs more portable

### DIFF
--- a/docs/guides/admin/docs/configuration/migration-domain-https.md
+++ b/docs/guides/admin/docs/configuration/migration-domain-https.md
@@ -25,7 +25,7 @@ In that case, the following steps might help.
          # This changes the domain AND from http to https. Carefully adjust the command as needed!
          # Your old URL may or may not have the port explicitly listed.  Check the previous value of org.opencastproject.server.url and match that.
          find . -type f -name "*.xml" -exec \
-            sed -i 's#http://old-domain.example.com:80#https://new-domain.example.com#g' {} +
+            perl -p -i -e 's#http://old-domain.example.com:80#https://new-domain.example.com#g' {} +
 
 5. Update database tables.
    Note: there more than the following two tables containing the old domain name, but only these two are relevant.

--- a/docs/guides/developer/docs/develop/devops/local-cluster.md
+++ b/docs/guides/developer/docs/develop/devops/local-cluster.md
@@ -23,22 +23,22 @@ ln -s ../../opencast-dist-admin/data/opencast opencast-dist-worker/data/opencast
 Configure different network ports (`8080 -> admin`, `8081 -> presentation`, `8082 -> worker`) for the distributions:
 
 ```sh
-sed -i 's/8080/8081/' opencast-dist-presentation/etc/org.ops4j.pax.web.cfg
-sed -i 's/8080/8081/' opencast-dist-presentation/etc/custom.properties
-sed -i 's/8080/8082/' opencast-dist-worker/etc/org.ops4j.pax.web.cfg
-sed -i 's/8080/8082/' opencast-dist-worker/etc/custom.properties
+perl -p -i -e 's/8080/8081/' opencast-dist-presentation/etc/org.ops4j.pax.web.cfg
+perl -p -i -e 's/8080/8081/' opencast-dist-presentation/etc/custom.properties
+perl -p -i -e 's/8080/8082/' opencast-dist-worker/etc/org.ops4j.pax.web.cfg
+perl -p -i -e 's/8080/8082/' opencast-dist-worker/etc/custom.properties
 
-sed -i 's_#prop.org.opencastproject.engage.ui.url=.*$_prop.org.opencastproject.engage.ui.url=http://localhost:8081_' */etc/org.opencastproject.organization-mh_default_org.cfg
-sed -i 's_#prop.org.opencastproject.admin.ui.url=.*$_prop.org.opencastproject.admin.ui.url=http://localhost:8080_' */etc/org.opencastproject.organization-mh_default_org.cfg
+perl -p -i -e 's_#prop.org.opencastproject.engage.ui.url=.*$_prop.org.opencastproject.engage.ui.url=http://localhost:8081_' */etc/org.opencastproject.organization-mh_default_org.cfg
+perl -p -i -e 's_#prop.org.opencastproject.admin.ui.url=.*$_prop.org.opencastproject.admin.ui.url=http://localhost:8080_' */etc/org.opencastproject.organization-mh_default_org.cfg
 ```
 
 Configure a MariaDB database:
 
 ```sh
-sed -i 's/#org.opencastproject.db.jdbc.driver/org.opencastproject.db.jdbc.driver/' */etc/custom.properties
-sed -i 's/#org.opencastproject.db.jdbc.url/org.opencastproject.db.jdbc.url/' */etc/custom.properties
-sed -i 's/#org.opencastproject.db.jdbc.user/org.opencastproject.db.jdbc.user/' */etc/custom.properties
-sed -i 's/#org.opencastproject.db.jdbc.pass/org.opencastproject.db.jdbc.pass/' */etc/custom.properties
+perl -p -i -e 's/#org.opencastproject.db.jdbc.driver/org.opencastproject.db.jdbc.driver/' */etc/custom.properties
+perl -p -i -e 's/#org.opencastproject.db.jdbc.url/org.opencastproject.db.jdbc.url/' */etc/custom.properties
+perl -p -i -e 's/#org.opencastproject.db.jdbc.user/org.opencastproject.db.jdbc.user/' */etc/custom.properties
+perl -p -i -e 's/#org.opencastproject.db.jdbc.pass/org.opencastproject.db.jdbc.pass/' */etc/custom.properties
 ```
 
 Start Opencast:


### PR DESCRIPTION
Unfortunately there is no way to make calls to `sed -i` portable and at the same time have it not create a buckup copy.

Luckily, Perl is an easy replacement.