### PR TITLE
Fix version of subtitle timeshift operation

### DIFF
--- a/modules/subtitle-timeshift-workflowoperation/pom.xml
+++ b/modules/subtitle-timeshift-workflowoperation/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.opencastproject</groupId>
     <artifactId>base</artifactId>
-    <version>15-SNAPSHOT</version>
+    <version>16-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <properties>


### PR DESCRIPTION
The module version in `r/16.x` is still set to `15-SNAPSHOT`. This is a problem of my `r/15.x` → `r/16.x` merge I did earlier.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
