### PR TITLE
Allow Amberscript transcriptions to be attached as tracks

### DIFF
--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AmberscriptAttachTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AmberscriptAttachTranscriptionOperationHandler.java
@@ -23,12 +23,12 @@ package org.opencastproject.transcription.workflowoperation;
 import org.opencastproject.caption.api.CaptionService;
 import org.opencastproject.job.api.Job;
 import org.opencastproject.job.api.JobContext;
-import org.opencastproject.mediapackage.Attachment;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElement;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.mediapackage.MediaPackageElementParser;
 import org.opencastproject.mediapackage.Track;
+import org.opencastproject.mediapackage.track.TrackImpl;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
 import org.opencastproject.transcription.api.TranscriptionService;
 import org.opencastproject.transcription.api.TranscriptionServiceException;
@@ -98,22 +98,7 @@ public class AmberscriptAttachTranscriptionOperationHandler extends AbstractWork
     MediaPackageElementFlavor targetFlavor = tagsAndFlavors.getSingleTargetFlavor();
     List<String> targetTagOption = tagsAndFlavors.getTargetTags();
     String captionFormatOption = StringUtils.trimToNull(operation.getConfiguration(TARGET_CAPTION_FORMAT));
-    String typeUnparsed = StringUtils.trimToEmpty(operation.getConfiguration(TARGET_TYPE));
-    MediaPackageElement.Type type = null;
-    if (!typeUnparsed.isEmpty()) {
-      // Case insensitive matching between user input (workflow config key) and enum value
-      for (MediaPackageElement.Type t : MediaPackageElement.Type.values()) {
-        if (t.name().equalsIgnoreCase(typeUnparsed)) {
-          type = t;
-        }
-      }
-      if (type == null || (type != Track.TYPE && type != Attachment.TYPE)) {
-        throw new IllegalArgumentException(String.format("The given type '%s' for mediapackage %s was illegal. Please"
-                + "check the operations' configuration keys.", type, mediaPackage.getIdentifier()));
-      }
-    } else {
-      type = Track.TYPE;
-    }
+    MediaPackageElement.Type type = getTargetType(operation.getConfiguration(TARGET_TYPE));
 
     // If the target format is not specified, convert to vtt (default output format is srt)
     String format = (captionFormatOption != null) ? captionFormatOption : "vtt";
@@ -129,12 +114,28 @@ public class AmberscriptAttachTranscriptionOperationHandler extends AbstractWork
       MediaPackageElement convertedTranscription = MediaPackageElementParser.getFromXml(job.getPayload());
       workspace.delete(transcription.getURI());
 
+      // The SubRip converter always returns Attachments. We may need to turn it into a Track
+      if (type == MediaPackageElement.Type.Track) {
+        var elem = new TrackImpl();
+        elem.setURI(convertedTranscription.getURI());
+        elem.setIdentifier(convertedTranscription.getIdentifier());
+        elem.setMimeType(convertedTranscription.getMimeType());
+        for (var tag: convertedTranscription.getTags()) {
+          elem.addTag(tag);
+        }
+        convertedTranscription = elem;
+      }
+
+      convertedTranscription.addTag("generator-type:auto");
+      convertedTranscription.addTag("generator:amberscript");
       convertedTranscription.setFlavor(targetFlavor);
       for (String tag : targetTagOption) {
         convertedTranscription.addTag(tag);
       }
       mediaPackage.add(convertedTranscription);
-      logger.info("Added transcription to the media package {}: {}", mediaPackage, convertedTranscription.getURI());
+      logger.info("Added transcription to the media package {} as {}: {}", mediaPackage,
+          convertedTranscription.getElementType(),
+          convertedTranscription.getURI());
 
     } catch (TranscriptionServiceException e) {
       if (e.isCancel()) {
@@ -147,6 +148,25 @@ public class AmberscriptAttachTranscriptionOperationHandler extends AbstractWork
     }
 
     return createResult(mediaPackage, Action.CONTINUE);
+  }
+
+  /**
+   * Parse the target-type configuration and return the requested MediaPackageElement.Type
+   * @param typeUnparsed Configuration value
+   * @return Requested type
+   */
+  private static MediaPackageElement.Type getTargetType(String typeUnparsed) {
+    if (StringUtils.isBlank(typeUnparsed)) {
+      return Track.TYPE;
+    }
+    if (MediaPackageElement.Type.Attachment.name().equalsIgnoreCase(typeUnparsed)) {
+      return MediaPackageElement.Type.Attachment;
+    }
+    if (MediaPackageElement.Type.Track.name().equalsIgnoreCase(typeUnparsed)) {
+      return MediaPackageElement.Type.Track;
+    }
+    throw new IllegalArgumentException(String.format("The requested type '%s' is illegal. Please"
+            + "check the operation's configuration keys.", typeUnparsed));
   }
 
   @Reference(target = "(provider=amberscript)")


### PR DESCRIPTION
Configuring the `amberscript-attach-transcription` workflow operation handler to add subtitles as tracks to the media package has no effect and they will still be added as attachments since the SubRib converter always returns attachments.

This patch fixes the problem by simplifying the configuration parsing, converting the attachment to a track if necessary and also adding the recommended generator tags to the final media package element.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
