### PR TITLE
Remove unnecessary tag operation from fast workflow

### DIFF
--- a/etc/workflows/fast.yaml
+++ b/etc/workflows/fast.yaml
@@ -55,16 +55,6 @@ operations:
       - target-tags: "engage-download,engage-streaming,rss,atom"
       - encoding-profile: "fast.http"
 
-  - id: tag
-    fail-on-error: true
-    exception-handler-workflow: "partial-error"
-    description: "Tag captions for publication"
-    configurations:
-      - source-flavor: "captions/source"
-      - target-flavor: "captions/preview"
-      - target-tags: "+engage-download"
-      - copy: true
-
   - id: image
     if: "${straightToPublishing}"
     fail-on-error: true
@@ -126,7 +116,7 @@ operations:
     exception-handler-workflow: "partial-error"
     description: "Publishing to Engage"
     configurations:
-      - download-source-flavors: "dublincore/*,security/*"
+      - download-source-flavors: "dublincore/*,security/*,captions/*"
       - download-source-tags: "engage-download"
       - check-availability: false
 


### PR DESCRIPTION
This patch removes an unnecessary tag operation from the fast workflow. We can just publish the captions without creating a copy first.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
