### PR TITLE
Always send adopter registration statistics in rest api

### DIFF
--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
@@ -242,12 +242,7 @@ public class ScheduledDataCollector extends TimerTask {
   public String getRegistrationDataAsString() throws Exception {
     Form adopter = (Form) adopterFormService.retrieveFormData();
     String generalJson = collectGeneralData(adopter);
-    String statsJson;
-    if (adopter.allowsStatistics()) {
-      statsJson = collectStatisticData(adopter.getAdopterKey(), adopter.getStatisticKey());
-    } else {
-      statsJson = "{}";
-    }
+    String statsJson = collectStatisticData(adopter.getAdopterKey(), adopter.getStatisticKey());
     //It's not stupid if it works!
     return "{ \"general\":" + generalJson + ", \"statistics\":" + statsJson + "}";
   }


### PR DESCRIPTION
Currently, the `/admin-ng/adopter/summary` route only returns the statistics data if statistics are allowed. This causes the admin ui problem mentioned in opencast/opencast-admin-interface#858. These changes return this data always.

Close opencast/opencast-admin-interface#858

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
