### PR TITLE
Upgrade upload-artifacts from v3 to v4

### DIFF
--- a/.github/workflows/test-opencast-build.yml
+++ b/.github/workflows/test-opencast-build.yml
@@ -173,7 +173,8 @@ jobs:
         if: >
           matrix.java == 11
           && github.repository == 'opencast/opencast'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: opencast-allinone
           path: build/opencast-dist-allinone/
+          overwrite: true

--- a/.github/workflows/test-paella-7.yml
+++ b/.github/workflows/test-paella-7.yml
@@ -27,9 +27,10 @@ jobs:
       run: npx playwright install --with-deps
     - name: Run Playwright tests
       run: npx playwright test
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: playwright-report
         path: ./modules/engage-paella-player-7/playwright-report/
         retention-days: 30
+        overwrite: true


### PR DESCRIPTION
This PR updates the `upload-artifacts` workflow action from v3 to v4.  v3 will be deprecated Dec 5, with brownouts occurring sooner.  This PR should not change behaviour in terms of uploaded builds.

This PR should go into `r/15.x` because the v3 will likely stop working around Dec 5, and this will also prevent hte brownouts (Nov 14 and 21) from causing unneccessary workflow failures.

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
