### PR TITLE
Add more admin-UI Tobira endpoints

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -38,6 +38,7 @@ import static javax.servlet.http.HttpServletResponse.SC_NO_CONTENT;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
 import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
 import static org.opencastproject.index.service.util.RestUtils.conflictJson;
 import static org.opencastproject.index.service.util.RestUtils.notFound;
@@ -59,6 +60,8 @@ import static org.opencastproject.util.doc.rest.RestParameter.Type.TEXT;
 
 import org.opencastproject.adminui.exception.JobEndpointException;
 import org.opencastproject.adminui.impl.AdminUIConfiguration;
+import org.opencastproject.adminui.tobira.TobiraException;
+import org.opencastproject.adminui.tobira.TobiraService;
 import org.opencastproject.adminui.util.BulkUpdateUtil;
 import org.opencastproject.adminui.util.QueryPreprocessor;
 import org.opencastproject.assetmanager.api.AssetManager;
@@ -1822,6 +1825,55 @@ public abstract class AbstractEventEndpoint {
     if (publication == null)
       return notFound("Cannot find publication with id '%s'.", id);
     return okJson(publicationToJSON(publication));
+  }
+
+  @GET
+  @Path("{eventId}/tobira/pages")
+  @RestQuery(
+          name = "getEventHostPages",
+          description = "Returns the pages of a connected Tobira instance that contain the given event",
+          returnDescription = "The Tobira pages that contain the given event",
+          pathParameters = {
+                  @RestParameter(
+                          name = "eventId",
+                          isRequired = true,
+                          description = "The event identifier",
+                          type = STRING
+                  ),
+          },
+          responses = {
+                  @RestResponse(
+                          responseCode = SC_OK,
+                          description = "The Tobira pages containing the given event"
+                  ),
+                  @RestResponse(
+                          responseCode = SC_NOT_FOUND,
+                          description = "Tobira doesn't know about the given event"
+                  ),
+                  @RestResponse(
+                          responseCode = SC_SERVICE_UNAVAILABLE,
+                          description = "Tobira is not configured (correctly)"
+                  ),
+          }
+  )
+  public Response getEventHostPages(@PathParam("eventId") String eventId) {
+    var tobira = TobiraService.getTobira(getSecurityService().getOrganization().getId());
+    if (!tobira.ready()) {
+      return Response.status(Status.SERVICE_UNAVAILABLE)
+              .entity("Tobira is not configured (correctly)")
+              .build();
+    }
+
+    try {
+      var eventData = tobira.getEventHostPages(eventId);
+      if (eventData == null) {
+        throw new WebApplicationException(NOT_FOUND);
+      }
+      eventData.put("baseURL", tobira.getOrigin());
+      return Response.ok(eventData.toJSONString()).build();
+    } catch (TobiraException e) {
+      throw new WebApplicationException(e, Status.INTERNAL_SERVER_ERROR);
+    }
   }
 
   @GET

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
@@ -130,7 +130,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -242,7 +241,6 @@ public class SeriesEndpoint {
     return aclServiceFactory.serviceFor(securityService.getOrganization());
   }
 
-  private Map<String, TobiraService> tobiras = new HashMap<>();
 
   /** OSGi DI. */
   @Reference
@@ -287,7 +285,7 @@ public class SeriesEndpoint {
       if (!matches.matches()) {
         return;
       }
-      var tobira = getTobira(matches.group("organization"));
+      var tobira = TobiraService.getTobira(matches.group("organization"));
       switch (matches.group("key")) {
         case "origin":
           tobira.setOrigin((String) value);
@@ -534,12 +532,8 @@ public class SeriesEndpoint {
     return Response.ok(themesJson.toJSONString()).build();
   }
 
-  private TobiraService getTobira(String organization) {
-    return tobiras.computeIfAbsent(organization, org -> new TobiraService());
-  }
-
   private TobiraService getTobira() {
-    return getTobira(securityService.getOrganization().getId());
+    return TobiraService.getTobira(securityService.getOrganization().getId());
   }
 
   @GET

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/tobira/TobiraService.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/tobira/TobiraService.java
@@ -34,6 +34,7 @@ import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.HashMap;
 import java.util.Map;
 
 public final class TobiraService {
@@ -73,6 +74,23 @@ public final class TobiraService {
                     + "}",
             Map.of("seriesId", seriesId))
             .get("series");
+  }
+
+  public JSONObject getEventHostPages(String eventId) throws TobiraException {
+    return (JSONObject) request(
+            "query AdminUIHostPages($eventId: String!) {"
+                    + "  event: eventByOpencastId(id: $eventId) {"
+                    + "    ...on AuthorizedEvent {"
+                    + "      hostPages: hostRealms {"
+                    + "        title: name"
+                    + "        path"
+                    + "        ancestors { title: name }"
+                    + "      }"
+                    + "    }"
+                    + "  }"
+                    + "}",
+            Map.of("eventId", eventId)
+    ).get("event");
   }
 
   public void mount(Map<String, Object> variables) throws TobiraException {
@@ -151,4 +169,10 @@ public final class TobiraService {
           .build();
 
   private static final Logger logger = LoggerFactory.getLogger(TobiraService.class);
+
+  private static Map<String, TobiraService> tobiras = new HashMap<>();
+
+  public static TobiraService getTobira(String organization) {
+    return tobiras.computeIfAbsent(organization, org -> new TobiraService());
+  }
 }


### PR DESCRIPTION
This adds
 - a) an endpoint to get paths of pages in Tobira that host an event
 - b) an endpoint to update the path of a series in Tobira

This shouldn't break any existing behaviour.

These are needed for additional requirements of https://github.com/opencast/opencast-admin-interface/issues/311.
Corresponding Tobira and admin-UI PRs: https://github.com/elan-ev/tobira/pull/1225, https://github.com/opencast/opencast-admin-interface/pull/878.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
