### PR TITLE
Make Tobira harvest API work with multi-tenancy

### DIFF
--- a/modules/playlists/src/main/java/org/opencastproject/playlists/PlaylistService.java
+++ b/modules/playlists/src/main/java/org/opencastproject/playlists/PlaylistService.java
@@ -169,8 +169,10 @@ public class PlaylistService {
 
   public List<Playlist> getAllForAdministrativeRead(Date from, Date to, int limit)
           throws IllegalStateException, UnauthorizedException {
-    if (!this.securityService.getUser().hasRole(GLOBAL_ADMIN_ROLE)) {
-      throw new UnauthorizedException("Only admins can call this method");
+    final var user = securityService.getUser();
+    final var orgAdminRole = securityService.getOrganization().getAdminRole();
+    if (!user.hasRole(GLOBAL_ADMIN_ROLE) && !user.hasRole(orgAdminRole)) {
+      throw new UnauthorizedException("Only (org-)admins can call this method");
     }
 
     try {

--- a/modules/playlists/src/main/java/org/opencastproject/playlists/persistence/PlaylistDatabaseServiceImpl.java
+++ b/modules/playlists/src/main/java/org/opencastproject/playlists/persistence/PlaylistDatabaseServiceImpl.java
@@ -170,10 +170,12 @@ public class PlaylistDatabaseServiceImpl implements PlaylistDatabaseService {
         final var criteriaBuilder = em.getCriteriaBuilder();
         final var criteriaQuery = criteriaBuilder.createQuery(Playlist.class);
         final var from = criteriaQuery.from(Playlist.class);
+        final var org = securityService.getOrganization().getId();
         final var select = criteriaQuery.select(from)
             .where(
                 criteriaBuilder.greaterThanOrEqualTo(from.get("updated"), startDate),
-                criteriaBuilder.lessThan(from.get("updated"), endDate)
+                criteriaBuilder.lessThan(from.get("updated"), endDate),
+                criteriaBuilder.equal(from.get("organization"), org)
             )
             .orderBy(criteriaBuilder.asc(from.get("updated")));
 

--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Harvest.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Harvest.java
@@ -90,7 +90,7 @@ final class Harvest {
     var orgAdminRole = securityService.getOrganization().getAdminRole();
     var isAdmin = user.hasRole(SecurityConstants.GLOBAL_ADMIN_ROLE) || user.hasRole(orgAdminRole);
     if (!isAdmin) {
-      throw new UnauthorizedException(user, "only (org-) admins can access the Tobira harvest API");
+      throw new UnauthorizedException(user, "Only (org-) admins can access the Tobira harvest API");
     }
 
     // ===== Retrieve information about events, series, and playlists =============================
@@ -101,9 +101,9 @@ final class Harvest {
     // Retrieve episodes from index.
     final SearchSourceBuilder q = new SearchSourceBuilder().query(
             QueryBuilders.boolQuery()
-                    .must(QueryBuilders.termQuery(SearchResult.ORG, org))
-                    .must(QueryBuilders.rangeQuery(SearchResult.MODIFIED_DATE).gte(since.getTime()))
-                    .must(QueryBuilders.termQuery(SearchResult.TYPE, SearchService.IndexEntryType.Episode)))
+                .must(QueryBuilders.termQuery(SearchResult.ORG, org))
+                .must(QueryBuilders.rangeQuery(SearchResult.MODIFIED_DATE).gte(since.getTime()))
+                .must(QueryBuilders.termQuery(SearchResult.TYPE, SearchService.IndexEntryType.Episode)))
         .sort(SearchResult.MODIFIED_DATE, SortOrder.ASC)
         .size(preferredAmount + 1);
     final SearchResultList results = searchService.search(q);

--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/TobiraEndpoint.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/TobiraEndpoint.java
@@ -28,6 +28,7 @@ import static org.opencastproject.util.doc.rest.RestParameter.Type;
 import org.opencastproject.playlists.PlaylistService;
 import org.opencastproject.search.api.SearchService;
 import org.opencastproject.security.api.AuthorizationService;
+import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.series.api.SeriesService;
 import org.opencastproject.util.Jsons;
 import org.opencastproject.util.doc.rest.RestParameter;
@@ -102,6 +103,7 @@ public class TobiraEndpoint {
   private SearchService searchService;
   private SeriesService seriesService;
   private AuthorizationService authorizationService;
+  private SecurityService securityService;
   private PlaylistService playlistService;
   private Workspace workspace;
 
@@ -123,6 +125,11 @@ public class TobiraEndpoint {
   @Reference
   public void setAuthorizationService(AuthorizationService service) {
     this.authorizationService = service;
+  }
+
+  @Reference
+  public void setSecurityService(SecurityService service) {
+    this.securityService = service;
   }
 
   @Reference
@@ -206,7 +213,7 @@ public class TobiraEndpoint {
       var json = Harvest.harvest(
           preferredAmount,
           new Date(since),
-          searchService, seriesService, authorizationService, playlistService, workspace);
+          searchService, seriesService, authorizationService, securityService, playlistService, workspace);
 
       // TODO: encoding
       return Response.ok(json.toJson()).build();


### PR DESCRIPTION
This is technically a breaking change in that with this PR, it is not possible anymore to get all events or playlists from all orgs via the harvest API. However, the series were already filtered by org, so the API always just returned the series for one org. So I really don't see how anyone could have relied on the old behavior of getting all events and playlists of all orgs, but only series for one org. So I think it's totally fine to merge this into 16. I don't even think anyone with multi-tenancy is already using Tobira right now anyway.

I would invite the reviewer(s) to review these few lines carefully to make sure I didn't screw something up. This is security-related and I really don't want to accidentally expose stuff via the Tobira API. 

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
