### PR TITLE
Treat `filter` parameter elements in admin UI APIs as URL encoded

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/EndpointUtil.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/EndpointUtil.java
@@ -22,6 +22,7 @@
 package org.opencastproject.adminui.endpoint;
 
 import org.opencastproject.adminui.exception.JsonCreationException;
+import org.opencastproject.index.service.util.RestUtils;
 import org.opencastproject.list.impl.ResourceListQueryImpl;
 import org.opencastproject.list.query.StringListFilter;
 
@@ -86,16 +87,8 @@ public final class EndpointUtil {
    *          The query to update with the filters
    */
   public static void addRequestFiltersToQuery(final String filterString, ResourceListQueryImpl query) {
-    if (filterString != null) {
-      String[] filters = filterString.split(",");
-      for (String filter : filters) {
-        String[] splitFilter = filter.split(":", 2);
-        if (splitFilter != null && splitFilter.length == 2) {
-          String key = splitFilter[0].trim();
-          String value = splitFilter[1].trim();
-          query.addFilter(new StringListFilter(key, value));
-        }
-      }
+    for (var filter : RestUtils.parseFilter(filterString).entrySet()) {
+      query.addFilter(new StringListFilter(filter.getKey(), filter.getValue()));
     }
   }
 }

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/GroupsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/GroupsEndpoint.java
@@ -60,6 +60,7 @@ import com.entwinemedia.fn.data.json.JValue;
 import com.entwinemedia.fn.data.json.Jsons;
 
 import org.apache.commons.collections4.ComparatorUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -69,6 +70,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -161,7 +163,18 @@ public class GroupsEndpoint {
     }
 
     // The API currently does not offer full text search for groups
-    Map<String, String> filters = RestUtils.parseFilter(filter);
+    Map<String, String> filters = new HashMap<>();
+    if (StringUtils.isNotBlank(filter)) {
+      for (String f : filter.split(",")) {
+        String[] filterTuple = f.split(":");
+        if (filterTuple.length < 2) {
+          logger.debug("No value for filter '{}' in filters list: {}", filterTuple[0], filter);
+          continue;
+        }
+        // use substring because dates also contain : so there might be more than two parts
+        filters.put(filterTuple[0].trim(), f.substring(filterTuple[0].length() + 1).trim());
+      }
+    }
     Optional<String> optNameFilter = Optional.ofNullable(filters.get(GroupsListQuery.FILTER_NAME_NAME));
 
     Set<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(sort);

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/util/RestUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/util/RestUtils.java
@@ -43,6 +43,8 @@ import org.slf4j.LoggerFactory;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -292,7 +294,8 @@ public final class RestUtils {
           continue;
         }
         // use substring because dates also contain : so there might be more than two parts
-        filters.put(filterTuple[0].trim(), f.substring(filterTuple[0].length() + 1).trim());
+        filters.put(filterTuple[0].trim(), URLDecoder.decode(f.substring(filterTuple[0].length() + 1).trim(),
+            StandardCharsets.UTF_8));
       }
     }
     return filters;


### PR DESCRIPTION
This allows us to use literal `,` and `:` in filters, cf. #1673, specifically https://github.com/opencast/opencast/issues/1673#issuecomment-2093704704.

Note that this targets `r/15.x` despite it changing behavior! Arguably a comma leading to filters being misinterpreted is a bug, but this "fixes" it by also changing the meaning of certain other filters. (Think literal `%2C` for example.)

I did this to not lock ourselves out of updating the admin UI in `legacy` and `stable` once the corresponding PR for the admin UI lands.

Note also that I had to duplicate the old version of the method used into the `GroupsEndpoint` of the external API as to not change its behavior. This makes most (hopefully all) admin UI endpoints' behavior regarding the `filter` parameter (more) inconsistent with the external API.

Fixing that would be disproportionally more effort in my opinion, and if I were to do that, I would probably completely revamp how filters are passed/processed to begin with, because frankly naively splitting a string at `,` was never a good idea.

This way at least clicking on a name with a comma in the admin UI does the right thing. 🤷‍♀️