### PR TITLE
Allow rolling back to a specified snapshot in asset manager

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/asset-delete-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/asset-delete-woh.md
@@ -3,34 +3,51 @@ Asset Manager Delete Workflow Operation
 
 ID: `asset-delete`
 
+<div class=warn>
+This operation will permanently delete internal Opencast data.
+This can result in data loss.
+Make sure to carefully read the documentation and understand the side-effects.
+This especially means the publication storage mentioned below.
+</div>
+
 Description
 -----------
 
-The delete handler is responsible for deleting an episode, identified by the workflow’s current media package, from the
-asset manager.
+The delete handler can be used for deleting snapshotted versions of an episode, identified by the workflow’s current
+media package, from the asset manager.
 
-If no parameter is given, the whole episode and all of its snapshots are deleted.
-If the keep-last-snapshot parameter is used, it is advised to use the *ingest-download* workflow before *asset-delete*.
-Otherwise there will be logged a lot of errors for unreferenced snapshots and ACLs may vanish.
-
+The media package resulting from this operation is the one from the latest snapshot after the deletion, but with the
+publication section from the current workflow from when the operation started.
 
 Parameter Table
 ---------------
 
-|Configuration Key         |Example           |Description                                       |
-|--------------------------|------------------|--------------------------------------------------|
-|keep-last-snapshot        |true              |Deletes every snapshot except the last one.        |
+|Configuration Key  |Example |Description                                                           |
+|-------------------|--------|----------------------------------------------------------------------|
+|keep-last-snapshot |true    |Deletes every snapshot except the last one.                           |
+|roll-back-to       |5       |Rolls back to the specified snapshot version, deleting all newer ones.|
+
+
+Publications
+------------
+
+Opencast stores the current version of a publication in the latest snapshot.
+This means that rolling back and thus deleting newer snapshots may result in the loss of the current publication data.
+If that is what you need or if the publications were not modified in the snapshots you deleted, that's fine.
+
+In case you do need to keep the current list of publications, however, the operation will return the media package of
+the version you rolled back to, but with the publication section from when the operation started.
+This allows you to easily create a new snapshot with the media from the version you rolled back to,
+but the current list of publications.
+You just need to add a `snapshot` operation after this operation.
 
 
 Operation Example
 -----------------
 
-```xml
-<operation
-    id="asset-delete"
-    description="Delete from AssetManager">
-  <configurations>
-    <configuration key="keep-last-snapshot">true</configuration>
-  </configurations>
-</operation>
+```yaml
+- id: asset-delete
+  description: Delete all but latest snapshot
+  configurations:
+    - keep-last-snapshot: true
 ```

--- a/modules/asset-manager-workflowoperation/src/main/java/org/opencastproject/workflow/handler/assetmanager/AssetManagerDeleteWorkflowOperationHandler.java
+++ b/modules/asset-manager-workflowoperation/src/main/java/org/opencastproject/workflow/handler/assetmanager/AssetManagerDeleteWorkflowOperationHandler.java
@@ -24,8 +24,8 @@ import static org.opencastproject.assetmanager.api.AssetManager.DEFAULT_OWNER;
 
 import org.opencastproject.assetmanager.api.AssetManager;
 import org.opencastproject.assetmanager.api.query.AQueryBuilder;
+import org.opencastproject.assetmanager.impl.VersionImpl;
 import org.opencastproject.job.api.JobContext;
-import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
 import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
 import org.opencastproject.workflow.api.WorkflowInstance;
@@ -36,6 +36,7 @@ import org.opencastproject.workflow.api.WorkflowOperationResult;
 import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
 
 import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -64,6 +65,7 @@ public class AssetManagerDeleteWorkflowOperationHandler extends AbstractWorkflow
 
   /** Configuration if last snapshot should not be deleted */
   private static final String OPT_LAST_SNAPSHOT = "keep-last-snapshot";
+  private static final String OPT_ROLL_BACK_TO = "roll-back-to";
 
   @Activate
   @Override
@@ -80,11 +82,17 @@ public class AssetManagerDeleteWorkflowOperationHandler extends AbstractWorkflow
   @Override
   public WorkflowOperationResult start(WorkflowInstance workflowInstance, JobContext context)
           throws WorkflowOperationException {
-    final MediaPackage mediaPackage = workflowInstance.getMediaPackage();
-    final String mpId = mediaPackage.getIdentifier().toString();
+    final String mpId = workflowInstance.getMediaPackage().getIdentifier().toString();
 
     WorkflowOperationInstance currentOperation = workflowInstance.getCurrentOperation();
     boolean keepLastSnapshot = BooleanUtils.toBoolean(currentOperation.getConfiguration(OPT_LAST_SNAPSHOT));
+    long rollbackVersion = NumberUtils.toLong(currentOperation.getConfiguration(OPT_ROLL_BACK_TO), -1);
+
+    if (rollbackVersion >= 0 && keepLastSnapshot) {
+      throw new WorkflowOperationException("Operation cannot roll back to an old version and keep the latest version.");
+    } else if (rollbackVersion < 0 && !keepLastSnapshot) {
+      throw new WorkflowOperationException("Operation needs a version to roll back to or keep the latest version.");
+    }
 
     try {
       final AQueryBuilder q = assetManager.createQuery();
@@ -92,18 +100,40 @@ public class AssetManagerDeleteWorkflowOperationHandler extends AbstractWorkflow
 
       if (keepLastSnapshot) {
         logger.info("Deleting all but latest snapshot of episode {}", mpId);
-        deleted = q.delete(DEFAULT_OWNER, q.snapshot())
-                .where(q.mediaPackageId(mpId).and(q.version().isLatest().not())).run();
+        deleted = q.delete(DEFAULT_OWNER, q.snapshot()).where(q.mediaPackageId(mpId).and(q.version().isLatest().not()))
+            .run();
       } else {
-        logger.info("Deleting all snapshots of episode {}", mpId);
+        logger.info("Rolling back to version {} in the asset manager", rollbackVersion);
         deleted = q.delete(DEFAULT_OWNER, q.snapshot())
-                .where(q.mediaPackageId(mpId)).run();
+            .where(q.mediaPackageId(mpId)
+            .and(q.version().gt(new VersionImpl(rollbackVersion)))).run();
       }
 
       logger.info("Successfully deleted {} version/s episode {} from the asset manager", deleted, mpId);
     } catch (Exception e) {
       var errorMessage = String.format("Error deleting episode %s from the asset manager", mpId);
       throw new WorkflowOperationException(errorMessage, e);
+    }
+
+    // Get the media package we rolled back to from asset manager
+    final AQueryBuilder q = assetManager.createQuery();
+    var record = q.select(q.snapshot()).where(q.mediaPackageId(mpId).and(q.version().isLatest()))
+        .run().getRecords().stream().findFirst();
+    if (record.isEmpty()) {
+      throw new WorkflowOperationException("Could not get any results from asset manager. Expected at least one.");
+    }
+    var snapshot = record.get().getSnapshot();
+    if (snapshot.isEmpty()) {
+      throw new WorkflowOperationException("Asset manager record contains no snapshot.");
+    }
+    var mediaPackage = snapshot.get().getMediaPackage();
+
+    // Update media package from asset manager with publications from workflow media package
+    for (var publication: mediaPackage.getPublications()) {
+      mediaPackage.remove(publication);
+    }
+    for (var publication: workflowInstance.getMediaPackage().getPublications()) {
+      mediaPackage.add(publication);
     }
     return createResult(mediaPackage, Action.CONTINUE);
   }


### PR DESCRIPTION
This patch improves the `asset-delete` workflow operation handlöer to not only allow for deleting all or all except the latest snapshot of an event, but also allows deleting all version newer than a given version. This essentially means that you can roll back to a given event in the asset manager.

Along the way, this also fixes the problem of this operation creating errors since it may delete files the current workflow requires to work on. This could previously be worked around using `ingest-download`, but is actually quite unnecessary.

*This keeps the current behavior (e.g. if you were already working around the problem using `ingest-download`) unchanged*

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
