### PR TITLE
Update docs on how to access old admin ui

### DIFF
--- a/docs/guides/admin/docs/configuration/admin-ui/new-admin-ui.md
+++ b/docs/guides/admin/docs/configuration/admin-ui/new-admin-ui.md
@@ -10,6 +10,7 @@ Accessing Old And New Admin Interface
 -------------------------------------
 
 You can access the admin interfaces by replacing the `ng` in your address bar with `ui` and vice versa.
+Before you can use the old interface, its plugin needs to be enabled in `etc/org.opencastproject.plugin.impl.PluginManagerImpl.cfg`.
 
 - New: `/admin-ui/index.html`
 - Old: `/admin-ng/index.html`

--- a/docs/guides/admin/docs/configuration/plugin-management.md
+++ b/docs/guides/admin/docs/configuration/plugin-management.md
@@ -8,6 +8,9 @@ configuration to `on` or `off`.
 List of Available Plugins
 -------------------------
 
+- opencast-plugin-admin-ng
+    - Old version of the admin interface. The new UI has more features and is actively maintained and improved,
+      but until the old one is removed completely, this plugin can be turned on for legacy use-cases.
 - opencast-plugin-legacy-annotation
     - Legacy annotation functionality. We do not recommend turning this on. It also requires additional configuration in
       the player. It's kept for a few legacy use-cases.


### PR DESCRIPTION
Since the old admin ui was turned into a plugin, accessing it via `/admin-ng/index.html` only works after activating that plugin.
This adds the above info to the docs.

Closes #6231 

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
