### PR TITLE
Remove mentions of the old admin interface

### DIFF
--- a/docs/guides/admin/docs/configuration/plugin-management.md
+++ b/docs/guides/admin/docs/configuration/plugin-management.md
@@ -8,9 +8,6 @@ configuration to `on` or `off`.
 List of Available Plugins
 -------------------------
 
-- opencast-plugin-admin-ng
-    - Old version of the admin interface. The new UI has more features and is actively maintained and improved,
-      but until the old one is removed completely, this plugin can be turned on for legacy use-cases.
 - opencast-plugin-legacy-annotation
     - Legacy annotation functionality. We do not recommend turning this on. It also requires additional configuration in
       the player. It's kept for a few legacy use-cases.

--- a/docs/guides/admin/docs/configuration/security.aai.md
+++ b/docs/guides/admin/docs/configuration/security.aai.md
@@ -134,7 +134,7 @@ interface which is supposed to be protected by Shibboleth.
 
     <!-- Redirects unauthenticated requests to the login form -->
     <bean id="userEntryPoint" class="org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint">
-      <property name="loginFormUrl" value="/admin-ng/index.html" />
+      <property name="loginFormUrl" value="/admin-ui/index.html" />
     </bean>
 
 Last but not least, you need to add the *preauthAuthProvider* authentication provider to the *authentication-manager*:

--- a/docs/guides/admin/docs/configuration/transcription.configuration/microsoftazuretranscripts.md
+++ b/docs/guides/admin/docs/configuration/transcription.configuration/microsoftazuretranscripts.md
@@ -122,7 +122,7 @@ workflow can retrieve the mediapackage to attach captions/transcriptions
       <configurations>
         <configuration key="download-source-flavors">*/source</configuration>
         <configuration key="channel-id">internal</configuration>
-        <configuration key="url-pattern">http://localhost:8080/admin-ng/index.html#/events/events/${event_id}/tools/playback</configuration>
+        <configuration key="url-pattern">http://localhost:8080/editor-ui/index.html?id=${event_id}</configuration>
         <configuration key="check-availability">false</configuration>
       </configurations>
     </operation>

--- a/docs/guides/admin/docs/workflowoperationhandlers/publish-configure-aws-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/publish-configure-aws-woh.md
@@ -91,7 +91,7 @@ Publish to internal channel:
   <configurations>
     <configuration key="source-tags">engage</configuration>
     <configuration key="channel-id">internal</configuration>
-    <configuration key="url-pattern">http://localhost:8080/admin-ng/index.html#/events/events/${event_id}/tools/playback</configuration>
+    <configuration key="url-pattern">http://localhost:8080/editor-ui/index.html?id=${event_id}</configuration>
   </configurations>
 </operation>
 ```

--- a/docs/guides/admin/docs/workflowoperationhandlers/publish-configure-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/publish-configure-woh.md
@@ -96,7 +96,7 @@ Publish to internal channel:
   <configurations>
     <configuration key="download-source-tags">engage</configuration>
     <configuration key="channel-id">internal</configuration>
-    <configuration key="url-pattern">http://localhost:8080/admin-ng/index.html#/events/events/${event_id}/tools/playback</configuration>
+    <configuration key="url-pattern">http://localhost:8080/editor-ui/index.html?id=${event_id}</configuration>
   </configurations>
 </operation>
 ```


### PR DESCRIPTION
Since the old admin interface was removed, we shouldn't mention it in the documentation. This patch removes a few things left over in the docs.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
