### PR TITLE
Add useful videos to documentation

### DIFF
--- a/docs/guides/admin/docs/configuration/encoding.md
+++ b/docs/guides/admin/docs/configuration/encoding.md
@@ -10,6 +10,8 @@ build to work for everyone, meaning that in most cases optimization can be done 
 these profiles or building new ones often makes sense. This document will help you modify or augment Opencast's
 default encoding profiles for audio, video and still images.
 
+If you prefer a video introduction to the topic, check out [this talk on encoding profiles and ffmpeg](https://video.ethz.ch/events/opencast/2020/gent/63bccf44-3409-4434-9988-be4e8674f607.html) 
+
 Default Profiles and Possible Settings
 --------------------------------------
 

--- a/docs/guides/admin/docs/configuration/ltimodule.md
+++ b/docs/guides/admin/docs/configuration/ltimodule.md
@@ -14,6 +14,8 @@ Opencast videos without ever leaving their course.
 
 More information about the LTI specification is available at
 [IMS Learning Tools Interoperability](https://imsglobal.org/activity/learning-tools-interoperability).
+For a better  understanding of what LTI is and what it is not, consider this
+[introductory webinar](https://video.ethz.ch/events/opencast/miscellaneous/webinars/3bb13443-19d3-4147-8ff9-7106f5a959bb.html).
 
 
 Configuration

--- a/docs/guides/admin/docs/configuration/workflow.md
+++ b/docs/guides/admin/docs/configuration/workflow.md
@@ -13,6 +13,9 @@ operations, see:
 
 > [List of Workflow Operation Handler](../workflowoperationhandlers/index.md)
 
+For a video introduction to workflow, take a look at this [workflow workshop](https://video.ethz.ch/events/opencast/2020/gent/7cb2164f-e060-4108-9b3f-770e9f361ec7.html).
+Or for longer session, check out this [in-depth webinar on workflows](https://video.ethz.ch/events/opencast/miscellaneous/webinars/445be642-685a-4575-9bbf-08db21bd8c94.html).
+
 ## Overview
 
 A Opencast workflow is an ordered list of operations. There is no limit to the number of operations or their

--- a/docs/guides/developer/docs/architecture/filesystem.md
+++ b/docs/guides/developer/docs/architecture/filesystem.md
@@ -1,1 +1,3 @@
 # Under Construction
+
+While this page is being constructed, consider checking out [this webinar on Storage management and snapshots](https://video.ethz.ch/events/opencast/miscellaneous/webinars/ba506689-f6ff-4ebd-bfb7-b61d2f3fcaef.html).

--- a/docs/guides/developer/docs/architecture/job-dispatch.md
+++ b/docs/guides/developer/docs/architecture/job-dispatch.md
@@ -1,1 +1,3 @@
-# In construction
+# Under construction
+
+While this page is being constructed, consider checking out [this webinar on Job Dispatching and Job Loads](https://video.ethz.ch/events/opencast/miscellaneous/webinars/ac93170a-79ab-4981-b8c0-06bd224a07a8.html).

--- a/docs/guides/developer/docs/develop/integration.md
+++ b/docs/guides/developer/docs/develop/integration.md
@@ -1,0 +1,7 @@
+Integrating with Opencast
+-------------------------
+
+### Video guides
+[How to integrate? An overview of Opencast's APIs](https://video.ethz.ch/events/opencast/2023/berlin/41ccd52d-97cc-4cbc-bfdc-26dfa5271135.html),
+a talk from the Opencast Summit 2023 which goes over the different APIs Opencast makes available and how they should or
+should not be used.

--- a/docs/guides/developer/docs/participate/development-process.md
+++ b/docs/guides/developer/docs/participate/development-process.md
@@ -289,6 +289,9 @@ and that code patches do not break the existing functionality. These tests are a
 built. If building repeatedly fails due to test failures, then something is most likely wrong. Please report this as a
 severe bug.
 
+For a guide on how to write unit tests, see [Writing Unit Tests](https://video.ethz.ch/events/opencast/2023/berlin/b4861f53-738b-40fb-a1ab-ec4726eec6bd.html),
+a talk how to write (good!) unit tests.
+
 ### User Tests
 
 Before each major release, the release and quality assurance managers will ask the whole community to participate in

--- a/docs/guides/developer/mkdocs.yml
+++ b/docs/guides/developer/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
             - Typeface: 'develop/frontends/admin-ui/style/typeface.md'
             - View Structure: 'develop/frontends/admin-ui/style/view-structure.md'
    - Documentation: 'develop/documentation.md'
+   - Integrating with Opencast: 'develop/integration.md'
 - Opencast architecture:
    - Overview: 'architecture/overview.md'
    - Admin-UI: 'architecture/admin-ui.md'


### PR DESCRIPTION
Fixes #5962.

Adds various talks and webinars to the opencast documentation. These are mostly introductory talks to a given topic, or relatively timeless guides to timeless topics.

If you feel I missed a publicly available video recording that should definitely be included in the docs, shoot me the link and I'll try to fit it in.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
