### PR TITLE
Paella fix: Track captions have priority over attachments captions.

### DIFF
--- a/modules/engage-paella-player-7/src/js/EpisodeConversor.js
+++ b/modules/engage-paella-player-7/src/js/EpisodeConversor.js
@@ -450,11 +450,14 @@ function getCaptions(episode) {
   if (!(attachments instanceof Array)) { attachments = attachments ? [attachments] : []; }
   if (!(tracks instanceof Array)) { tracks = tracks ? [tracks] : []; }
 
-  // Read the attachments
-  readCaptions(attachments, captions);
-
-  // Read the tracks
+  // Read the captions from the tracks
   readCaptions(tracks, captions);
+
+  // If no captions were found in the tracks, read them from the attachments
+  // (compatibility with older versions of Opencast)
+  if (captions.length == 0) {
+    readCaptions(attachments, captions);
+  }
 
   return captions;
 }


### PR DESCRIPTION
Track captions have priority over attachments captions. Fix #6041

### Your pull request should…

* [x] have a concise title
* [x] close #6041
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
