### PR TITLE
Fix integration tests, distribution upload and demo server update

### DIFF
--- a/.github/workflows/test-opencast-build.yml
+++ b/.github/workflows/test-opencast-build.yml
@@ -78,7 +78,7 @@ jobs:
             -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
 
       - name: build assemblies
-        if: matrix.java == 11
+        if: matrix.java == 17
         working-directory: assemblies
         run: |
           mvn clean install \
@@ -90,53 +90,53 @@ jobs:
             -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
 
       - name: prepare cluster
-        if: matrix.java == 11
+        if: matrix.java == 17
         run: |
           ./.github/multi-node-test-setup
 
       - name: verify jar file integrity
-        if: matrix.java == 11
+        if: matrix.java == 17
         run: |
           .github/test-jars
 
       - name: wait for opensearch to boot
-        if: matrix.java == 11
+        if: matrix.java == 17
         run: >
           curl -fisS --retry 60 --retry-delay 1 --retry-all-errors
           http://localhost:9200/
 
       - name: start admin
-        if: matrix.java == 11
+        if: matrix.java == 17
         run: ./build/opencast-dist-admin/bin/start-opencast daemon &
 
       - name: start presentation
-        if: matrix.java == 11
+        if: matrix.java == 17
         run: ./build/opencast-dist-presentation/bin/start-opencast daemon &
 
       - name: start worker
-        if: matrix.java == 11
+        if: matrix.java == 17
         run: ./build/opencast-dist-worker/bin/start-opencast daemon &
 
       - name: test admin
-        if: matrix.java == 11
+        if: matrix.java == 17
         run: >
           curl -fisS --retry 30 --retry-delay 10 --retry-all-errors -u admin:opencast
           http://localhost:8080/sysinfo/bundles/version
 
       - name: test presentation
-        if: matrix.java == 11
+        if: matrix.java == 17
         run: >
           curl -fisS --retry 30 --retry-delay 10 --retry-all-errors -u admin:opencast
           http://localhost:8081/sysinfo/bundles/version
 
       - name: test worker
-        if: matrix.java == 11
+        if: matrix.java == 17
         run: >
           curl -fisS --retry 30 --retry-delay 10 --retry-all-errors -u admin:opencast
           http://localhost:8082/sysinfo/bundles/version
 
       - name: create test user
-        if: matrix.java == 11
+        if: matrix.java == 17
         run: >
           curl -i -u admin:opencast http://localhost:8080/user-utils/
           -F username=test
@@ -144,7 +144,7 @@ jobs:
           -F 'roles=["ROLE_STUDIO"]'
 
       - name: ingest test media as non-admin
-        if: matrix.java == 11
+        if: matrix.java == 17
         run: >
           curl -i -f -u test:opencast http://localhost:8080/ingest/addMediaPackage/fast
           -F flavor=presenter/source
@@ -154,7 +154,7 @@ jobs:
           -F acl='{"acl": {"ace": [{"role": "ROLE_USER","action": "read"},{"role": "ROLE_USER","action": "write"}]}}'
 
       - name: wait for event to finish
-        if: matrix.java == 11
+        if: matrix.java == 17
         env:
           STATUS_URL: 'http://localhost:8080/workflow/mediaPackage/test/hasActiveWorkflows'
         run: |
@@ -165,7 +165,7 @@ jobs:
           done
 
       - name: check that processing was successful
-        if: matrix.java == 11
+        if: matrix.java == 17
         run: |
           curl -s -O -u admin:opencast http://localhost:8080/workflow/mediaPackage/test/instances.json
           jq < instances.json
@@ -188,7 +188,7 @@ jobs:
         working-directory: build
         if: >
           github.event_name == 'push'
-          && matrix.java == 11
+          && matrix.java == 17
           && github.repository == 'opencast/opencast'
           && (github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/r/'))
         run: |
@@ -197,7 +197,7 @@ jobs:
       - name: configure s3cmd
         if: >
           github.event_name == 'push'
-          && matrix.java == 11
+          && matrix.java == 17
           && github.repository == 'opencast/opencast'
           && (github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/r/'))
         env:
@@ -217,21 +217,21 @@ jobs:
         working-directory: build
         if: >
           github.event_name == 'push'
-          && matrix.java == 11
+          && matrix.java == 17
           && github.repository == 'opencast/opencast'
           && (github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/r/'))
         run: |
           s3cmd put -P *.commit opencast-dist-allinone*tar.gz s3://opencast-daily/
 
       - name: prepare allinone for upload
-        if: matrix.java == 11
+        if: matrix.java == 17
         working-directory: build
         run: |
           tar xf opencast-dist-allinone*.tar.gz
 
       - name: upload tarball as workflow asset
         if: >
-          matrix.java == 11
+          matrix.java == 17
           && github.repository == 'opencast/opencast'
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
We switched to Java 17 and 23 on `develop`, but the integration tests and the distribution upload were still set to only happen for Java 11 builds.

This means that the “Test Opencast” workflow finished successfully, but the integration tests were skipped and develop.opencast.org did not get updated for a while now.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
