### PR TITLE
Add per-organization bucket name configuration

### DIFF
--- a/etc/org.opencastproject.assetmanager.aws.s3.AwsS3AssetStore.cfg
+++ b/etc/org.opencastproject.assetmanager.aws.s3.AwsS3AssetStore.cfg
@@ -6,11 +6,14 @@ org.opencastproject.assetmanager.aws.s3.enabled=false
 # The AWS region. Default is us-east-1. Name must be a valid AWS region name like us-east-1.
 #org.opencastproject.assetmanager.aws.s3.region=
 
-# The AWS S3 bucket name (mandatory). '_' is not allowed.
+# The AWS S3 bucket name (optional if bucket name is not configured per organization). '_' is not allowed.
 #
 # You should use a distinct bucket name for each MH cluster.
 # Example: cluster-name-file-assetmanager
 #org.opencastproject.assetmanager.aws.s3.bucket=
+
+# Organization AWS S3 bucket mapping
+#org.opencastproject.distribution.aws.s3.bucket.<org>=assetmanager-for-<org>
 
 # The number of days which to restore objects in the Glacier storage class for.
 # Default: 2

--- a/etc/org.opencastproject.distribution.aws.s3.AwsS3DistributionServiceImpl.cfg
+++ b/etc/org.opencastproject.distribution.aws.s3.AwsS3DistributionServiceImpl.cfg
@@ -6,11 +6,14 @@ org.opencastproject.distribution.aws.s3.distribution.enable=false
 # The AWS region. Name must be a valid AWS region name like us-east-1.
 #org.opencastproject.distribution.aws.s3.region=
 
-# The AWS S3 bucket name (mandatory). '_' is not allowed.
+# The default AWS S3 bucket name (optional if bucket name is not configured per organization). '_' is not allowed.
 #
 # You should use a distinct bucket name for each MH cluster.
 # Example: cluster-name-distribution
 #org.opencastproject.distribution.aws.s3.bucket=
+
+# Organization AWS S3 bucket mapping
+#org.opencastproject.distribution.aws.s3.bucket.<org>=distribution-for-<org>
 
 # The base URL for the bucket.
 #org.opencastproject.distribution.aws.s3.distribution.base=

--- a/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/AwsAbstractArchive.java
+++ b/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/AwsAbstractArchive.java
@@ -176,7 +176,8 @@ public abstract class AwsAbstractArchive implements AssetStore {
     String objectVersion = null;
     try {
       // Upload file to AWS
-      AwsUploadOperationResult result = uploadObject(origin, objectName, source.getMimeType());
+      AwsUploadOperationResult result = uploadObject(storagePath.getOrganizationId(), origin, objectName,
+          source.getMimeType());
       objectName = result.getObjectName();
       objectVersion = result.getObjectVersion();
     } catch (Exception e) {
@@ -193,8 +194,8 @@ public abstract class AwsAbstractArchive implements AssetStore {
     }
   }
 
-  protected abstract AwsUploadOperationResult uploadObject(File origin, String objectName, Optional<MimeType> mimeType)
-          throws AssetStoreException;
+  protected abstract AwsUploadOperationResult uploadObject(String orgId, File origin, String objectName,
+          Optional<MimeType> mimeType) throws AssetStoreException;
 
   /** @see AssetStore#get(StoragePath) */
   public Optional<InputStream> get(final StoragePath path) throws AssetStoreException {

--- a/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/s3/AwsS3AssetStore.java
+++ b/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/s3/AwsS3AssetStore.java
@@ -202,6 +202,10 @@ public class AwsS3AssetStore extends AwsAbstractArchive implements RemoteAssetSt
             orgBucketNameMap.put(orgId, bucketName);
           });
 
+      if (orgBucketNameMap.isEmpty()) {
+        throw new ConfigurationException("AWS S3 asset store is enabled, but no buckets are configured");
+      }
+
       // AWS region
       regionName = getAWSConfigKey(cc, AWS_S3_REGION_CONFIG);
       logger.info("AWS region is {}", regionName);

--- a/modules/asset-manager-storage-aws/src/test/java/org/opencastproject/assetmanager/aws/s3/AwsS3AssetStoreTest.java
+++ b/modules/asset-manager-storage-aws/src/test/java/org/opencastproject/assetmanager/aws/s3/AwsS3AssetStoreTest.java
@@ -136,7 +136,7 @@ public class AwsS3AssetStoreTest {
     EasyMock.replay(workspace);
 
     store = new AwsS3AssetStore();
-    store.setBucketName(BUCKET_NAME);
+    store.setBucketName(ORG_ID, BUCKET_NAME);
     store.setS3(s3Client);
     store.setS3TransferManager(s3Transfer);
     store.setWorkspace(workspace);

--- a/modules/distribution-service-aws-s3/src/main/java/org/opencastproject/distribution/aws/s3/AwsS3DistributionServiceImpl.java
+++ b/modules/distribution-service-aws-s3/src/main/java/org/opencastproject/distribution/aws/s3/AwsS3DistributionServiceImpl.java
@@ -278,6 +278,10 @@ public class AwsS3DistributionServiceImpl extends AbstractDistributionService
             orgBucketNameMap.put(orgId, bucketName);
           });
 
+      if (orgBucketNameMap.isEmpty()) {
+        throw new ConfigurationException("AWS S3 distribution is enabled, but no buckets are configured");
+      }
+
       // AWS region
       String regionStr = getAWSConfigKey(cc, AWS_S3_REGION_CONFIG);
       logger.info("AWS region is {}", regionStr);

--- a/modules/distribution-service-aws-s3/src/test/java/org/opencastproject/distribution/aws/s3/AwsS3DistributionServiceImplTest.java
+++ b/modules/distribution-service-aws-s3/src/test/java/org/opencastproject/distribution/aws/s3/AwsS3DistributionServiceImplTest.java
@@ -108,7 +108,7 @@ public class AwsS3DistributionServiceImplTest {
 
     service = new AwsS3DistributionServiceImpl();
     service.setServiceRegistry(serviceRegistry);
-    service.setBucketName(BUCKET_NAME);
+    service.setBucketName(defaultOrganization.getId(), BUCKET_NAME);
     service.setOpencastDistributionUrl(DOWNLOAD_URL);
     service.setS3(s3);
     service.setS3TransferManager(tm);


### PR DESCRIPTION
Add the ability to configure S3 buckets for each organization (asset manager and distribution). The old configuration is still compatible and will result in a default bucket configuration, i.e. if no org-specific buckets are configured, the default bucket will be used.

This likely depends on #6252 (I have not tested without this additional patch).

### How to test this patch

1. Configure two tenants (e.g. using https://github.com/opencast/community-integrations/tree/main/multi-tenant)
2. Configure different S3 buckets for each tenant
3. Upload videos to each tenant
4. Observe which S3 buckets are used

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
