### PR TITLE
Fix tobira harvest acls

### DIFF
--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Item.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Item.java
@@ -36,6 +36,7 @@ import org.opencastproject.metadata.dublincore.DublinCoreUtil;
 import org.opencastproject.metadata.dublincore.EncodingSchemeUtils;
 import org.opencastproject.metadata.mpeg7.MediaTimePointImpl;
 import org.opencastproject.search.api.SearchResultItem;
+import org.opencastproject.security.api.AccessControlEntry;
 import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.security.api.AccessControlParser;
 import org.opencastproject.security.api.AclScope;
@@ -236,11 +237,11 @@ class Item {
     // value being a list of roles, e.g.
     // `{ "read": ["ROLE_USER", "ROLE_FOO"], "write": [...] }`
     final var actionToRoles = new HashMap<String, ArrayList<Jsons.Val>>();
-    for (final var entry: acl.getEntries()) {
+    acl.getEntries().stream().filter(AccessControlEntry::isAllow).forEach(entry -> {
       final var action = entry.getAction();
-      actionToRoles.putIfAbsent(action, new ArrayList());
+      actionToRoles.putIfAbsent(action, new ArrayList<>());
       actionToRoles.get(action).add(Jsons.v(entry.getRole()));
-    }
+    });
 
     final var props = actionToRoles.entrySet().stream()
         .map(e -> Jsons.p(e.getKey(), Jsons.arr(e.getValue())))


### PR DESCRIPTION
An ACL can contain `allow` and `deny` rules; until now, all roles were added to the action to roles map, which only represents the allowed actions.

This has led to users seeing videos in Tobira for which access has been denied.

This can be tested by updating the series acl via /series endpoint and republishing the acl.

**POST /series/{seriesID:.+}/accesscontrol**
```XML
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<acl xmlns="http://org.opencastproject.security">
  <ace>
    <role>ROLE_USER</role>
    <action>write</action>
    <allow>false</allow>
  </ace>
  <ace>
    <role>ROLE_USER</role>
    <action>read</action>
    <allow>true</allow>
  </ace>
  <ace>
    <role>ROLE_USER_TEST</role>
    <action>read</action>
    <allow>true</allow>
  </ace>
  <ace>
    <role>ROLE_USER_TEST</role>
    <action>write</action>
    <allow>true</allow>
  </ace>
</acl>
```

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
