### PR TITLE
Make developers explain why they target legacy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,9 @@
+<!--
+If your pull request is targeting the legacy (second oldest release branch), explain why this patch is so important that
+it needs to go into the legacy and can not just into stable or develop.
+-->
+
+
 ### Your pull request should…
 
 * [ ] have a concise title
@@ -7,3 +13,4 @@
 * [ ] pass automated tests
 * [ ] have a clean commit history
 * [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
+* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch


### PR DESCRIPTION
This patch adds a section to the GitHub pull request templates, asking developers to explain why they target the legacy branch with a given pull request, if they target the legacy branch.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
