### PR TITLE
Fix downloadsPlugin in PaellaPlayer7

### DIFF
--- a/modules/engage-paella-player-7/src/js/OpencastAuth.js
+++ b/modules/engage-paella-player-7/src/js/OpencastAuth.js
@@ -87,16 +87,15 @@ export default class OpencastAuth {
       if (!(roles instanceof Array)) { roles = [roles]; }
 
       let canWrite = false;
-      if (acl?.ace) {
-        let aces = acl?.ace;
-        if (!(aces instanceof Array)) { aces = [aces]; }
+      if (acl) {
+        if (!(acl instanceof Array)) { acl = [acl]; }
 
         canWrite = roles.some(function(currentRole) {
           if (currentRole == userInfo.org.adminRole) {
             return true;
           }
           else {
-            return aces.some(function(currentAce) {
+            return acl.some(function(currentAce) {
               if (currentRole == currentAce.role) {
                 if (currentAce.action == 'write') {
                   return true;

--- a/modules/engage-paella-player-7/src/js/PaellaOpencast.js
+++ b/modules/engage-paella-player-7/src/js/PaellaOpencast.js
@@ -344,7 +344,7 @@ export class PaellaOpencast extends Paella {
   async getEpisode({episodeId}) {
     return fetch(getUrlFromOpencastServer(`/search/episode.json?id=${episodeId}`))
     .then(response => response.json() )
-    .then(response => response['result'][0]?.id)
+    .then(response => response['result'][0])
     .catch(() => null);
   }
 

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.downloadsPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.downloadsPlugin.js
@@ -54,7 +54,10 @@ export default class DownloadsPlugin extends PopUpButtonPlugin {
 
   async getDownloadableContent() {
     const episode = await this.player.getEpisode({episodeId: this.player.videoId});
-    const tracks = episode?.mediapackage?.media?.track ?? [];
+    var tracks = episode?.mediapackage?.media?.track ?? [];
+    if (Object.getPrototypeOf(tracks) == Object.prototype) {
+      tracks = [].concat(tracks);
+    }
     // const attachments = episode?.mediapackage?.attachments?.attachment ?? [];
     const downloadable = {};
 


### PR DESCRIPTION
In OC16 there have been some changes to the search-API, which in part were not correctly adressed for the downloadsPlugin to work properly. If you check any current OC build >= 16.x the download tab will not be shown in Paella,  even if it is correctly configured. 

This PR should fix this problem. 
