### PR TITLE
Remove references to JIRA in feedback URL docs

### DIFF
--- a/etc/org.opencastproject.organization-mh_default_org.cfg
+++ b/etc/org.opencastproject.organization-mh_default_org.cfg
@@ -122,11 +122,10 @@ prop.org.opencastproject.admin.help.restdocs.url=/rest_docs.html
 # Default: undefined
 prop.org.opencastproject.admin.mediamodule.url=${prop.org.opencastproject.engage.ui.url}/engage/ui
 
-# Link to a JIRA feedback widget collector.
+# Link to a feedback collector page.
 #
-# If the property is specified, the feedback button in the lower right corner will
-# link to the widget and allow to create issues right inside the project. If the
-# property is not specified, the feedback button will be hidden.
+# If the property is specified, a feedback button will appear in the lower right corner of the admin UI, linking
+# to the given URL. If it is not specified, no feedback button will be shown.
 #
 # Value: <a complete url with scheme and port>
 #


### PR DESCRIPTION
The feedback URL doesn't seem to have anything to dow ith JIRA anymore.