### PR TITLE
Properly handle ACL publication for non-admins

### DIFF
--- a/modules/search-service-impl/pom.xml
+++ b/modules/search-service-impl/pom.xml
@@ -67,6 +67,10 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
+      <artifactId>osgi.core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.component</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
If a non-admin user tries to publish something, Opencast will try to get the ACL for the media package intended for publication. During this process, Opencast tries to evaluate the ACL and write it to the database. Unfortunately, this process silently fails, causing an empty ACL to be written into the database instead.

The search service then tries to publish to the search index. This causes several files linked in the media package to be accessed for which the ACL in the database is being evaluated. Since that is now an empty ACL, the access check fails, meaning that the publication fails halfway (event is in the database, but not in the index).

This patch allows Opencast to always access the access control list linked in the media package, so that the correct ACL ends up in the database, meaning the correct ACL will be used for the index checks.

This fixes the overall problem and allows non-admin users to actually publish events.

This fixes #5333
This fixes #6040

---

Easy way to test the problem is to run this in the Opencast git repository:
```
curl -i -u admin:opencast http://localhost:8080/user-utils/ \
  -F username=test \
  -F password=opencast \
  -F 'roles=["ROLE_STUDIO"]'

curl -i -f -u test:opencast http://localhost:8080/ingest/addMediaPackage/fast \
  -F flavor=presenter/source \
  -F BODY=@modules/inspection-service-ffmpeg/src/test/resources/segments_1.mp4 \
  -F title=test \
  -F identifier=test \
  -F acl='{"acl": {"ace": [{"role": "ROLE_USER","action": "read"},{"role": "ROLE_USER","action": "write"}]}}'
```

---

We might want to check if this was broken prior to 16.x but since this code has changed with the migration away from Solr, it would need a different patch.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
