### PR TITLE
Don't duplicate captions during publication

### DIFF
--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -14,6 +14,12 @@ See [changelog](changelog.md#opencast-157) for a comprehensive list of changes.
 
 ## Opencast 15.6
 
+**Attention:**
+The fix for the handling of captions by the select-tracks operation
+([5829](https://github.com/opencast/opencast/pull/5829)) requires the removal of the operation directly afterwards from
+the `partial-publish` community workflow, otherwise captions will be duplicated during publication (see
+[6046](https://github.com/opencast/opencast/pull/6046) which is _not_ included in this release).
+
 ### Behavior changes
 
 - **Handle lang tag by asset upload correctly:**

--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -17,8 +17,8 @@ See [changelog](changelog.md#opencast-157) for a comprehensive list of changes.
 **Attention:**
 The fix for the handling of captions by the select-tracks operation
 ([5829](https://github.com/opencast/opencast/pull/5829)) requires the removal of the operation directly afterwards from
-the `partial-publish` community workflow, otherwise captions will be duplicated during publication (see
-[6046](https://github.com/opencast/opencast/pull/6046) which is _not_ included in this release).
+the `partial-publish` workflow, otherwise captions will be duplicated during publication.
+This workflow has been fixed in 15.8 (see [6046](https://github.com/opencast/opencast/pull/6046) for details).
 
 ### Behavior changes
 

--- a/etc/workflows/partial-publish.xml
+++ b/etc/workflows/partial-publish.xml
@@ -47,19 +47,6 @@
       </configurations>
     </operation>
 
-    <!-- Keep captions in the loop, as they are ignored by select-tracks -->
-
-    <operation
-        id="tag"
-        description="Tag captions for cutting">
-      <configurations>
-        <configuration key="source-flavors">captions/prepared</configuration>
-        <configuration key="target-flavor">captions/work</configuration>
-        <configuration key="target-tags">-archive</configuration>
-        <configuration key="copy">true</configuration>
-      </configurations>
-    </operation>
-
     <operation
       id="analyze-tracks"
       exception-handler-workflow="partial-error"


### PR DESCRIPTION
#5829 requires a change to the publication workflow, otherwise we duplicate captions during publication.