### PR TITLE
Lower log level for filter parsing errors

### DIFF
--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -754,7 +754,7 @@ public class EventsEndpoint implements ManagedService {
         for (String f : filterPart.split(",")) {
           String[] filterTuple = f.split(":");
           if (filterTuple.length < 2) {
-            logger.info("No value for filter {} in filters list: {}", filterTuple[0], filter);
+            logger.debug("No value for filter {} in filters list: {}", filterTuple[0], filter);
             continue;
           }
 

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
@@ -237,7 +237,7 @@ public class SeriesEndpoint {
         for (String f : filter.split(",")) {
           String[] filterTuple = f.split(":",2);
           if (filterTuple.length < 2) {
-            logger.info("Filter {} not valid: {}", filterTuple[0], filter);
+            logger.debug("Filter {} not valid: {}", filterTuple[0], filter);
             continue;
           }
           String name = filterTuple[0];

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowDefinitionsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowDefinitionsEndpoint.java
@@ -158,7 +158,7 @@ public class WorkflowDefinitionsEndpoint {
       for (String f : filter.split(",")) {
         int sepIdx = f.indexOf(':');
         if (sepIdx < 0 || sepIdx == f.length() - 1) {
-          logger.info("No value for filter {} in filters list: {}", f, filter);
+          logger.debug("No value for filter {} in filters list: {}", f, filter);
           continue;
         }
         String name = f.substring(0, sepIdx);


### PR DESCRIPTION
Opencast is noisy when users pass in invalid filters. This lowers the log level to debug.

### How to test this patch

1. Pass invalid filter to External API (e.g. leave out the `:`)
2. Observe what log level is used

### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
