### PR TITLE
Add missing payload in delete adopter request

### DIFF
--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/HttpDeleteWithEntity.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/HttpDeleteWithEntity.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.adopter.statistic;
+
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+
+import java.net.URI;
+
+/**
+ * Http DELETE method with request body
+ */
+public class HttpDeleteWithEntity extends HttpEntityEnclosingRequestBase {
+
+  public static final String METHOD_NAME = "DELETE";
+
+  public HttpDeleteWithEntity(final String uri) {
+    super();
+    setURI(URI.create(uri));
+  }
+
+  @Override
+  public String getMethod() {
+    return METHOD_NAME;
+  }
+}

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/Sender.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/Sender.java
@@ -23,9 +23,8 @@ package org.opencastproject.adopter.statistic;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.slf4j.Logger;
@@ -130,15 +129,15 @@ public class Sender {
   private void send(String json, String urlSuffix, String method) throws IOException {
     HttpClient client = HttpClientBuilder.create().useSystemProperties().build();
     String url = new URL(baseUrl + urlSuffix).toString();
-    HttpRequestBase request = null;
+    HttpEntityEnclosingRequestBase request = null;
     if ("DELETE".equals(method)) {
-      request = new HttpDelete(url);
+      request = new HttpDeleteWithEntity(url);
     } else {
       request = new HttpPost(url);
-      request.addHeader("Content-Type", "application/json; utf-8");
-      request.addHeader("Accept", "application/json");
-      ((HttpPost) request).setEntity(new StringEntity(json, StandardCharsets.UTF_8));
     }
+    request.addHeader("Content-Type", "application/json; utf-8");
+    request.addHeader("Accept", "application/json");
+    request.setEntity(new StringEntity(json, StandardCharsets.UTF_8));
 
     HttpResponse resp = client.execute(request);
     int httpStatus = resp.getStatusLine().getStatusCode();


### PR DESCRIPTION
Currently, the deletion of adopters is broken as the registration server expects a body in DELETE requests. If no data is transferred, a parsing error occurs on the registration server and no data will be deleted.

Unfortunately, the client library has no support for bodies in delete requests. Therefore, I had to create a new request method based on https://stackoverflow.com/a/43265866.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
