### PR TITLE
Fix sorting in engage interface

### DIFF
--- a/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
+++ b/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
@@ -191,23 +191,14 @@ function($, bootbox, _, alertify, jsyaml) {
 
     $('body').append(template(tData));
 
-    sortMap['DATE_CREATED_DESC'] = tData.recording_date_new;
-    sortMap['DATE_CREATED'] = tData.recording_date_old;
-    sortMap['DATE_MODIFIED_DESC'] = tData.publishing_date_new;
-    sortMap['DATE_MODIFIED'] = tData.publishing_date_old;
+    sortMap['MODIFIED_DESC'] = tData.publishing_date_new;
+    sortMap['MODIFIED'] = tData.publishing_date_old;
     sortMap['TITLE'] = tData.title_a_z;
     sortMap['TITLE_DESC'] = tData.title_z_a;
     sortMap['CREATOR'] = tData.author_a_z;
     sortMap['CREATOR_DESC'] = tData.author_z_a;
     sortMap['CONTRIBUTOR'] = tData.contributor_a_z;
     sortMap['CONTRIBUTOR_DESC'] = tData.contributor_z_a;
-    sortMap['PUBLISHER'] = tData.publisher_a_z;
-    sortMap['PUBLISHER_DESC'] = tData.publisher_z_a;
-    sortMap['SERIES_ID'] = tData.series;
-    sortMap['LANGUAGE'] = tData.language;
-    sortMap['LICENSE'] = tData.license;
-    sortMap['SUBJECT'] = tData.subject;
-    sortMap['DESCRIPTION'] = tData.description;
 
     // set variables
     title_enterUsernamePassword = tData.login_title;
@@ -265,7 +256,7 @@ function($, bootbox, _, alertify, jsyaml) {
       sort = '';
     } else {
       sort = 'sort=' + GetURLParameter('sort') + '&';
-      sortDescription = GetURLParameter('sort');
+      sortDescription = GetURLParameter('sort').replace(/[ +]/, '_').toUpperCase();
       $('#' + sortDescription).prop('checked', true);
       $('#buttonSorting').text(sortMap[sortDescription]);
     }

--- a/modules/engage-ui/src/main/resources/ui/template/desktop.html
+++ b/modules/engage-ui/src/main/resources/ui/template/desktop.html
@@ -59,107 +59,52 @@
           </button>
           <ul id="dropdownMenuSorting" class="dropdown-menu" role="menu" tabindex="-1">
             <li role="presentation">
-              <input type="radio" class="oc-sort-dropdown" name="sort" id="DATE_CREATED_DESC" value="DATE_CREATED_DESC">
-              <label for="DATE_CREATED_DESC">
-              <%- recording_date_new %>
-              </label>
-            </li>
-            <li role="presentation">
-              <input type="radio" class="oc-sort-dropdown" name="sort" id="DATE_CREATED" value="DATE_CREATED">
-              <label for="DATE_CREATED">
-                <%- recording_date_old %>
-              </label>
-            </li>
-            <li role="presentation">
-              <input type="radio" class="oc-sort-dropdown" name="sort" id="DATE_MODIFIED_DESC" value="DATE_MODIFIED_DESC">
+              <input type="radio" class="oc-sort-dropdown" name="sort" id="DATE_MODIFIED_DESC" value="modified desc">
               <label for="DATE_MODIFIED_DESC">
               <%- publishing_date_new %>
               </label>
             </li>
             <li role="presentation">
-              <input type="radio" class="oc-sort-dropdown" name="sort" id="DATE_MODIFIED" value="DATE_MODIFIED">
+              <input type="radio" class="oc-sort-dropdown" name="sort" id="DATE_MODIFIED" value="modified">
               <label for="DATE_MODIFIED">
               <%- publishing_date_old %>
               </label>
             </li>
             <li role="presentation" class="divider"></li>
             <li role="presentation">
-              <input type="radio" class="oc-sort-dropdown" name="sort" id="TITLE" value="TITLE">
+              <input type="radio" class="oc-sort-dropdown" name="sort" id="TITLE" value="title">
               <label for="TITLE">
               <%- title_a_z %>
               </label>
             </li>
             <li role="presentation">
-              <input type="radio" class="oc-sort-dropdown" name="sort" id="TITLE_DESC" value="TITLE_DESC">
+              <input type="radio" class="oc-sort-dropdown" name="sort" id="TITLE_DESC" value="title desc">
               <label for="TITLE_DESC">
               <%- title_z_a %>
               </label>
             </li>
             <li role="presentation">
-              <input type="radio" class="oc-sort-dropdown" name="sort" id="CREATOR" value="CREATOR">
+              <input type="radio" class="oc-sort-dropdown" name="sort" id="CREATOR" value="creator">
               <label for="CREATOR">
               <%- author_a_z %>
               </label>
             </li>
             <li role="presentation">
-              <input type="radio" class="oc-sort-dropdown" name="sort" id="CREATOR_DESC" value="CREATOR_DESC">
+              <input type="radio" class="oc-sort-dropdown" name="sort" id="CREATOR_DESC" value="creator desc">
               <label for="CREATOR_DESC">
               <%- author_z_a %>
               </label>
             </li>
             <li role="presentation">
-              <input type="radio" class="oc-sort-dropdown" name="sort" id="CONTRIBUTOR" value="CONTRIBUTOR">
+              <input type="radio" class="oc-sort-dropdown" name="sort" id="CONTRIBUTOR" value="contributor">
               <label for="CONTRIBUTOR">
               <%- contributor_a_z %>
               </label>
             </li>
             <li role="presentation">
-              <input type="radio" class="oc-sort-dropdown" name="sort" id="CONTRIBUTOR_DESC" value="CONTRIBUTOR_DESC">
+              <input type="radio" class="oc-sort-dropdown" name="sort" id="CONTRIBUTOR_DESC" value="contributor desc">
               <label for="CONTRIBUTOR_DESC">
               <%- contributor_z_a %>
-              </label>
-            </li>
-            <li role="presentation">
-              <input type="radio" class="oc-sort-dropdown" name="sort" id="PUBLISHER" value="PUBLISHER">
-              <label for="PUBLISHER">
-              <%- publisher_a_z %>
-              </label>
-            </li>
-            <li role="presentation">
-              <input type="radio" class="oc-sort-dropdown" name="sort" id="PUBLISHER_DESC" value="PUBLISHER_DESC">
-              <label for="PUBLISHER_DESC">
-              <%- publisher_z_a %>
-              </label>
-            </li>
-            <li role="presentation" class="divider"></li>
-            <li role="presentation">
-              <input type="radio" class="oc-sort-dropdown" name="sort" id="SERIES_ID" value="SERIES_ID">
-              <label for="SERIES_ID">
-              <%- series %>
-              </label>
-            </li>
-            <li role="presentation">
-              <input type="radio" class="oc-sort-dropdown" name="sort" id="LANGUAGE" value="LANGUAGE">
-              <label for="LANGUAGE">
-              <%- language %>
-              </label>
-            </li>
-            <li role="presentation">
-              <input type="radio" class="oc-sort-dropdown" name="sort" id="LICENSE" value="LICENSE">
-              <label for="LICENSE">
-              <%- license %>
-              </label>
-            </li>
-            <li role="presentation">
-              <input type="radio" class="oc-sort-dropdown" name="sort" id="SUBJECT" value="SUBJECT">
-              <label for="SUBJECT">
-              <%- subject %>
-              </label>
-            </li>
-            <li role="presentation">
-              <input type="radio" class="oc-sort-dropdown" name="sort" id="DESCRIPTION" value="DESCRIPTION">
-              <label for="DESCRIPTION">
-              <%- description %>
               </label>
             </li>
           </ul>


### PR DESCRIPTION
This patch fixes the sorting (dialog) in the engage UI. The options and parameters have changed in Opencast 16 but were never adapted in this user interface.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
