### PR TITLE
Switch to docker compose

### DIFF
--- a/.github/workflows/test-opencast-build.yml
+++ b/.github/workflows/test-opencast-build.yml
@@ -103,7 +103,7 @@ jobs:
         if: matrix.java == 11
         working-directory: docs/scripts/devel-dependency-containers
         run: |
-          docker-compose up -d
+          docker compose up -d
 
       - name: wait for elasticsearch to boot
         if: matrix.java == 11


### PR DESCRIPTION
The command `docker-compose` has been deprecated for a while and seems to finally be broken now:

```
Run docker-compose up -d
  docker-compose up -d
  shell: /usr/bin/bash -e {0}
  ...
/home/runner/work/_temp/c5c18e1f-32e8-4962-bd06-9bbdb4895343.sh: line 1: docker-compose: command not found
```

This patch switches to using `docker compose` instead.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
