### PR TITLE
Add system type attribute in adopter registration

### DIFF
--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Controller.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Controller.java
@@ -163,6 +163,8 @@ public class Controller {
                           isRequired = false, name = "agreedToPolicy", type = BOOLEAN),
                   @RestParameter(description = "Does the adopter allow the gathering of error reports.",
                           isRequired = false, name = "allowsErrorReports", type = BOOLEAN),
+                  @RestParameter(description = "Is this a test system.",
+                          isRequired = false, name = "isTestSystem", type = BOOLEAN),
                   @RestParameter(description = "Does the adopter allow the gathering of statistic data.",
                           isRequired = false, name = "allowsStatistics", type = BOOLEAN),
                   @RestParameter(description = "Is the adopter already registered.",
@@ -184,13 +186,14 @@ public class Controller {
           @FormParam("streetNo") String streetNo,
           @FormParam("contactMe") boolean contactMe,
           @FormParam("agreedToPolicy") boolean agreedToPolicy,
+          @FormParam("isTestSystem") boolean isTestSystem,
           @FormParam("allowsErrorReports") boolean allowsErrorReports,
           @FormParam("allowsStatistics") boolean allowsStatistics,
           @FormParam("registered") boolean registered) {
     logger.debug("Saving adopter registration data.");
 
     Form form = new Form(organisationName, departmentName, firstName, lastName, email, country, postalCode, city,
-            street, streetNo, contactMe, allowsStatistics, allowsErrorReports, agreedToPolicy, registered
+            street, streetNo, contactMe, isTestSystem, allowsStatistics, allowsErrorReports, agreedToPolicy, registered
     );
     try {
       registrationService.saveFormData(form);

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Controller.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Controller.java
@@ -163,8 +163,8 @@ public class Controller {
                           isRequired = false, name = "agreedToPolicy", type = BOOLEAN),
                   @RestParameter(description = "Does the adopter allow the gathering of error reports.",
                           isRequired = false, name = "allowsErrorReports", type = BOOLEAN),
-                  @RestParameter(description = "Is this a test system.",
-                          isRequired = false, name = "isTestSystem", type = BOOLEAN),
+                  @RestParameter(description = "Which type of system is this.",
+                          isRequired = false, name = "systemType", type = STRING),
                   @RestParameter(description = "Does the adopter allow the gathering of statistic data.",
                           isRequired = false, name = "allowsStatistics", type = BOOLEAN),
                   @RestParameter(description = "Is the adopter already registered.",
@@ -186,14 +186,14 @@ public class Controller {
           @FormParam("streetNo") String streetNo,
           @FormParam("contactMe") boolean contactMe,
           @FormParam("agreedToPolicy") boolean agreedToPolicy,
-          @FormParam("isTestSystem") boolean isTestSystem,
+          @FormParam("systemType") String systemType,
           @FormParam("allowsErrorReports") boolean allowsErrorReports,
           @FormParam("allowsStatistics") boolean allowsStatistics,
           @FormParam("registered") boolean registered) {
     logger.debug("Saving adopter registration data.");
 
     Form form = new Form(organisationName, departmentName, firstName, lastName, email, country, postalCode, city,
-            street, streetNo, contactMe, isTestSystem, allowsStatistics, allowsErrorReports, agreedToPolicy, registered
+            street, streetNo, contactMe, systemType, allowsStatistics, allowsErrorReports, agreedToPolicy, registered
     );
     try {
       registrationService.saveFormData(form);

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Form.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Form.java
@@ -103,8 +103,8 @@ public class Form implements IForm {
   @Column(name = "contact_me")
   private boolean contactMe;
 
-  @Column(name = "is_test_system")
-  private boolean isTestSystem;
+  @Column(name = "system_type")
+  private String systemType;
 
   @Column(name = "allows_statistics")
   private boolean allowsStatistics;
@@ -149,7 +149,7 @@ public class Form implements IForm {
 
   public Form(String organisationName, String departmentName, String firstName, String lastName, String email,
           String country, String postalCode, String city, String street, String streetNo, boolean contactMe,
-          boolean isTestSystem, boolean allowsStatistics, boolean allowsErrorReports, boolean agreedToPolicy,
+          String systemType, boolean allowsStatistics, boolean allowsErrorReports, boolean agreedToPolicy,
           boolean registered) {
     this.organisationName = organisationName;
     this.departmentName = departmentName;
@@ -162,7 +162,7 @@ public class Form implements IForm {
     this.street = street;
     this.streetNo = streetNo;
     this.contactMe = contactMe;
-    this.isTestSystem = isTestSystem;
+    this.systemType = systemType;
     this.allowsStatistics = allowsStatistics;
     this.allowsErrorReports = allowsErrorReports;
     this.agreedToPolicy = agreedToPolicy;
@@ -185,7 +185,7 @@ public class Form implements IForm {
     this.street = f.street;
     this.streetNo = f.streetNo;
     this.contactMe = f.contactMe;
-    this.isTestSystem = f.isTestSystem;
+    this.systemType = f.systemType;
     this.allowsStatistics = f.allowsStatistics;
     this.allowsErrorReports = f.allowsErrorReports;
     this.agreedToPolicy = f.agreedToPolicy;
@@ -326,12 +326,12 @@ public class Form implements IForm {
     this.contactMe = contactMe;
   }
 
-  public boolean isTestSystem() {
-    return isTestSystem;
+  public String systemType() {
+    return systemType;
   }
 
-  public void setIsTestSystem(boolean isTestSystem) {
-    this.isTestSystem = isTestSystem;
+  public void setSystemType(String systemType) {
+    this.systemType = systemType;
   }
 
   public boolean allowsStatistics() {
@@ -399,7 +399,7 @@ public class Form implements IForm {
     this.street = null;
     this.streetNo = null;
     this.contactMe = false;
-    this.isTestSystem = false;
+    this.systemType = null;
     this.allowsStatistics = false;
     this.allowsErrorReports = false;
     this.dateModified = new Date();

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Form.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Form.java
@@ -103,6 +103,9 @@ public class Form implements IForm {
   @Column(name = "contact_me")
   private boolean contactMe;
 
+  @Column(name = "is_test_system")
+  private boolean isTestSystem;
+
   @Column(name = "allows_statistics")
   private boolean allowsStatistics;
 
@@ -146,7 +149,8 @@ public class Form implements IForm {
 
   public Form(String organisationName, String departmentName, String firstName, String lastName, String email,
           String country, String postalCode, String city, String street, String streetNo, boolean contactMe,
-          boolean allowsStatistics, boolean allowsErrorReports, boolean agreedToPolicy, boolean registered) {
+          boolean isTestSystem, boolean allowsStatistics, boolean allowsErrorReports, boolean agreedToPolicy,
+          boolean registered) {
     this.organisationName = organisationName;
     this.departmentName = departmentName;
     this.firstName = firstName;
@@ -158,6 +162,7 @@ public class Form implements IForm {
     this.street = street;
     this.streetNo = streetNo;
     this.contactMe = contactMe;
+    this.isTestSystem = isTestSystem;
     this.allowsStatistics = allowsStatistics;
     this.allowsErrorReports = allowsErrorReports;
     this.agreedToPolicy = agreedToPolicy;
@@ -180,6 +185,7 @@ public class Form implements IForm {
     this.street = f.street;
     this.streetNo = f.streetNo;
     this.contactMe = f.contactMe;
+    this.isTestSystem = f.isTestSystem;
     this.allowsStatistics = f.allowsStatistics;
     this.allowsErrorReports = f.allowsErrorReports;
     this.agreedToPolicy = f.agreedToPolicy;
@@ -320,6 +326,14 @@ public class Form implements IForm {
     this.contactMe = contactMe;
   }
 
+  public boolean isTestSystem() {
+    return isTestSystem;
+  }
+
+  public void setIsTestSystem(boolean isTestSystem) {
+    this.isTestSystem = isTestSystem;
+  }
+
   public boolean allowsStatistics() {
     return allowsStatistics;
   }
@@ -385,6 +399,7 @@ public class Form implements IForm {
     this.street = null;
     this.streetNo = null;
     this.contactMe = false;
+    this.isTestSystem = false;
     this.allowsStatistics = false;
     this.allowsErrorReports = false;
     this.dateModified = new Date();

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/dto/GeneralData.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/dto/GeneralData.java
@@ -82,6 +82,10 @@ public class GeneralData {
   @SerializedName("contact_me")
   private final boolean allowContact;
 
+  /** Whether this is a test system */
+  @SerializedName("test_system")
+  private final boolean isTestSystem;
+
   /** Whether we can send error reports */
   @SerializedName("send_errors")
   private final boolean allowErrorReports;
@@ -108,6 +112,7 @@ public class GeneralData {
     this.streetNo = adopterRegistrationForm.getStreetNo();
     this.email = adopterRegistrationForm.getEmail();
     this.allowContact = adopterRegistrationForm.allowsContacting();
+    this.isTestSystem = adopterRegistrationForm.isTestSystem();
     this.allowErrorReports = adopterRegistrationForm.allowsErrorReports();
     this.allowStatistics = adopterRegistrationForm.allowsStatistics();
   }
@@ -175,6 +180,10 @@ public class GeneralData {
 
   public String getContactMe() {
     return Boolean.toString(allowContact);
+  }
+
+  public String getTestSystem() {
+    return Boolean.toString(isTestSystem);
   }
 
   public String getErrorReports() {

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/dto/GeneralData.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/dto/GeneralData.java
@@ -82,9 +82,9 @@ public class GeneralData {
   @SerializedName("contact_me")
   private final boolean allowContact;
 
-  /** Whether this is a test system */
-  @SerializedName("test_system")
-  private final boolean isTestSystem;
+  /** Which type of system is this */
+  @SerializedName("system_type")
+  private final String systemType;
 
   /** Whether we can send error reports */
   @SerializedName("send_errors")
@@ -112,7 +112,7 @@ public class GeneralData {
     this.streetNo = adopterRegistrationForm.getStreetNo();
     this.email = adopterRegistrationForm.getEmail();
     this.allowContact = adopterRegistrationForm.allowsContacting();
-    this.isTestSystem = adopterRegistrationForm.isTestSystem();
+    this.systemType = adopterRegistrationForm.systemType();
     this.allowErrorReports = adopterRegistrationForm.allowsErrorReports();
     this.allowStatistics = adopterRegistrationForm.allowsStatistics();
   }
@@ -182,8 +182,8 @@ public class GeneralData {
     return Boolean.toString(allowContact);
   }
 
-  public String getTestSystem() {
-    return Boolean.toString(isTestSystem);
+  public String getSystemType() {
+    return systemType;
   }
 
   public String getErrorReports() {


### PR DESCRIPTION
Add the necessary rest api parameter and model column for the system type attribute which is send to registry.opencast.org. This change involves the [admin-interface](https://github.com/opencast/opencast-admin-interface) and the [adopter registration server](https://github.com/opencast/adopter-registration-server). 

Database migration is not required because [`create-or-extend-tables`](https://eclipse.dev/eclipselink/documentation/2.7/jpa/extensions/persistenceproperties_ref.htm#r3c1-t35) is configured:

https://github.com/opencast/opencast/blob/0b368b5203010f4d1cc43de9950deea22738fba7/modules/adopter-registration-impl/src/main/resources/META-INF/persistence.xml#L14

Close #5841

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
