### PR TITLE
Check org of role provider when adding roles

### DIFF
--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
@@ -410,8 +410,11 @@ public class UserAndRoleDirectoryServiceImpl implements UserDirectoryService, Us
     // Add additional roles from role providers
     if (!InMemoryUserAndRoleProvider.PROVIDER_NAME.equals(user.getProvider())) {
       for (RoleProvider roleProvider : roleProviders) {
-        List<Role> rolesForUser = roleProvider.getRolesForUser(userName);
-        for (Role role : rolesForUser) {
+        String providerOrgId = roleProvider.getOrganization();
+        if (!ALL_ORGANIZATIONS.equals(providerOrgId) && !user.getOrganization().getId().equals(providerOrgId)) {
+          continue;
+        }
+        for (Role role : roleProvider.getRolesForUser(userName)) {
           authorities.add(new SimpleGrantedAuthority(role.getName()));
         }
       }


### PR DESCRIPTION
#4525 added checks for the organization of role providers, but missed one spot.

~~Not tested yet.~~ Successfully tested in production.

_Bug found thanks to the University of Vienna._