### PR TITLE
Prevent broken XML from failing index rebuild completely

### DIFF
--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
@@ -473,7 +473,7 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
             logIndexRebuildError(logger, total, current.get(), e);
             //NB: Runtime exception thrown to escape the functional interfacing
             throw new RuntimeException("Internal Index Rebuild Failure", e);
-          } catch (NotFoundException e) {
+          } catch (RuntimeException | NotFoundException e) {
             logSkippingElement(logger, "event", tuple.getA().getIdentifier().toString(), e);
           }
         });


### PR DESCRIPTION
We had one broken DC XML file which caused a RuntimeException when Opencast tried parsing it during the search service search index rebuild. This patch prevents the error from creaking the rebuild, only logging the error instead.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
