### PR TITLE
Allow generating subtitles in the background

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/index.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/index.md
@@ -107,6 +107,7 @@ The following table contains the workflow operations that are available in an ou
 | silence                              | Silence detection on audio of the mediapackage                                            | [Documentation](silence-woh.md)                              |
 | snapshot                             | Archive the current state of the mediapackage                                             | [Documentation](snapshot-woh.md)                             |
 | speechtotext                         | Create subtitles for video and audio sources                                              | [Documentation](speechtotext-woh.md)                         |
+| speechtotext-attach                  | Attach results of asynchronous speechtotext jobs                                          | [Documentation](speechtotext-attach-woh.md)                  |
 | start-watson-transcription           | Starts automated transcription provided by IBM Watson                                     | [Documentation](start-watson-transcription-woh.md)           |
 | start-workflow                       | Start a new workflow for given media package ID                                           | [Documentation](start-workflow-woh.md)                       |
 | statistics-writer                    | Log statistical data about the video                                                      | [Documentation](statistics-writer.md)                        |

--- a/docs/guides/admin/docs/workflowoperationhandlers/speechtotext-attach-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/speechtotext-attach-woh.md
@@ -1,0 +1,41 @@
+Speech to Text Attach Workflow Operation
+========================================
+
+ID: `speechtotext-attach`
+
+Description
+-----------
+
+The speech to text attach operation can be used to attach the generated subtitles from a previously run
+[`speechtotext`](speechtotext-woh.md) operation if the process was started asynchronously.
+
+Parameter Table
+---------------
+
+| Configuration Keys       | Required | Example          | Description
+|--------------------------|----------|------------------|-------------
+| target-flavor            | yes      | archive          | Flavor of the produced subtitle
+| target-tags              | no       | captions/source  | Tags for the subtitle file².
+| target-element           | no       | track            | Define where to append the subtitles file. Possibilities are: as a 'track' or as an 'attachment' (default: `track`).
+
+
+Operation Examples
+------------------
+
+```yaml
+- id: speechtotext
+  description: Generates subtitles for video and audio files
+  configurations:
+    - source-flavor: '*/source'
+    - target-flavor: captions/source
+    - limit-to-one: true
+    - async: true
+
+- … other operations
+
+- id: speechtotext-attach
+  description: Attach generated subtitles
+  configurations:
+    - target-flavor: captions/source
+    - target-tags: engage-download
+```

--- a/docs/guides/admin/docs/workflowoperationhandlers/speechtotext-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/speechtotext-woh.md
@@ -23,7 +23,7 @@ Parameter Table
 | target-tags              | no       | captions/source  | Tags for the subtitle file².
 | target-element           | no       | track            | Define where to append the subtitles file. Possibilities are: as a 'track' or as an 'attachment' (default: `track`).
 | language-code            | no       | de               | The language of the video or audio source³.
-| language-fallback        | no¹      | en               | The fallback value if the dublin core/media package language field is not present (default: `en`).
+| language-fallback        | no¹      | en               | Optional fallback value if the dublin core/media package language field is not set.
 | translate                | no       | true             | Transcription is translated into English, valid values `true` or `false` (Whisper/WhisperC++ only)
 | limit-to-one             | no       | true             | Limits the maximum of generated subtitles to one.
 | track-selection-strategy | no       | everything       | Define what tracks shall be selected for subtitle generation if used together with `limit-to-one` (default: `everything`).

--- a/docs/guides/admin/docs/workflowoperationhandlers/speechtotext-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/speechtotext-woh.md
@@ -20,9 +20,9 @@ Parameter Table
 |--------------------------|----------|------------------|-------------
 | source-flavor            | yes      | presenter/source | The source media package to use
 | target-flavor            | yes      | archive          | Flavor of the produced subtitle
-| target-tags              | no       | captions/source  | Tags for the subtitle file².
+| target-tags              | no       | captions/source  | Tags applies to the resulting subtitle element²³.
 | target-element           | no       | track            | Define where to append the subtitles file. Possibilities are: as a 'track' or as an 'attachment' (default: `track`).
-| language-code            | no       | de               | The language of the video or audio source³.
+| language-code            | no       | de               | The language of the video or audio source⁴.
 | language-fallback        | no¹      | en               | Optional fallback value if the dublin core/media package language field is not set.
 | translate                | no       | true             | Transcription is translated into English, valid values `true` or `false` (Whisper/WhisperC++ only)
 | limit-to-one             | no       | true             | Limits the maximum of generated subtitles to one.
@@ -34,6 +34,7 @@ Parameter Table
 2. For conventionally used tags see the general page on [Subtitles](../configuration/subtitles.md). The `generator`
    and `generator-type` tags will be set automatically. For Whisper, iIf no `language-code` is set, the `lang` tag will
    be auto-generated.
+3. This has no effect if the transcription is run asynchronously. It only applies to attached in this operation.
 3. Vosk only: It has to match the name of the language model directory. See 'vosk-cli'.
 
 Requirements

--- a/docs/guides/admin/mkdocs.yml
+++ b/docs/guides/admin/mkdocs.yml
@@ -247,6 +247,7 @@ nav:
    - Series: 'workflowoperationhandlers/series-woh.md'
    - Silence: 'workflowoperationhandlers/silence-woh.md'
    - Speech to Text: 'workflowoperationhandlers/speechtotext-woh.md'
+   - Speech to Text Attach: 'workflowoperationhandlers/speechtotext-attach-woh.md'
    - Start Watson Transcription: 'workflowoperationhandlers/start-watson-transcription-woh.md'
    - Start Workflow: 'workflowoperationhandlers/start-workflow-woh.md'
    - Statistics Writer: 'workflowoperationhandlers/statistics-writer.md'

--- a/etc/org.opencastproject.speechtotext.impl.SpeechToTextServiceImpl.cfg
+++ b/etc/org.opencastproject.speechtotext.impl.SpeechToTextServiceImpl.cfg
@@ -4,5 +4,5 @@
 
 # Select STT engine.
 # Available engines: vosk, whisper, whispercpp
-# Default: (enginetype=whisper)
-#SpeechToTextEngine.target=(enginetype=whisper)
+# Default: (enginetype=whispercpp)
+#SpeechToTextEngine.target=(enginetype=whispercpp)

--- a/etc/org.opencastproject.speechtotext.impl.engine.WhisperCppEngine.cfg
+++ b/etc/org.opencastproject.speechtotext.impl.engine.WhisperCppEngine.cfg
@@ -1,6 +1,6 @@
-# Configuration for setting a custom path to the Whisper command line tool
-# Default: whisper
-#whispercpp.root.path=whispercpp
+# Configuration for setting a custom path to the Whisper.cpp command line tool
+# Default: whisper.cpp
+#whispercpp.root.path=whisper.cpp
 
 # Absolute path to language model
 # RPMs install models to /usr/share/ggml/ggml-<model>.bin

--- a/modules/common/src/main/java/org/opencastproject/mediapackage/AbstractMediaPackageElement.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/AbstractMediaPackageElement.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.UUID;
 
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
@@ -180,6 +181,12 @@ public abstract class AbstractMediaPackageElement implements MediaPackageElement
   @Override
   public void setIdentifier(String id) {
     this.id = id;
+  }
+
+  @Override
+  public String generateIdentifier() {
+    id = UUID.randomUUID().toString();
+    return id;
   }
 
   /**

--- a/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageElement.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageElement.java
@@ -56,6 +56,13 @@ public interface MediaPackageElement extends ManifestContributor, Comparable<Med
   void setIdentifier(String id);
 
   /**
+   * Generate a new random identifier for this element.
+   *
+   * @return The new identifier.
+   */
+  String generateIdentifier();
+
+  /**
    * Returns the element's manifest type.
    *
    * @return the manifest type

--- a/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/SpeechToTextServiceImpl.java
+++ b/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/SpeechToTextServiceImpl.java
@@ -213,7 +213,7 @@ public class SpeechToTextServiceImpl extends AbstractJobProducer implements Spee
 
   @Reference(
           name = "SpeechToTextEngine",
-          target = "(enginetype=whisper)"
+          target = "(enginetype=whispercpp)"
   )
   public void setSpeechToTextEngine(SpeechToTextEngine engine) {
     this.speechToTextEngine = engine;

--- a/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/WhisperCppEngine.java
+++ b/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/WhisperCppEngine.java
@@ -73,7 +73,7 @@ public class WhisperCppEngine implements SpeechToTextEngine {
   private static final String WHISPERCPP_EXECUTABLE_PATH_CONFIG_KEY = "whispercpp.root.path";
 
   /** Default path to WhisperC++. */
-  public static final String WHISPERCPP_EXECUTABLE_DEFAULT_PATH = "whispercpp";
+  public static final String WHISPERCPP_EXECUTABLE_DEFAULT_PATH = "whisper.cpp";
 
   /** Currently used path of the WhisperC++ installation. */
   private String whispercppExecutable = WHISPERCPP_EXECUTABLE_DEFAULT_PATH;

--- a/modules/speech-to-text-workflowoperation/src/main/java/org/opencastproject/workflow/handler/speechtotext/SpeechToTextAttachWorkflowOperationHandler.java
+++ b/modules/speech-to-text-workflowoperation/src/main/java/org/opencastproject/workflow/handler/speechtotext/SpeechToTextAttachWorkflowOperationHandler.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.opencastproject.workflow.handler.speechtotext;
+
+import org.opencastproject.inspection.api.MediaInspectionService;
+import org.opencastproject.job.api.Job;
+import org.opencastproject.job.api.JobContext;
+import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.mediapackage.MediaPackageElementParser;
+import org.opencastproject.mediapackage.attachment.AttachmentImpl;
+import org.opencastproject.mediapackage.track.TrackImpl;
+import org.opencastproject.serviceregistry.api.ServiceRegistry;
+import org.opencastproject.serviceregistry.api.ServiceRegistryException;
+import org.opencastproject.speechtotext.api.SpeechToTextServiceException;
+import org.opencastproject.util.NotFoundException;
+import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
+import org.opencastproject.workflow.api.ConfiguredTagsAndFlavors;
+import org.opencastproject.workflow.api.WorkflowInstance;
+import org.opencastproject.workflow.api.WorkflowOperationException;
+import org.opencastproject.workflow.api.WorkflowOperationHandler;
+import org.opencastproject.workflow.api.WorkflowOperationInstance;
+import org.opencastproject.workflow.api.WorkflowOperationResult;
+import org.opencastproject.workspace.api.Workspace;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Workflow operation for attaching results from asynchronously running speech-to-text service jobs.
+ */
+@Component(
+    immediate = true,
+    service = WorkflowOperationHandler.class,
+    property = {
+        "service.description=Speech-to-Text Attach Workflow Operation Handler",
+        "workflow.operation=speechtotext-attach"
+    }
+)
+public class SpeechToTextAttachWorkflowOperationHandler extends AbstractWorkflowOperationHandler {
+
+  private static final Logger logger = LoggerFactory.getLogger(SpeechToTextAttachWorkflowOperationHandler.class);
+
+  /** Property name for configuring the place where the subtitles shall be appended. */
+  private static final String TARGET_ELEMENT = "target-element";
+
+  /** Workflow configuration name to store jobs in */
+  private static final String JOBS_WORKFLOW_CONFIGURATION = "speech-to-text-jobs";
+
+  private enum AppendSubtitleAs {
+    attachment, track
+  }
+
+  /** The workspace service. */
+  private Workspace workspace;
+
+  /** The inspection service. */
+  private MediaInspectionService mediaInspectionService;
+
+  @Override
+  @Activate
+  public void activate(ComponentContext cc) {
+    super.activate(cc);
+    logger.info("Registering speechtotext-attach workflow operation handler");
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @see
+   * WorkflowOperationHandler#start(WorkflowInstance,
+   * JobContext)
+   */
+  @Override
+  public WorkflowOperationResult start(WorkflowInstance workflowInstance, JobContext context)
+          throws WorkflowOperationException {
+
+    MediaPackage mediaPackage = workflowInstance.getMediaPackage();
+    logger.info("Start speechtotext-attach workflow operation for media package {}", mediaPackage);
+
+    ConfiguredTagsAndFlavors tagsAndFlavors = getTagsAndFlavors(workflowInstance,
+            Configuration.none, Configuration.none,
+            Configuration.many, Configuration.one);
+
+    // How to save the subtitle file? (as attachment, as track...)
+    AppendSubtitleAs appendSubtitleAs = howToAppendTheSubtitles(workflowInstance);
+
+    // get previously started speech-to-text jobs
+    var jobIds = Objects.toString(workflowInstance.getConfiguration(JOBS_WORKFLOW_CONFIGURATION), "");
+    if (jobIds.isEmpty()) {
+      logger.info("No speechtotext jobs to attach. Skipping.");
+      return createResult(mediaPackage, WorkflowOperationResult.Action.SKIP);
+    }
+
+    for (var jobId: jobIds.split(",")) {
+      attachSubtitle(Long.parseLong(jobId), mediaPackage, tagsAndFlavors, appendSubtitleAs);
+    }
+
+    // Remove tracked jobs from workflow
+    workflowInstance.getConfigurations().remove(JOBS_WORKFLOW_CONFIGURATION);
+
+    logger.info("Speech-To-Text workflow operation for media package {} completed", mediaPackage);
+    return createResult(mediaPackage, WorkflowOperationResult.Action.CONTINUE);
+  }
+
+  /**
+   * Creates the subtitle file for a track and appends it to the media package.
+   *
+   * @param jobId Identifier of the speectotext job
+   * @param mediaPackage The media package where the track is located.
+   * @param tagsAndFlavors Tags and flavors instance (to get target flavor information)
+   * @param appendSubtitleAs Tells how the subtitles file has to be appended.
+   * @throws WorkflowOperationException Get thrown if an error occurs.
+   */
+  private void attachSubtitle(long jobId, MediaPackage mediaPackage, ConfiguredTagsAndFlavors tagsAndFlavors,
+      AppendSubtitleAs appendSubtitleAs) throws WorkflowOperationException {
+
+    logger.info("Attaching subtitle from job '{}' to media package {}", jobId, mediaPackage);
+    Job job;
+    try {
+      job = serviceRegistry.getJob(jobId);
+    } catch (NotFoundException | ServiceRegistryException e) {
+      throw new WorkflowOperationException(
+              String.format("Could not find speechtotext job %s", jobId), e);
+    }
+    if (!"speechtotext".equals(job.getOperation())) {
+      throw  new WorkflowOperationException(String.format(
+          "Job %s is on type %s. Expected `speechtotext`", jobId, job.getOperation()));
+    }
+
+    if (!waitForStatus(job).isSuccess()) {
+      throw new WorkflowOperationException(
+              String.format("Speechtotext job for media package '%s' failed", mediaPackage));
+    }
+
+    // add subtitle to media package
+    try {
+      String[] jobOutput = job.getPayload().split(",");
+      URI output = new URI(jobOutput[0]);
+      String outputLanguage = jobOutput[1];
+      String engineType = jobOutput[2];
+
+      var subtitleElement = appendSubtitleAs == AppendSubtitleAs.attachment ? new AttachmentImpl() : new TrackImpl();
+      var elementId = subtitleElement.generateIdentifier();
+
+      try (InputStream in = workspace.read(output)) {
+        URI uri = workspace.put(mediaPackage.getIdentifier().toString(), elementId,
+                FilenameUtils.getName(output.getPath()), in);
+        subtitleElement.setURI(uri);
+      }
+      subtitleElement.setFlavor(tagsAndFlavors.getSingleTargetFlavor());
+
+      List<String> targetTags = tagsAndFlavors.getTargetTags();
+      targetTags.add("lang:" + outputLanguage);
+      targetTags.add("generator-type:auto");
+      targetTags.add("generator:" + engineType.toLowerCase());
+      for (String tag : targetTags) {
+        subtitleElement.addTag(tag);
+      }
+
+      // this is used to set some values automatically, like the correct mimetype
+      Job inspection = mediaInspectionService.enrich(subtitleElement, true);
+      if (!waitForStatus(inspection).isSuccess()) {
+        throw new SpeechToTextServiceException(String.format(
+            "Transcription for '%s' failed at enriching process", mediaPackage));
+      }
+
+      mediaPackage.add(MediaPackageElementParser.getFromXml(inspection.getPayload()));
+
+      workspace.delete(output);
+    } catch (Exception e) {
+      throw new WorkflowOperationException("Error handling text-to-speech service output", e);
+    }
+
+    try {
+      workspace.cleanup(mediaPackage.getIdentifier());
+    } catch (IOException e) {
+      throw new WorkflowOperationException(e);
+    }
+  }
+
+  /**
+   * Get the information how to append the subtitles file to the media package.
+   *
+   * @param workflowInstance Contains the workflow configuration.
+   * @return How to append the subtitles file to the media package.
+   * @throws WorkflowOperationException Get thrown if an error occurs.
+   */
+  private AppendSubtitleAs howToAppendTheSubtitles(WorkflowInstance workflowInstance)
+          throws WorkflowOperationException {
+    WorkflowOperationInstance operation = workflowInstance.getCurrentOperation();
+    String targetElement = StringUtils.trimToEmpty(operation.getConfiguration(TARGET_ELEMENT)).toLowerCase();
+    if (targetElement.isEmpty()) {
+      return AppendSubtitleAs.track;
+    }
+    try {
+      return AppendSubtitleAs.valueOf(targetElement);
+    } catch (IllegalArgumentException e) {
+      throw new WorkflowOperationException(String.format(
+          "Speech-to-Text job for media package '%s' failed, because of wrong workflow configuration. "
+              + "target-element of type '%s' does not exist.", workflowInstance.getMediaPackage(), targetElement));
+    }
+  }
+
+  //================================================================================
+  // OSGi setter
+  //================================================================================
+
+  @Reference
+  public void setMediaInspectionService(MediaInspectionService mediaInspectionService) {
+    this.mediaInspectionService = mediaInspectionService;
+  }
+
+  @Reference
+  public void setWorkspace(Workspace workspace) {
+    this.workspace = workspace;
+  }
+
+  @Reference
+  public void setServiceRegistry(ServiceRegistry serviceRegistry) {
+    this.serviceRegistry = serviceRegistry;
+  }
+}

--- a/modules/speech-to-text-workflowoperation/src/main/java/org/opencastproject/workflow/handler/speechtotext/SpeechToTextWorkflowOperationHandler.java
+++ b/modules/speech-to-text-workflowoperation/src/main/java/org/opencastproject/workflow/handler/speechtotext/SpeechToTextWorkflowOperationHandler.java
@@ -488,8 +488,8 @@ public class
     }
 
     if (language.isEmpty()) {
-      // If nothing helps, use the fallback language
-      language = Objects.toString(operation.getConfiguration(LANGUAGE_FALLBACK), "en");
+      // Use the fallback language if the operation configuration defines one
+      language = Objects.toString(operation.getConfiguration(LANGUAGE_FALLBACK), "");
     }
 
     return language;


### PR DESCRIPTION
This patch allows generating subtitles in the backgrould, starting the jobs first and attaching the result later in the workflow.

Unfortunately, looking into the code, I also found a lot of minor issues which I fixed as well, but which were hard to separate from this patch:

- `language-fallback` didn't work
- Defaults for generator enging and Whisper.cpp binary fixed
- Defaults for several operations
- Simplified code

### How to test this patch

- Make sure to install Whisper.cpp. You may need to update the configuration `etc/org.opencastproject.speechtotext.impl.engine.WhisperCppEngine.cfg`. Likely you just have to configure something like:
  - `whispercpp.root.path=/home/lars/dev/whisper.cpp/main`
  - `whispercpp.model=/home/lars/dev/whisper.cpp/models/ggml-tiny.bin`
- Update the `fast.yaml` workflow:
```diff
diff --git a/etc/workflows/fast.yaml b/etc/workflows/fast.yaml
index 7a0494ed46..f526ed0a60 100644
--- a/etc/workflows/fast.yaml
+++ b/etc/workflows/fast.yaml
@@ -25,6 +25,7 @@ configuration_panel_json: |-
     ]
   }]
 operations:
+
   - id: defaults
     description: "Applying default configuration values"
     configurations:
@@ -45,6 +46,14 @@ operations:
       - overwrite: false
       - accept-no-media: false
 
+  - id: speechtotext
+    description: Generates subtitles for video and audio files
+    configurations:
+      - source-flavor: '*/prepared'
+      - target-flavor: captions/source
+      - limit-to-one: true
+      - async: true
+
   - id: encode
     fail-on-error: true
     exception-handler-workflow: "partial-error"
@@ -61,9 +70,7 @@ operations:
     description: "Tag captions for publication"
     configurations:
       - source-flavor: "captions/source"
-      - target-flavor: "captions/preview"
       - target-tags: "+engage-download"
-      - copy: true
 
   - id: image
     if: "${straightToPublishing}"
@@ -110,6 +117,12 @@ operations:
       - target-tags: "engage-download"
       - encoding-profile: "player-slides.http"
 
+  - id: speechtotext-attach
+    description: Generates subtitles for video and audio files
+    configurations:
+      - target-flavor: captions/source
+      - target-tags: engage-download
+
   - id: publish-configure
     exception-handler-workflow: "partial-error"
     description: "Publish to preview publication channel"
```

- Download a video with subtitles like:
  https://github.com/user-attachments/assets/932ef91b-580a-4d11-9717-011b7bbdb142
- Convert this to a wav file:
    ```
    ffmpeg -i github-multiline-suggestion.mp4 github-multiline-suggestion.wav
    ```
- Ingest both files:
    ```
    curl -i -u admin:opencast http://localhost:8080/ingest/addMediaPackage/fast -F 'flavor=presentation/source' -F BODY=@github-multiline-suggestion.mp4 -F flavor=presentation/prepared -F BODY2=@github-multiline-suggestion.wav -F title="I 🖤 Opencast"
    ```

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
