### PR TITLE
Deleting events which do not exist in the search index

### DIFF
--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
@@ -355,7 +355,11 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
       var updateRequst = new UpdateRequest(INDEX_NAME, mediaPackageId)
           .doc(gson.toJson(json), XContentType.JSON);
       esIndex.getClient().update(updateRequst, RequestOptions.DEFAULT);
-
+    } catch (ElasticsearchStatusException e) {
+      if (e.status().getStatus() != RestStatus.NOT_FOUND.getStatus()) {
+        throw e;
+      }
+      logger.warn("Event {} is not in the search index. Skipping deletion", mediaPackageId);
     } catch (IOException e) {
       throw new SearchException("Could not delete episode " + mediaPackageId + " from index", e);
     }


### PR DESCRIPTION
Deleting an event from the search service fails completely if the event is not in OpenSearch. It should be happy that it's already gone instead and continue.

This fixes #6174

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
