### PR TITLE
Add missing target-tags to amberscript attach transcription docs

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/amberscript-attach-transcription-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/amberscript-attach-transcription-woh.md
@@ -18,8 +18,9 @@ Parameter Table
 |-----------------------|----------|------------------------------------------------------------------------------------|-----------------------|----------------------------------------------|
 | transcription-job-id  | yes      | This is filled out by the transcription service when starting the workflow.        | -                     | **Should always be "${transcriptionJobId}"** |
 | target-flavor         | yes      | The flavor to apply to the captions/transcriptions file.                           | -                     | captions/source                              |
-| target-tag            | no       | The tag to apply to the caption/transcription file generated.*                     | -                     | generator-type:auto                          |
+| target-tag            | no       | A tag to apply to the caption/transcription file generated¹                        | -                     | generator-type:auto                          |
+| target-tags           | no       | Comma separated list of tags to apply to generated file¹. Overwrites `target-tag`  | -                     | generator-type:auto,generator:amberscript    |
 | target-caption-format | no       | The caption format to be generated.                                                | vtt                   | srt                                          |
 | target-element-type   | no       | Define where to append the subtitles file. Accepted values: 'track', 'attachment'. | track                 | track                                        |
 
-*For conventionally used tags see the general page on [Subtitles](../configuration/subtitles.md).
+¹⁾For conventionally used tags see the general page on [Subtitles](../configuration/subtitles.md).


### PR DESCRIPTION
The documentation only mentions `target-tag`, but the operation also supports `target-tags`.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
