### PR TITLE
Fix stale JWK provider cache when using kid

### DIFF
--- a/modules/security-jwt/src/main/java/org/opencastproject/security/jwt/JWTVerifier.java
+++ b/modules/security-jwt/src/main/java/org/opencastproject/security/jwt/JWTVerifier.java
@@ -61,10 +61,11 @@ public final class JWTVerifier {
     DecodedJWT jwt = JWT.decode(token);
 
     // First try with cache...
-    List<Algorithm> algorithms = provider.getAlgorithms(jwt, false);
+    List<Algorithm> algorithms;
     try {
+      algorithms = provider.getAlgorithms(jwt, false);
       return verify(jwt, claimConstraints, algorithms);
-    } catch (JWTVerificationException e) {
+    } catch (JWTVerificationException | JwkException e) {
       // ...then try again with forced fetch
       // (recommended by e.g. https://openid.net/specs/openid-connect-core-1_0.html#RotateSigKeys)
       algorithms = provider.getAlgorithms(jwt, true);


### PR DESCRIPTION
The JWK provider cache can become stale (e.g. upon key rotation). When using key IDs this can result in an empty algorithm selection. An exception is thrown, however, the cache is not refreshed. This patch will force a refresh if no key could be found.

### How to test this patch

1. Configure JWT, including a JWKS endpoint (that includes `kid` for configured keys)
2. Start Opencast and authenticate using JWTs
3. Rotate keys
4. Try to authenticate using JWTs that are signed using new keys

### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
