### PR TITLE
Fix ICLA Check

### DIFF
--- a/.github/workflows/check-icla.yml
+++ b/.github/workflows/check-icla.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/setup-python@v4
 
       - name: Install Python module
-        run: pip install apereocla
+        run: pip install --break-system-packages apereocla
 
       - name: Check Apereo ICLA for GitHub user
         run: apereocla -g "${{ github.event.pull_request.user.login }}"


### PR DESCRIPTION
The tool we use for checking if contributors signed their ICLA is failing to install on CI runs with new Python versions since we just install it system wide. While that may not be good practice on your local machine, this shouldn't matter in the CI since we immediately throw away the machine anyway.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
