### PR TITLE
Handle content id being null for playlist entries

### DIFF
--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/PlaylistsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/PlaylistsEndpoint.java
@@ -21,6 +21,7 @@
 package org.opencastproject.external.endpoint;
 
 import static com.entwinemedia.fn.data.json.Jsons.BLANK;
+import static com.entwinemedia.fn.data.json.Jsons.NULL;
 import static com.entwinemedia.fn.data.json.Jsons.arr;
 import static com.entwinemedia.fn.data.json.Jsons.f;
 import static com.entwinemedia.fn.data.json.Jsons.obj;
@@ -350,7 +351,7 @@ public class PlaylistsEndpoint {
     List<Field> fields = new ArrayList<>();
 
     fields.add(f("id", v(playlistEntry.getId())));
-    fields.add(f("contentId", v(playlistEntry.getContentId())));
+    fields.add(f("contentId", v(playlistEntry.getContentId(), NULL)));
     fields.add(f("type", enumToJSON(playlistEntry.getType())));
     return obj(fields);
   }

--- a/modules/playlists/src/main/java/org/opencastproject/playlists/PlaylistService.java
+++ b/modules/playlists/src/main/java/org/opencastproject/playlists/PlaylistService.java
@@ -417,12 +417,20 @@ public class PlaylistService {
     // Add additional infos about events
     List<JaxbPlaylistEntry> jaxbPlaylistEntries = jaxbPlaylist.getEntries();
     for (JaxbPlaylistEntry entry : jaxbPlaylistEntries) {
+      String contentId = entry.getContentId();
+
+      if (contentId == null || contentId.isEmpty()) {
+        entry.setType(PlaylistEntryType.INACCESSIBLE);
+        logger.warn("Entry {} has no content, marking as inaccessible", entry.getId());
+        continue;
+      }
+
       try {
         if (entry.getType() == PlaylistEntryType.EVENT) {
 
           // We only get an event from the index if we have permission to do so (and if it exists ofc)
           SearchResult<Event> result = elasticsearchIndex.getByQuery(
-              new EventSearchQuery(org, user).withIdentifier(entry.getContentId()));
+              new EventSearchQuery(org, user).withIdentifier(contentId));
           if (result.getPageSize() != 0) {
             Event event = result.getItems()[0].getSource();
             entry.setPublications(event.getPublications());


### PR DESCRIPTION
Currently it's possible to create playlist entries with empty or null content ids. This causes problems when trying to get the playlist both from the External API (during the transformation to json) and the endpoint of the service itself (though only when `withPublications` is set).

In my opinion the real solution would be not allowing empty content ids in the first place because I don't see how that could be useful, but I didn't manage that in the limited time I had. For now this should at least fix #5744.