### PR TITLE
Sign urls in search rest service again

### DIFF
--- a/modules/search-service-impl/pom.xml
+++ b/modules/search-service-impl/pom.xml
@@ -146,6 +146,11 @@
       <artifactId>lucene-core</artifactId>
       <version>${lucene.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-urlsigning-service-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
@@ -116,8 +116,6 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
 
   private UrlSigningService urlSigningService;
 
-  private long expireSeconds = UrlSigningServiceOsgiUtil.DEFAULT_URL_SIGNING_EXPIRE_DURATION;
-
   @GET
   @Path("series.json")
   @Produces(MediaType.APPLICATION_JSON)
@@ -468,7 +466,7 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
             try {
               String signedUrl = this.urlSigningService.sign(
                   urlToSign,
-                  expireSeconds,
+                  UrlSigningServiceOsgiUtil.DEFAULT_URL_SIGNING_EXPIRE_DURATION,
                   null,
                   null);
               map.put(entry.getKey(), signedUrl);

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
@@ -299,6 +299,13 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
               type = RestParameter.Type.INTEGER,
               defaultValue = "0",
               description = "The page number."
+          ),
+          @RestParameter(
+              name = "sign",
+              isRequired = false,
+              type = RestParameter.Type.BOOLEAN,
+              defaultValue = "true",
+              description = "If results are to be signed"
           )
       },
       responses = {
@@ -316,7 +323,8 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
       @QueryParam("sname") String seriesName,
       @QueryParam("sort") String sort,
       @QueryParam("limit") String limit,
-      @QueryParam("offset") String offset
+      @QueryParam("offset") String offset,
+      @QueryParam("sign") String sign
   ) throws SearchException {
 
     // There can only be one, sid or sname
@@ -431,7 +439,7 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
           .collect(Collectors.toList());
 
       // Sign urls if id is present
-      if (StringUtils.isNotEmpty(id) && this.urlSigningService != null) {
+      if (!"false".equals(sign) && this.urlSigningService != null) {
         this.findURLsAndSign(result);
       }
 
@@ -465,7 +473,7 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
                   null);
               map.put(entry.getKey(), signedUrl);
             } catch (UrlSigningException e) {
-              logger.debug("Unable to sign url '" + urlToSign + "'.");
+              logger.debug("Unable to sign url '{}'.", urlToSign);
             }
           }
         } else {

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
@@ -33,6 +33,9 @@ import org.opencastproject.search.impl.SearchServiceIndex;
 import org.opencastproject.security.api.Role;
 import org.opencastproject.security.api.SecurityConstants;
 import org.opencastproject.security.api.SecurityService;
+import org.opencastproject.security.urlsigning.exception.UrlSigningException;
+import org.opencastproject.security.urlsigning.service.UrlSigningService;
+import org.opencastproject.security.urlsigning.utils.UrlSigningServiceOsgiUtil;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
 import org.opencastproject.util.doc.rest.RestParameter;
 import org.opencastproject.util.doc.rest.RestQuery;
@@ -110,6 +113,10 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
   private SecurityService securityService;
 
   private final Gson gson = new Gson();
+
+  private UrlSigningService urlSigningService;
+
+  private long expireSeconds = UrlSigningServiceOsgiUtil.DEFAULT_URL_SIGNING_EXPIRE_DURATION;
 
   @GET
   @Path("series.json")
@@ -422,6 +429,12 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
       result = hits.getHits().stream()
           .map(SearchResult::dehydrateForREST)
           .collect(Collectors.toList());
+
+      // Sign urls if id is present
+      if (StringUtils.isNotEmpty(id) && this.urlSigningService != null) {
+        this.findURLsAndSign(result);
+      }
+
       total = hits.getTotalHits();
     }
     var json = gson.toJsonTree(Map.of(
@@ -431,6 +444,39 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
         "limit", size));
 
     return Response.ok(gson.toJson(json)).build();
+  }
+
+  /**
+   * Iterate recursively through Object List and sign all Strings with key=url
+   * @param obj
+   */
+  private void findURLsAndSign(Object obj) {
+    if (obj instanceof Map) {
+      Map<String, Object> map = (Map<String, Object>) obj;
+      for (Map.Entry<String, Object> entry : map.entrySet()) {
+        if (entry.getKey().equals("url") && entry.getValue() instanceof String) {
+          String urlToSign = (String) entry.getValue();
+          if (this.urlSigningService.accepts(urlToSign)) {
+            try {
+              String signedUrl = this.urlSigningService.sign(
+                  urlToSign,
+                  expireSeconds,
+                  null,
+                  null);
+              map.put(entry.getKey(), signedUrl);
+            } catch (UrlSigningException e) {
+              logger.debug("Unable to sign url '" + urlToSign + "'.");
+            }
+          }
+        } else {
+          findURLsAndSign(entry.getValue());
+        }
+      }
+    } else if (obj instanceof List) {
+      for (Object item : (List<?>) obj) {
+        findURLsAndSign(item);
+      }
+    }
   }
 
   /**
@@ -470,6 +516,11 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
   @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
+  }
+
+  @Reference
+  void setUrlSigningService(UrlSigningService service) {
+    this.urlSigningService = service;
   }
 
 }

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
@@ -438,7 +438,7 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
           .map(SearchResult::dehydrateForREST)
           .collect(Collectors.toList());
 
-      // Sign urls if id is present
+      // Sign urls if sign-parameter is not false
       if (!"false".equals(sign) && this.urlSigningService != null) {
         this.findURLsAndSign(result);
       }


### PR DESCRIPTION
closes #5957

Since the search rest service doesnt sign urls anymore, the engage player wont work when signing is required for all urls. This PR adds url signing again to the search rest service and therefore reintroduces the `sign` parameter, having the default to true.

Previous PR that falsely targeted develop: https://github.com/opencast/opencast/pull/6082