### PR TITLE
Fix default session timeout

### DIFF
--- a/etc/org.ops4j.pax.web.cfg
+++ b/etc/org.ops4j.pax.web.cfg
@@ -51,5 +51,8 @@ org.ops4j.pax.web.ssl.key.password=password
 # Prevent cookie from being accessed by client side scripts, default false
 org.ops4j.pax.web.session.cookie.httpOnly=true
 
-# Timeout for user sessions in minutes.
-org.ops4j.pax.web.session.timeout=240
+# Timeout for user sessions in seconds
+# Note: This is seconds, not minutes due to a bug in Pax Web:
+# https://github.com/opencast/opencast/issues/6260
+# 14400 seconds = 240 minutes = 4 hours
+org.ops4j.pax.web.session.timeout=14400


### PR DESCRIPTION
Due to a bug in Pax Web, the default session timeout for Opencast was set to 4 minutes instead of 4 hours. This caused users to be logged out automatically if they do not have an additional remember-me cookie (e.g. LTI users don't have that). This basically means that users are unable to watch videos longer than four minutes for which they need authentication.

This is a temporary fix for #6260

### How to test this patch

To test this (check that the value is indeed seconds):

- Set `org.ops4j.pax.web.session.timeout=20`
- Go to http://localhost:8080, make sure to **remove the check mark for remember me** and log-in
- Wait for 21 seconds
- Go to http://localhost:8080 again
  - You will be logged out and asked to log in again

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
