### PR TITLE
Fix NPE when MP element can't be found in local asset manager store

### DIFF
--- a/modules/shared-filesystem-utils/src/main/java/org/opencastproject/assetmanager/util/AssetPathUtils.java
+++ b/modules/shared-filesystem-utils/src/main/java/org/opencastproject/assetmanager/util/AssetPathUtils.java
@@ -137,6 +137,11 @@ public final class AssetPathUtils {
         localPath = path;
       }
     }
+    // if remote asset stores are used, localPath could be null (i.e. all snapshots live remotely)
+    if (localPath == null) {
+      logger.debug("Local snapshot for {} not available.", uri);
+      return null;
+    }
     final File file = Paths.get(localPath, organizationId, mediaPackageID, version, filename).toFile();
     if (file.isFile()) {
       logger.debug("Converted {} to local file at {}", uri, file);


### PR DESCRIPTION
Opencast currently assumes that assets can be found locally when checking for the correct local path. This is not true when using remote asset stores (e.g. S3), resulting in an NPE. This patch adds a null check.

### How to test this patch

1. Configure S3 asset store
2. Force all files to move to S3
3. Try to retrieve assets from asset manager endpoint

### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
