### PR TITLE
Fix sort parameter in search series rest endpoint

### DIFF
--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
@@ -224,7 +224,7 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
       if ("modified".equals(sortParam[0])) {
         searchSource.sort(sortParam[0], order);
       } else {
-        searchSource.sort(SearchResult.DUBLINCORE + sortParam[0], order);
+        searchSource.sort(SearchResult.DUBLINCORE + "." + sortParam[0], order);
       }
     }
 


### PR DESCRIPTION
Adds the missing dot in the field name to be sorted. 

Fixes the 500 error in the endpoint `GET /series.json` of the search rest service:

![image](https://github.com/user-attachments/assets/37d7c66b-d45b-4ee2-b072-33c088f8fd02)


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
