### PR TITLE
Fix broken ingest

### DIFF
--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
@@ -23,10 +23,6 @@ package org.opencastproject.ingest.endpoint;
 
 import static org.apache.commons.lang3.StringUtils.trimToNull;
 import static org.opencastproject.mediapackage.MediaPackageElements.XACML_POLICY_EPISODE;
-import static org.opencastproject.metadata.dublincore.DublinCore.PROPERTY_CREATED;
-import static org.opencastproject.metadata.dublincore.DublinCore.PROPERTY_DATE;
-import static org.opencastproject.metadata.dublincore.DublinCore.PROPERTY_IDENTIFIER;
-import static org.opencastproject.metadata.dublincore.DublinCore.PROPERTY_TEMPORAL;
 
 import org.opencastproject.authorization.xacml.XACMLUtils;
 import org.opencastproject.capture.CaptureParameters;
@@ -771,9 +767,7 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
             String fieldName = item.getFieldName();
             String value = Streams.asString(item.openStream(), StandardCharsets.UTF_8.toString());
             if (dcterms.contains(fieldName)) {
-              if (PROPERTY_CREATED.getLocalName().equals(fieldName)
-                  || PROPERTY_DATE.getLocalName().equals(fieldName)
-                  || PROPERTY_TEMPORAL.getLocalName().equals(fieldName)) {
+              if ("created".equals(fieldName) || "date".equals(fieldName) || "temporal".equals(fieldName)) {
                 try {
                   OpencastMetadataCodec.decodeDate(value);
                 } catch (IllegalArgumentException e) {
@@ -808,7 +802,7 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
               tags.add(value);
               /* Fields for DC catalog */
             } else if (dcterms.contains(fieldName)) {
-              if (PROPERTY_IDENTIFIER.getLocalName().equals(fieldName)) {
+              if ("identifier".equals(fieldName)) {
                 /* Use the identifier for the mediapackage */
                 mp.setIdentifier(new IdImpl(value));
               }

--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
@@ -760,24 +760,6 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
       int episodeDCCatalogNumber = 0;
       boolean hasMedia = false;
       if (ServletFileUpload.isMultipartContent(request)) {
-        // Validate first
-        for (FileItemIterator iter = new ServletFileUpload().getItemIterator(request); iter.hasNext();) {
-          FileItemStream item = iter.next();
-          if (item.isFormField()) {
-            String fieldName = item.getFieldName();
-            String value = Streams.asString(item.openStream(), "UTF-8");
-            if (dcterms.contains(fieldName)) {
-              if ("created".equals(fieldName) || "date".equals(fieldName) || "temporal".equals(fieldName)) {
-                try {
-                  OpencastMetadataCodec.decodeDate(value);
-                } catch (IllegalArgumentException e) {
-                  return badRequest("Provided dates were not well formatted", e);
-                }
-              }
-            }
-          }
-        }
-        // Add to mediapackage
         for (FileItemIterator iter = new ServletFileUpload().getItemIterator(request); iter.hasNext();) {
           FileItemStream item = iter.next();
           if (item.isFormField()) {
@@ -805,6 +787,13 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
               if ("identifier".equals(fieldName)) {
                 /* Use the identifier for the mediapackage */
                 mp.setIdentifier(new IdImpl(value));
+              }
+              if ("created".equals(fieldName) || "date".equals(fieldName) || "temporal".equals(fieldName)) {
+                try {
+                  OpencastMetadataCodec.decodeDate(value);
+                } catch (IllegalArgumentException e) {
+                  return badRequest("Provided dates were not well formatted", e);
+                }
               }
               if (dcc == null) {
                 dcc = dublinCoreService.newInstance();

--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
@@ -45,7 +45,6 @@ import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalogService;
 import org.opencastproject.metadata.dublincore.DublinCoreXmlFormat;
 import org.opencastproject.metadata.dublincore.DublinCores;
-import org.opencastproject.metadata.dublincore.OpencastMetadataCodec;
 import org.opencastproject.rest.AbstractJobProducerEndpoint;
 import org.opencastproject.scheduler.api.SchedulerConflictException;
 import org.opencastproject.scheduler.api.SchedulerException;
@@ -787,13 +786,6 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
               if ("identifier".equals(fieldName)) {
                 /* Use the identifier for the mediapackage */
                 mp.setIdentifier(new IdImpl(value));
-              }
-              if ("created".equals(fieldName) || "date".equals(fieldName) || "temporal".equals(fieldName)) {
-                try {
-                  OpencastMetadataCodec.decodeDate(value);
-                } catch (IllegalArgumentException e) {
-                  return badRequest("Provided dates were not well formatted", e);
-                }
               }
               if (dcc == null) {
                 dcc = dublinCoreService.newInstance();

--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
@@ -505,7 +505,7 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
         String fieldName = item.getFieldName();
         if (item.isFormField()) {
           if ("flavor".equals(fieldName)) {
-            String flavorString = Streams.asString(item.openStream(), StandardCharsets.UTF_8.toString());
+            String flavorString = Streams.asString(item.openStream(), "UTF-8");
             logger.trace("flavor: {}", flavorString);
             if (flavorString != null) {
               try {
@@ -517,12 +517,12 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
               }
             }
           } else if ("tags".equals(fieldName)) {
-            String tagsString = Streams.asString(item.openStream(), StandardCharsets.UTF_8.toString());
+            String tagsString = Streams.asString(item.openStream(), "UTF-8");
             logger.trace("tags: {}", tagsString);
             tags = tagsString.split(",");
           } else if ("mediaPackage".equals(fieldName)) {
             try {
-              String mediaPackageString = Streams.asString(item.openStream(), StandardCharsets.UTF_8.toString());
+              String mediaPackageString = Streams.asString(item.openStream(), "UTF-8");
               logger.trace("mediaPackage: {}", mediaPackageString);
               mp = MP_FACTORY.newMediaPackageBuilder().loadFromXml(mediaPackageString);
             } catch (MediaPackageException e) {
@@ -530,7 +530,7 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
               return Response.serverError().status(Status.BAD_REQUEST).build();
             }
           } else if ("startTime".equals(fieldName) && "/addPartialTrack".equals(request.getPathInfo())) {
-            String startTimeString = Streams.asString(item.openStream(), StandardCharsets.UTF_8.toString());
+            String startTimeString = Streams.asString(item.openStream(), "UTF-8");
             logger.trace("startTime: {}", startTime);
             try {
               startTime = Long.parseLong(startTimeString);
@@ -765,7 +765,7 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
           FileItemStream item = iter.next();
           if (item.isFormField()) {
             String fieldName = item.getFieldName();
-            String value = Streams.asString(item.openStream(), StandardCharsets.UTF_8.toString());
+            String value = Streams.asString(item.openStream(), "UTF-8");
             if (dcterms.contains(fieldName)) {
               if ("created".equals(fieldName) || "date".equals(fieldName) || "temporal".equals(fieldName)) {
                 try {
@@ -782,7 +782,7 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
           FileItemStream item = iter.next();
           if (item.isFormField()) {
             String fieldName = item.getFieldName();
-            String value = Streams.asString(item.openStream(), StandardCharsets.UTF_8.toString());
+            String value = Streams.asString(item.openStream(), "UTF-8");
             logger.trace("form field {}: {}", fieldName, value);
             /* Ignore empty fields */
             if ("".equals(value)) {
@@ -1072,7 +1072,7 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
           FileItemStream item = iter.next();
           if (item.isFormField()) {
             String fieldName = item.getFieldName();
-            String value = Streams.asString(item.openStream(), StandardCharsets.UTF_8.toString());
+            String value = Streams.asString(item.openStream(), "UTF-8");
             logger.trace("{}: {}", fieldName, value);
             if (WORKFLOW_INSTANCE_ID_PARAM.equals(fieldName)) {
               workflowIdAsString = value;
@@ -1202,7 +1202,7 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
         for (FileItemIterator iter = new ServletFileUpload().getItemIterator(request); iter.hasNext();) {
           FileItemStream item = iter.next();
           if (item.isFormField()) {
-            final String value = Streams.asString(item.openStream(), StandardCharsets.UTF_8.toString());
+            final String value = Streams.asString(item.openStream(), "UTF-8");
             formData.putSingle(item.getFieldName(), value);
           }
         }
@@ -1393,7 +1393,7 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
       return Response.status(Status.BAD_REQUEST).entity(e.getMessage()).build();
     }
 
-    try (InputStream in = IOUtils.toInputStream(dc, StandardCharsets.UTF_8.toString())) {
+    try (InputStream in = IOUtils.toInputStream(dc, "UTF-8")) {
       mediaPackage = ingestService.addCatalog(in, "dublincore.xml", dcFlavor, mediaPackage);
     } catch (MediaPackageException e) {
       return Response.serverError().status(Status.BAD_REQUEST).entity(e.getMessage()).build();


### PR DESCRIPTION
Pull request #6008 broke the ingest service. This may cause critical problems in production systems and even cause data loss if the uploaded data cannot be stored somewhere else temporarily. Even if it can, recovering from this might need manual work to get the data re-ingested.

```
❯ curl -i -u admin:opencast http://localhost:8080/ingest/addMediaPackage/fast -F 'flavor=presentation/source' -F mediaUri=https://data.lkiesow.io/opencast/vosk-test-en.mp4 -F title="I 🖤 Opencast" 

HTTP/2 400 
server: nginx
date: Thu, 15 Aug 2024 18:04:11 GMT
content-type: text/xml
content-length: 37
set-cookie: JSESSIONID=node0wvi51txwpbr51auxx95fvjquk66405.node0; Path=/; HTTPOnly; Secure; HttpOnly
expires: Thu, 01 Jan 1970 00:00:00 GMT
access-control-allow-methods: GET, POST, OPTIONS
access-control-allow-credentials: true
access-control-allow-headers: Origin,Content-Type,Accept,Authorization

Rejected ingest without actual media.
```

This patch reverts the pull request. That should cause no harm since it is a fix for #5954 which just reports that an incorrect error type is being returned.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
