### PR TITLE
Editor: Unify endpoints for saving

### DIFF
--- a/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/EditingData.java
+++ b/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/EditingData.java
@@ -64,10 +64,12 @@ public class EditingData {
   private final List<Subtitle> subtitles;
   private final Boolean local;
 
+  private final String metadataJSON;
+
   public EditingData(List<SegmentData> segments, List<TrackData> tracks, List<WorkflowData> workflows, Long duration,
           String title, String recordingStartDate, String seriesId, String seriesName, Boolean workflowActive,
           List<String> waveformURIs, List<Subtitle> subtitles, Boolean local, Boolean lockingActive,
-          Integer lockRefresh, User user) {
+          Integer lockRefresh, User user, String metadataJSON) {
     this.segments = segments;
     this.tracks = tracks;
     this.workflows = workflows;
@@ -83,6 +85,7 @@ public class EditingData {
     this.lockRefresh = lockRefresh * 1000;
     this.lockUUID = UUID.randomUUID().toString();
     this.lockUser = user.getUsername();
+    this.metadataJSON = metadataJSON;
   }
 
   public static EditingData parse(String json) {
@@ -116,6 +119,10 @@ public class EditingData {
 
   public List<Subtitle> getSubtitles() {
     return subtitles;
+  }
+
+  public String getMetadataJSON() {
+    return metadataJSON;
   }
 
   public String toString() {

--- a/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/EditorRestEndpointBase.java
+++ b/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/EditorRestEndpointBase.java
@@ -190,29 +190,6 @@ public abstract class EditorRestEndpointBase {
     return RestUtil.R.ok();
   }
 
-  @POST
-  @Path("{mediaPackageId}/metadata.json")
-  @RestQuery(name = "updateMetadata", description = "Update the passed metadata for the event with the given Id",
-          pathParameters = {
-          @RestParameter(name = "mediaPackageId", description = "The event id", isRequired = true,
-              type = RestParameter.Type.STRING) },
-          responses = {
-          @RestResponse(description = "The metadata have been updated.", responseCode = HttpServletResponse.SC_OK),
-          @RestResponse(description = "Could not parse metadata.", responseCode = HttpServletResponse.SC_BAD_REQUEST),
-          @RestResponse(description = "No event with this identifier was found.",
-                  responseCode = HttpServletResponse.SC_NOT_FOUND) }, returnDescription = "No content is returned.")
-  public Response updateEventMetadata(
-      @PathParam("mediaPackageId") String eventId,
-      @Context HttpServletRequest request) {
-    try {
-      String details = readInputStream(request);
-      editorService.setMetadata(eventId, details);
-    } catch (EditorServiceException e) {
-      return checkErrorState(eventId, e);
-    }
-    return RestUtil.R.ok();
-  }
-
   protected String readInputStream(HttpServletRequest request) {
     String details;
     try (InputStream is = request.getInputStream()) {

--- a/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/EditorService.java
+++ b/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/EditorService.java
@@ -69,9 +69,4 @@ public interface EditorService {
    * Provide all meta information about the given mediaPackageId
    */
   String getMetadata(String mediaPackageId) throws EditorServiceException;
-
-  /**
-   * Store meta data of the given mediaPackage
-   */
-  void setMetadata(String mediaPackageId, String metadata) throws EditorServiceException;
 }

--- a/modules/editor-service-remote/src/main/java/org/opencastproject/editor/remote/EditorServiceRemoteImpl.java
+++ b/modules/editor-service-remote/src/main/java/org/opencastproject/editor/remote/EditorServiceRemoteImpl.java
@@ -89,11 +89,6 @@ public class EditorServiceRemoteImpl extends RemoteBase implements EditorService
   }
 
   @Override
-  public void setMetadata(String mediaPackageId, String metadata) throws EditorServiceException {
-    doPostForMediaPackage(mediaPackageId, METADATA_SUFFIX, metadata);
-  }
-
-  @Override
   public void lockMediaPackage(String mediaPackageId, LockData lockData) throws EditorServiceException {
     Map<String, String> params = new HashMap<>();
     params.put("uuid", lockData.getUUID());

--- a/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
+++ b/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
@@ -1044,7 +1044,7 @@ public class EditorServiceImpl implements EditorService {
 
     return new EditingData(segments, tracks, workflows, mp.getDuration(), mp.getTitle(), event.getRecordingStartDate(),
             event.getSeriesId(), event.getSeriesName(), workflowActive, waveformList, subtitles, localPublication,
-            lockingActive, lockRefresh, user);
+            lockingActive, lockRefresh, user, "");
   }
 
 
@@ -1154,6 +1154,17 @@ public class EditorServiceImpl implements EditorService {
       throw new IOException(e);
     }
 
+    // Update Metadata
+    try {
+      index.updateAllEventMetadata(mediaPackageId, editingData.getMetadataJSON(), searchIndex);
+    } catch (SearchIndexException | IndexServiceException | IllegalArgumentException e) {
+      errorExit("Event metadata can't be updated.", mediaPackageId, ErrorStatus.METADATA_UPDATE_FAIL, e);
+    } catch (NotFoundException e) {
+      errorExit("Event not found.", mediaPackageId, ErrorStatus.MEDIAPACKAGE_NOT_FOUND, e);
+    } catch (UnauthorizedException e) {
+      errorExit("Not authorized to update event metadata .", mediaPackageId, ErrorStatus.NOT_AUTHORIZED, e);
+    }
+
     if (editingData.getPostProcessingWorkflow() != null) {
       final String workflowId = editingData.getPostProcessingWorkflow();
       try {
@@ -1200,18 +1211,4 @@ public class EditorServiceImpl implements EditorService {
 
     return MetadataJson.listToJson(metadataList, true).toString();
   }
-
-  @Override
-  public void setMetadata(String mediaPackageId, String metadata) throws EditorServiceException {
-    try {
-      index.updateAllEventMetadata(mediaPackageId, metadata, searchIndex);
-    } catch (SearchIndexException | IndexServiceException | IllegalArgumentException e) {
-      errorExit("Event metadata can't be updated.", mediaPackageId, ErrorStatus.METADATA_UPDATE_FAIL, e);
-    } catch (NotFoundException e) {
-      errorExit("Event not found.", mediaPackageId, ErrorStatus.MEDIAPACKAGE_NOT_FOUND, e);
-    } catch (UnauthorizedException e) {
-      errorExit("Not authorized to update event metadata .", mediaPackageId, ErrorStatus.NOT_AUTHORIZED, e);
-    }
-  }
-
 }


### PR DESCRIPTION
We have two endpoints for saving data from the editor frontend, one for metadata and one for all the rest. With the way the editor is set up, two seperate endpoints are wholly unnecessary, so this unifies them into one endpoint instead.

Will break the frontend without respective changes: https://github.com/opencast/opencast-editor/pull/1472

#### Why is this aimed at legacy?

This constitutes a breaking change. This needs to be merged into whatever version the related frontend PR is merged into.