### PR TITLE
Fix bug: user not always removed from LTI cache

### DIFF
--- a/modules/security-lti/src/main/java/org/opencastproject/security/lti/LtiLaunchAuthenticationHandler.java
+++ b/modules/security-lti/src/main/java/org/opencastproject/security/lti/LtiLaunchAuthenticationHandler.java
@@ -396,6 +396,8 @@ public class LtiLaunchAuthenticationHandler implements OAuthAuthenticationHandle
         logger.debug("Concurrent access of user {}. Ignoring.", username);
       } else if (!ltiRolesForUserCreation.contains("*") && !requestContainsMatchingRoles(request)) {
         logger.debug("No JpaUserReference will be created for LTI user {}.", username);
+        // Remove user from the cache; next time, the user may have additional/different roles.
+        activePersistenceTransactions.remove(username);
       } else {
         try {
           JpaOrganization organization = fromOrganization(securityService.getOrganization());


### PR DESCRIPTION
There's an internal cache to avoid concurrent access by the same user. Currently, if the user does not have a role that indicates it needs to be persistent to the db, that username is never removed from the cache. If, in a subsequent access, the user has different roles, those roles will not be taken into account.
This happened to us on a semester switch: an instructor had his roles related to last term courses and his username was in the internal cache so he did not have access to his current course.