### PR TITLE
Fix Amberscript Transcription Jobs Hanging

### DIFF
--- a/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/AmberscriptTranscriptionService.java
+++ b/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/AmberscriptTranscriptionService.java
@@ -1061,8 +1061,9 @@ public class AmberscriptTranscriptionService extends AbstractJobProducer impleme
             final AQueryBuilder q = assetManager.createQuery();
             final AResult r = q.select(q.snapshot()).where(q.mediaPackageId(mpId).and(q.version().isLatest())).run();
             if (r.getSize() == 0) {
-              // Media package not archived yet? Skip until next time.
-              logger.debug("Media package {} has not been archived yet. Skipped.", mpId);
+              logger.warn("Media package {} no longer exists in the asset manager. It was likely deleted. "
+                  + "Dropping the generated transcription.", mpId);
+              database.updateJobControl(jobId, TranscriptionJobControl.Status.Error.name());
               continue;
             }
 


### PR DESCRIPTION
This patch fixes the problem that AmberScript transcription jobs will never finish if the event has been deleted between starting and finishing the transcription.

The code checked if a snapshot exists, skipping the operation and repeating this on the next run again. An existing event will always have at least one snapshot, since one is created at ingest or even earlier if the event was scheduled. If you delete the event, however, there will be no snapshot, but there will obviously also never be any snapshot. That is why the jobs will just wait forever.

### How to test this patch

- Configure AmberScript
- Add a new media (triggering the transcription service)
- Delete the event as soon as it finished processing

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
