### PR TITLE
Fix non-themed subtitle publications

### DIFF
--- a/etc/workflows/partial-theming.xml
+++ b/etc/workflows/partial-theming.xml
@@ -46,7 +46,7 @@
       if="NOT(${theme_active})"
       description="Tag elements as themed">
       <configurations>
-        <configuration key="source-flavors">*/trimmed</configuration>
+        <configuration key="source-flavors">presenter/trimmed,presentation/trimmed</configuration>
         <configuration key="target-flavor">*/themed</configuration>
         <configuration key="copy">false</configuration>
       </configurations>


### PR DESCRIPTION
Fixes #6138 

At the end of the workflow partial-theming captions/trimmed is tagged as captions/shifted, this is necessary for the publication of the captions. If there is no branding/theme configured for an event, there is no captions/trimmed flavour available to tag. This is because captions/trimmed is replaced by captions/themed in partial-theming WF. To fix this, a copy needs to be created instead of replacing.

### Your pull request should…

* [x] have a concise title
* [x [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
