### PR TITLE
Refix the CLA check

### DIFF
--- a/.github/workflows/check-icla.yml
+++ b/.github/workflows/check-icla.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   main:
     if: github.event.pull_request.user.login != 'dependabot[bot]'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/setup-python@v4
 


### PR DESCRIPTION
This PR fixes the CLA check so that it works properly.  For some reason ubuntu-latest is *not* ubuntu 24.04 in October '24, instead we get ubuntu 22.04 which does not support `--break-system-packages`.

This should be in `r/15.x` since it affects the branch (with the original fix being merged a couple of weeks ago).  While we're not expecting significant contributions at this point, we should have the CLA checking in place regardless.

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
