### PR TITLE
Proposal: standard JWT schema and path for better JWT support

### DIFF
--- a/docs/guides/admin/docs/configuration/security.jwt.md
+++ b/docs/guides/admin/docs/configuration/security.jwt.md
@@ -40,10 +40,10 @@ This schema is designed to be flexible and support all current and conceivable f
 
     // Authorization, i.e. privileges the request/user should have
     "roles": ["ROLE_STUDIO", "ROLE_API_EVENTS_VIEW"],
-    "oc": [
-        "read+customaction:e:d622b861-4264-4947-8db1-c754c5956433",
-        "write:s:4ed02421-144c-42a1-b98a-22e84f3ac691"
-    ]
+    "oc": {
+        "e:d622b861-4264-4947-8db1-c754c5956433": ["read, "annotate"],
+        "s:4ed02421-144c-42a1-b98a-22e84f3ac691": ["write"]
+    }
 }
 ```
 
@@ -62,15 +62,12 @@ A claim being "required" means that the JWT provider (e.g. Tobira, LMS) has to i
 
 - *Authorization*: at least one of these claims has to be set, as otherwise no privileges are granted (which is the same as not sending a JWT at all).
     - `roles`: array of strings, specifying roles to grant to the request/user directly.
-    - `oc`: array of strings, grants access to single items in Opencast. The custom syntax is terse in order to keep JWTs as small as possible. Each string consists of three parts, which are separated by a colon (`:`):
-        - *Action(s)*: the first part specifies what actions are granted, corresponding to actions in the OC ACLs, e.g. `read` and `write`. Multiple actions can be specified by joining them with `+`. To keep the syntax unambigious, actions cannot contain `:` or `+` (ideally they are ASCII alphabetic only!). To further preserve space, some actions imply others:
-            - `write` implies `read` access
-            - `annotate` implies `read` access
-        - *Item Type*: The second part specifies what type of item this applies to. Note: giving access to a series or playlist only gives access to that item directly, and *not* to its videos (e.g. give write access for a series to be able to edit its metadata or add videos to it).
+    - `oc`: JSON map that grants access to single items in Opencast, as identified by the map key.
+        - The map key consists of a one-letter prefix (the item type), a colon, and finally the actual ID of the Opencast item. The following item types are supported. Note: giving access to a series or playlist only gives access to that item directly, and *not* to its videos (e.g. give write access for a series to be able to edit its metadata or add videos to it).
             - `e`: event
             - `s`: series
             - `p`: playlist
-        - *ID*: the final part specifies the ID of the item that is granted access to.
+        - The map value is just an array of actions, corresponding to actions in the OC ACLs, e.g. `read` and `write`.
 
 
 ### Examples
@@ -82,7 +79,7 @@ An external application wants a user to load a protected static file from Openca
 ```json
 {
     "exp": 1499863217,
-    "oc": ["read:e:d622b861-4264-4947-8db1-c754c5956433"]
+    "oc": { "e:d622b861-4264-4947-8db1-c754c5956433": ["read"] }
 }
 ```
 

--- a/docs/guides/admin/docs/configuration/security.jwt.md
+++ b/docs/guides/admin/docs/configuration/security.jwt.md
@@ -39,7 +39,7 @@ This schema is designed to be flexible and support all current and conceivable f
     "email": "jose@example.com",
 
     // Authorization, i.e. privileges the request/user should have
-    "roles": ["STUDIO", "API_EVENTS_VIEW"], // without `ROLE_` prefix
+    "roles": ["ROLE_STUDIO", "ROLE_API_EVENTS_VIEW"],
     "oc": [
         "read+customaction:e:d622b861-4264-4947-8db1-c754c5956433",
         "write:s:4ed02421-144c-42a1-b98a-22e84f3ac691"
@@ -61,7 +61,7 @@ A claim being "required" means that the JWT provider (e.g. Tobira, LMS) has to i
     - `email`: string.
 
 - *Authorization*: at least one of these claims has to be set, as otherwise no privileges are granted (which is the same as not sending a JWT at all).
-    - `roles`: array of strings, specifying roles to grant to the request/user directly. The `ROLE_` prefix must be omitted as Opencast adds it itself.
+    - `roles`: array of strings, specifying roles to grant to the request/user directly.
     - `oc`: array of strings, grants access to single items in Opencast. The custom syntax is terse in order to keep JWTs as small as possible. Each string consists of three parts, which are separated by a colon (`:`):
         - *Action(s)*: the first part specifies what actions are granted, corresponding to actions in the OC ACLs, e.g. `read` and `write`. Multiple actions can be specified by joining them with `+`. To keep the syntax unambigious, actions cannot contain `:` or `+` (ideally they are ASCII alphabetic only!). To further preserve space, some actions imply others:
             - `write` implies `read` access
@@ -96,7 +96,7 @@ An external application wants to let a user use Opencast Studio to record and up
     "username": "peter",
     "name": "Peter Lustig",
     "email": "peter@example.com",
-    "roles": ["STUDIO"]
+    "roles": ["ROLE_STUDIO"]
 }
 ```
 

--- a/docs/guides/admin/docs/configuration/security.jwt.md
+++ b/docs/guides/admin/docs/configuration/security.jwt.md
@@ -34,7 +34,7 @@ This schema is designed to be flexible and support all current and conceivable f
     "nbf": 1548632170, // optional
 
     // User info
-    "username": "jose",
+    "sub": "jose", // username
     "name": "José Carreño Quiñones",
     "email": "jose@example.com",
 
@@ -56,7 +56,7 @@ A claim being "required" means that the JWT provider (e.g. Tobira, LMS) has to i
 - `nbf` (not before): As [defined in the JWT RFC](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.5), a number timestamp in seconds since the unix epoch. JWTs with `nbf > now()` are rejected by Opencast. This claim is optional.
 
 - *User Info*: information about the user that's possibly used by parts of Opencast. Some JWT use cases don't require user information at all (e.g. static file auth), while others do (e.g. Studio). Therefore, these claims are optional. (TODO: specify when this is stored as user reference)
-    - `username`: string. (TODO: explain how this is used to lookup existing users, if at all)
+    - `sub`: Opencast username, string. (TODO: explain how this is used to lookup existing users, if at all)
     - `name`: display name, string.
     - `email`: string.
 
@@ -93,7 +93,7 @@ An external application wants to let a user use Opencast Studio to record and up
 ```json
 {
     "exp": 1499863217,
-    "username": "peter",
+    "sub": "peter",
     "name": "Peter Lustig",
     "email": "peter@example.com",
     "roles": ["ROLE_STUDIO"]
@@ -173,7 +173,7 @@ sections found in `etc/security/mh_default_org.xml`. Some of the options are con
   <property name="expectedAlgorithms" ref="jwtExpectedAlgorithms" />
   <property name="claimConstraints" ref="jwtClaimConstraints" />
   <!-- Mapping used to extract the username from the JWT (default: null) -->
-  <property name="usernameMapping" value="['username'].asString()" />
+  <property name="usernameMapping" value="['sub'].asString()" />
   <!-- Mapping used to extract the name from the JWT (default: null) -->
   <property name="nameMapping" value="['name'].asString()" />
   <!-- Mapping used to extract the email from the JWT (default: null) -->
@@ -207,7 +207,7 @@ sections found in `etc/security/mh_default_org.xml`. Some of the options are con
 <util:list id="jwtClaimConstraints" value-type="java.lang.String">
   <value>containsKey('iss')</value>
   <value>containsKey('aud')</value>
-  <value>containsKey('username')</value>
+  <value>containsKey('sub')</value>
   <value>containsKey('name')</value>
   <value>containsKey('email')</value>
   <value>containsKey('domain')</value>
@@ -225,8 +225,8 @@ sections found in `etc/security/mh_default_org.xml`. Some of the options are con
 <!-- The mapping from JWT claims to Opencast roles -->
 <util:list id="jwtRoleMappings" value-type="java.lang.String">
   <value>'ROLE_JWT_USER'</value>
-  <value>'ROLE_JWT_USER_' + ['username'].asString()</value>
-  <value>('ROLE_JWT_OWNER_' + ['username'].asString()).replaceAll("[^a-zA-Z0-9]","_").toUpperCase()</value>
+  <value>'ROLE_JWT_USER_' + ['sub'].asString()</value>
+  <value>('ROLE_JWT_OWNER_' + ['sub'].asString()).replaceAll("[^a-zA-Z0-9]","_").toUpperCase()</value>
   <value>['domain'] != null ? 'ROLE_JWT_ORG_' + ['domain'].asString() + '_MEMBER' : null</value>
   <value>['username'].asString() eq ('j_doe01@example.org') ? 'ROLE_ADMIN' : null</value>
   <value>['affiliation'].asList(T(String)).contains('faculty@example.org') ? 'ROLE_GROUP_JWT_TRAINER' : null</value>

--- a/docs/guides/admin/docs/configuration/security.jwt.md
+++ b/docs/guides/admin/docs/configuration/security.jwt.md
@@ -66,7 +66,7 @@ A claim being "required" means that the JWT provider (e.g. Tobira, LMS) has to i
         - *Action(s)*: the first part specifies what actions are granted, corresponding to actions in the OC ACLs, e.g. `read` and `write`. Multiple actions can be specified by joining them with `+`. To keep the syntax unambigious, actions cannot contain `:` or `+` (ideally they are ASCII alphabetic only!). To further preserve space, some actions imply others:
             - `write` implies `read` access
             - `annotate` implies `read` access
-        - *Item Type*: The second part specifies what type of item this applies to:
+        - *Item Type*: The second part specifies what type of item this applies to. Note: giving access to a series or playlist only gives access to that item directly, and *not* to its videos (e.g. give write access for a series to be able to edit its metadata or add videos to it).
             - `e`: event
             - `s`: series
             - `p`: playlist

--- a/docs/guides/admin/docs/configuration/security.jwt.md
+++ b/docs/guides/admin/docs/configuration/security.jwt.md
@@ -21,7 +21,7 @@ In order to integrate Opencast with an OIDC provider you could use the
 Standard OC Schema for JWTs
 ---------------------------
 
-After the signature verification, a JWT is just a bunch of "claims" (JSON fields). How to interpret these claims is completely up to the communicating parties. Protocols like OIDC define exactly which claims are to be used and how. For other cases where external Opencast apps (like Tobira or an LMS) need to communicate with Opencast, this section defines a standard schema to follow. You can configure Opencast differently, but this aims at standardizing JWT usage across Opencast-related applications and offer an out-of-the-box solution.
+After the signature verification, a JWT is just a bunch of "claims" (JSON fields). The communicating parties can decide fairly freely on how to interpret these claims. Protocols like OIDC define exactly which claims are to be used and how. For other cases where external Opencast apps (like Tobira or an LMS) need to communicate with Opencast, this section defines a standard schema to follow. You can configure Opencast differently, but this aims at standardizing JWT usage across Opencast-related applications and offer an out-of-the-box solution.
 
 This schema is designed to be flexible and support all current and conceivable future use cases, while keeping the JWT size for each use case small.
 

--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -755,6 +755,7 @@
     <property name="usernameMapping" value="['username'].asString()" />
     <property name="nameMapping" value="['name'].asString()" />
     <property name="emailMapping" value="['email'].asString()" />
+    <property name="ocStandardRoleMappings" value="true" />
     <property name="roleMappings" ref="jwtRoleMappings" />
     <property name="jwtCacheSize" value="500" />
     <property name="jwtCacheExpiresIn" value="60" />

--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -752,7 +752,7 @@
     <property name="secret" value="***" />
     <property name="expectedAlgorithms" ref="jwtExpectedAlgorithms" />
     <property name="claimConstraints" ref="jwtClaimConstraints" />
-    <property name="usernameMapping" value="['username'].asString()" />
+    <property name="usernameMapping" value="['sub'].asString()" />
     <property name="nameMapping" value="['name'].asString()" />
     <property name="emailMapping" value="['email'].asString()" />
     <property name="ocStandardRoleMappings" value="true" />
@@ -772,7 +772,7 @@
   <util:list id="jwtClaimConstraints" value-type="java.lang.String">
     <value>containsKey('iss')</value>
     <value>containsKey('aud')</value>
-    <value>containsKey('username')</value>
+    <value>containsKey('sub')</value>
     <value>containsKey('name')</value>
     <value>containsKey('email')</value>
     <value>containsKey('domain')</value>
@@ -787,8 +787,8 @@
   <!-- The mapping from JWT claims to Opencast roles
   <util:list id="jwtRoleMappings" value-type="java.lang.String">
     <value>'ROLE_JWT_USER'</value>
-    <value>'ROLE_JWT_USER_' + ['username'].asString()</value>
-    <value>('ROLE_JWT_OWNER_' + ['username'].asString()).replaceAll("[^a-zA-Z0-9]","_").toUpperCase()</value>
+    <value>'ROLE_JWT_USER_' + ['sub'].asString()</value>
+    <value>('ROLE_JWT_OWNER_' + ['sub'].asString()).replaceAll("[^a-zA-Z0-9]","_").toUpperCase()</value>
     <value>['domain'] != null ? 'ROLE_JWT_ORG_' + ['domain'].asString() + '_MEMBER' : null</value>
     <value>['username'].asString() eq ('j_doe01@example.org') ? 'ROLE_ADMIN' : null</value>
     <value>['affiliation'].asList(T(String)).contains('faculty@example.org') ? 'ROLE_GROUP_JWT_TRAINER' : null</value>

--- a/modules/security-jwt/src/main/java/org/opencastproject/security/jwt/DynamicLoginHandler.java
+++ b/modules/security-jwt/src/main/java/org/opencastproject/security/jwt/DynamicLoginHandler.java
@@ -281,9 +281,7 @@ public class DynamicLoginHandler implements InitializingBean, JWTLoginHandler {
         var rolesClaim = jwt.getClaim("roles");
         if (rolesClaim != null && !rolesClaim.isNull()) {
           for (String r : rolesClaim.asArray(String.class)) {
-            if (!r.isBlank()) {
-              addRole.accept("ROLE_" + r);
-            }
+            addRole.accept(r);
           }
         }
       } catch (JWTDecodeException e) {

--- a/modules/security-jwt/src/main/java/org/opencastproject/security/jwt/DynamicLoginHandler.java
+++ b/modules/security-jwt/src/main/java/org/opencastproject/security/jwt/DynamicLoginHandler.java
@@ -285,7 +285,7 @@ public class DynamicLoginHandler implements InitializingBean, JWTLoginHandler {
           }
         }
       } catch (JWTDecodeException e) {
-        logger.warn("claim 'roles' is not an array of strings, ignoring");
+        logger.debug("claim 'roles' is not an array of strings, ignoring");
       }
 
       // Read `oc` claim
@@ -295,7 +295,7 @@ public class DynamicLoginHandler implements InitializingBean, JWTLoginHandler {
           for (String entry : ocClaim.asArray(String.class)) {
             var parts = entry.split(":", 3);
             if (parts.length != 3) {
-              logger.warn("entry in 'oc' claim does not have three ':' separated parts, ignoring");
+              logger.debug("entry in 'oc' claim does not have three ':' separated parts, ignoring");
               continue;
             }
 
@@ -310,13 +310,13 @@ public class DynamicLoginHandler implements InitializingBean, JWTLoginHandler {
               if (type.equals("e")) {
                 addRole.accept(SecurityUtil.getEpisodeRoleId(id, action));
               } else {
-                logger.warn("in 'oc' claim: granting access to item type '{}' is not yet supported", type);
+                logger.debug("in 'oc' claim: granting access to item type '{}' is not yet supported", type);
               }
             }
           }
         }
       } catch (JWTDecodeException e) {
-        logger.warn("claim 'oc' is not an array of strings, ignoring");
+        logger.debug("claim 'oc' is not an array of strings, ignoring");
       }
     }
 


### PR DESCRIPTION
This pull request suggests a path forward for Opencast to improve JWT support and cover a wide range of use cases, while also already implementing the first step of that plan. So this PR consists of not only the git diff, but also of the description containing the full proposal. I intend to discuss this with the community, in particular also discussing this in person on the D/A/CH conference tomorrow.

---

## Why?

There are many parties interested in better JWT support. [This discussion](https://github.com/opencast/opencast/discussions/5334) has been open for nearly a year now, while need for this has been around for way longer. Tools like LMSs and Tobira require Opencast to disable static file authorization completely in order to work. The annotation tool might require similarly problematic workarounds. And external apps cannot properly link to the Opencast editor (granting access to edit a video). There is also interest in having a service that can serve static Opencast files without needing a database.

At elan, many clients asked us about these use cases and specifically about JWT in Opencast. The GitHub discussion thread was an attempt to get this started, but I think at this point, one simply has to start working on it.


## What?

Talking to various parties, thinking about different use cases, and examining what Opencast is already capablable of, I think we should take roughly the following steps to improve JWT support. Each of these is described further down.

1. Define a standard JWT schema and make it work out-of-the-box in Opencast (That's what this PR does!)
2. Add proper way to use JWTs in SFA (static file auth)
3. Add ability to merge login sessions
4. Create service for serving static files with authorization that keeps working when Opencast is down

EDIT: see [this comment](https://github.com/opencast/opencast/pull/6177#issuecomment-2377204640) for a change of priorities.

### (1) Standard JWT schema

After the cryptographic verification, a JWT is just a bunch of "claims" (JSON fields). How to interpret those fields is up to the communicating services. Since there are quite a few external projects in the Opencast ecosystem (Tobira, at least 3 LMS plugins, Annotation Tool), agreeing on a standard is reasonable to avoid diverging uses of JWTs. Having such a standard also means that we can make it work out of the box, without the need for admins to write complex role mappings.

This is what this PR does. Please check the git diff to read the actual schema proposal.

I think having one standard for all use cases makes sense. One could argue that one shouldn't mix static file auth with general user authentication/authorization. But this doesn't do that. This just defines a schema in which both, or a mix of the two, can be expressed. For static file auth, one would onle specify a single `"oc": ["read:e:<id>"]`, while for usage of Studio you would specify user info an `"roles": ["STUDIO"]`. For usage of the editor, you can mix both: give specific roles, but also write access to a specific event. Having use case specific JWT schemata could possibly make the JWTs for each use case smaller, but only by a a few bytes. And personally, I think this tiny overhead is acceptable in order to have only one schema.

This PR also implements this standard as `ocStandardRoleMappings`, so that it's not necessary anymore to write role mappings manually. 

With this done, external tools can start using this standard to attach JWTs to requests. And in Opencast, we can improve support for certain use cases.


### (2) JWTs in SFA

While step (1) already makes this possible, it is far from perfect since the JWT handler require a username, display name and email for sessions created by the JWT. For static file authorization, all of this shouldn't be necessary. So in step 2, we should adjust Opencast's SFA to correctly work with JWTs that do not contain user info, but just a single `oc` entry giving access to one event. This can also improve performance of static file serving, as in the JWT case, loading the event's ACL is often not necessary.

I tried implementing this already, but didn't come very far due to lacking familiarity with Spring security and Opencast's auth system. But I think implementation details can be done at a later stage anyway.


### (3) Merge login sessions

Currently, creating a login session via JWT while another login session exists either does nothing or, if you set `checkForPrincipalChanges` to true, it fully replaces the other session. This is not ideal. Consider someone opening the video editor via link in Tobira for two different videos in two different browser tabs. The first session that's created grants access to one video, the second one to the second video, rendering the first editor tab broken. There are a number of other scenarios where this can lead to problems.

Session merging should merge roles between the existing and new session, so that permissions stack. Details need to be figured out.


### (4) External static file serving application

The goal is to create a small program that, together with a webserver like nginx, can serve Opencast's static files, even while Opencast is down -- without disabling authorization! This external service would only support JWT authorization, as well as serving public files without requiring a JWT. But even this limited auth support can cover a wide range of use cases. If the request cannot be authorized via JWT, the service would forward it to Opencast to let it decide.

This has three main advantages:

- **Reducing downtime**: be it crashes or updates, Opencast downtime is just a fact of life and can become quite disruptive for institutions with large data sets during updates. With this file server, we can significantly reduce the *perceived* downtime for most users. The vast majority of time during "Opencast usage" is spent watching a video, i.e. downloading static files. And generally, most usage is read-only. Apps like Tobira or some LMSs keep a local copy of Opencast metadata and partially keep functioning during Opencast downtimes (this was an explicit requirement of Tobira). Keeping file serving working without Opencast, means that most users won't notice Opencast being down. 

- **Improving performance**: involving Opencast (and its whole framework/stack) in file serving, makes the operation a lot slower and use up a lot more computing resources. We are talking three-digit factors or more, compared to just nginx file serving. 

- **Stateless file serving**: this would make file serving less dependent on external factors, making it easier to scale it, deploy it to servers at different locations, use external storage solutions and the like. 

For this to work well, Opencast should adopt some changes to its static file URL pattern and its NFS file paths. Public files (i.e. from events that `ROLE_ANONYMOUS` can read) should be placed in the file system in a special way such that an external service can easily identify them. Ideally the URL pattern is also adjusted. And for protected files, it should be possible to omit the ID from the URL path, since the JWT will contain the event's ID anyway and we don't want to specify it twice. Both these techniques are commonly used by big CDNs. 


## Open questions

- Should we skip step 2 in favor of step 4? Once we have the external service, everyone should use it instead of letting Opencast serve. It just felt correct to have this work directly with Opencast itself. Or is that just wasted work?
- When and when not to load existing user data for the supplied username? Currently the JWT login handler looks up user info (including roles) in the user reference table. We should decide when that should happen, and whether only the user references should be checked.
- Similarly, decide when the user session created by a JWT is stored as user reference. For static file serving, it shouldn't. For Studio, Editor and other use cases, it should. Should it be saved whenever the user information is supplied in the JWT?
- Maybe use `kid` claim (key id) to avoid having to check multiple keys? That can happen in the far future though.


## Other TODOs

Here is an unordered list of other things that still need to happen.

- (in this PR) add example in security config for returning list of roles
- (in this PR) stop parsing SPeL expressions on every JWT request, but only once, using the parsed representation later.
- Frontends/players need to be adjusted to deal with expired JWTs. If a user stops watching a video and returns a day later (keeping the tab open), that should work. 


## Background info: JWTs in web servers

Webservers like nginx can be configured to verify JWTs. The important summary is that the business-logic claim validation is always deferred to some user specified, turing-complete "script". So we are not constrained by this when it comes to the design of our JWT schema. 


<details>

- Nginx
    - Built-in: https://docs.nginx.com/nginx/admin-guide/security-controls/configuring-jwt-authentication
        - only in nginx commercial solution
        - Can use external JWKS, with configurable caching
        - Verifies `exp` and `nbf`
        - Support for custom claim validation. Logic is encoded in `map` of externally via auth sub requests.
    - https://github.com/kjdev/nginx-auth-jwt
        - Seems to be basically an open source version of the official stuff?
    - https://github.com/TeslaGov/ngx-http-auth-jwt-module
        - Seems to be intended for user sessions (JWT is bad for that)
        - Cannot use JWKS URLs
        - Can extract claims into variables, custom checking in nginx code. But only string claims! (no number, bool, array, object)
        - -> Doesn't seem that great
- Apache
    - Seems to have only very basic module built in... dunno

It seems like many people would use their own script/server to validate JWTs. Webservers would then call into that (via auth subrequest for example) to determine whether to serve a file. And then, super custom logic is possible of course.

</details>


## Next steps

I invite everyone to read this proposal and give feedback. This will also be discussed at D/A/CH starting tomorrow. My intention is to get this started soon though. I don't want this PR to bit rod for half a year. So if you want to be involved in this discussion, please do so fairly quickly. In fact, I hope that after D/A/CH we will have agreed on a general direction.