### PR TITLE
Make loginbutton of engage ui configurable

### DIFF
--- a/docs/guides/admin/docs/configuration/security.aai.md
+++ b/docs/guides/admin/docs/configuration/security.aai.md
@@ -161,6 +161,19 @@ To protect HTML pages, you will need to adapt the configuration of your web serv
         require valid-user
     </LocationMatch>
 
+Step 4: Configuring engage-UI
+-------------------------------------------
+
+By default the engage-UI uses a standard login form. To make use of an AAI login we need to redirect the loginbutton to the AAI login URL:
+
+`etc/ui-config/mh_default_org/engage-ui/config.yml`:
+
+    customLoginURL: /Shibboleth.sso/Login?target=/engage/ui/index.html
+
+The logout works out of the box since the logoutbutton calls `/j_spring_security_logout` which then will redirect to the AAI logout location
+configured earlier in the logoutSuccessHandler.
+
+
 Advanced SSO configuration: The DynamicLoginHandler
 -----------------------------------
 

--- a/etc/ui-config/mh_default_org/engage-ui/config.yml
+++ b/etc/ui-config/mh_default_org/engage-ui/config.yml
@@ -1,3 +1,7 @@
 # The logo that is displayed in the upper left part of the media module page. This can be eithera path or a complete url
 # with scheme and port.
 logo: /engage/ui/img/logo/opencast-icon.svg
+
+# A custom URL the login button should point to.
+# Can be used for aai logins, e.g. /Shibboleth.sso/Login?target=/engage/ui/index.html
+# customLoginURL:

--- a/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
+++ b/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
@@ -39,6 +39,7 @@ function($, bootbox, _, alertify, jsyaml) {
   var configURL = '/ui/config/engage-ui/config.yml';
   var springSecurityLoginURL = '/j_spring_security_check';
   var springSecurityLogoutURL = '/j_spring_security_logout';
+  var customLoginURL = null;
 
   // various variables
   var mediaContainer = '<div class="col-xs-12 col-sm-6 col-md-4 col-lg-4">';
@@ -366,6 +367,13 @@ function($, bootbox, _, alertify, jsyaml) {
   });
 
   function login() {
+
+    // Redirect if login_url is present
+    if (customLoginURL) {
+      window.location.href = customLoginURL;
+      return null;
+    }
+
     if (!askedForLogin) {
       askedForLogin = true;
       var box = bootbox.dialog({
@@ -474,6 +482,7 @@ function($, bootbox, _, alertify, jsyaml) {
         log('Configuration loaded');
         var config = jsyaml.load(data);
         $($headerLogo).attr('src', config.logo || '');
+        customLoginURL = config.customLoginURL || null;
       }
     });
   }


### PR DESCRIPTION
closes #6089

Right now only credential login is supported by the engage ui. For setups that use aai login the loginbutton of the engage ui should be configurable e.g. to link to a shibboleth loginpage.

This PR introduces a new config variable in `etc/ui-config/mh_default_org/engage-ui/config.yml` to set a custom url the loginbutton should point to. If present, the ui will relocate to that url instead of showing the loginform.