### PR TITLE
Disable hard linking between organizations

### DIFF
--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
@@ -1187,7 +1187,7 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
       // find asset in versions & stores
       final Optional<StoragePath> existingAssetOpt =
           getDatabase()
-          .findAssetByChecksumAndStore(e.getChecksum().toString(), store.getStoreType())
+          .findAssetByChecksumAndStoreAndOrg(e.getChecksum().toString(), store.getStoreType(), orgId)
           .map(dto -> StoragePath.mk(
               dto.getOrganizationId(),
               dto.getMediaPackageId(),
@@ -1374,7 +1374,7 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
       final StoragePath storagePath = StoragePath.mk(orgId, mpId, version, e.getIdentifier());
       // find asset in versions
       final Optional<StoragePath> existingAssetOpt = getDatabase()
-          .findAssetByChecksumAndStore(e.getChecksum().toString(), getLocalAssetStore().getStoreType())
+          .findAssetByChecksumAndStoreAndOrg(e.getChecksum().toString(), getLocalAssetStore().getStoreType(), orgId)
           .map(dto -> StoragePath.mk(
                   dto.getOrganizationId(),
                   dto.getMediaPackageId(),

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/Database.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/Database.java
@@ -348,10 +348,13 @@ public class Database implements EntityPaths {
     return db.exec(SnapshotDto.countEventsQuery(organization));
   }
 
-  public Optional<AssetDtos.Full> findAssetByChecksumAndStore(final String checksum, final String storeId) {
+  public Optional<AssetDtos.Full> findAssetByChecksumAndStoreAndOrg(final String checksum, final String storeId,
+      final String orgId) {
     return db.execTx(em -> {
       final Tuple result = AssetDtos.baseJoin(em)
-          .where(QAssetDto.assetDto.checksum.eq(checksum).and(QAssetDto.assetDto.storageId.eq(storeId)))
+          .where(QAssetDto.assetDto.checksum.eq(checksum)
+              .and(QAssetDto.assetDto.storageId.eq(storeId))
+              .and(QAssetDto.assetDto.snapshot.organizationId.eq(orgId)))
           .singleResult(Full.select);
       var dtoOpt = Opt.nul(result).map(Full.fromTuple);
       return dtoOpt.isSome() ? Optional.of(dtoOpt.get()) : Optional.empty();


### PR DESCRIPTION
Opencast currently hard links assets with identical hash values. This is true even between different organizations. This patch will only allow hard linking within the same organization, resulting in a clear separation between organizations.

I'm pretty sure this is a controversial change, and chances are high that this will not land upstream. If not, it is at least documented publically in this PR.

This change is mainly driven from the perspective of a service provider that uses multi-tenancy and charges for used storage. Additionally, we have already patched Opencast for use per tenant S3 buckets (PR pending), which makes "linking" objects (in the DB) tricky.

Note that this will **not** separate assets between tenants that already use hard links, i.e. it will only affect new assets. It is, however, fully compatible with installations that have these hard links.

### How to test this patch

1. Configure two tenants (e.g. using https://github.com/opencast/community-integrations/tree/main/multi-tenant)
2. Ingest identical video one after another in each tenant
3. Observe if hard links are used for assets between orgs

### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
