### PR TITLE
Don't run attach transcription if AmberScript transcription failed

### DIFF
--- a/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/AmberscriptTranscriptionService.java
+++ b/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/AmberscriptTranscriptionService.java
@@ -1042,6 +1042,7 @@ public class AmberscriptTranscriptionService extends AbstractJobProducer impleme
               } catch (TranscriptionServiceException e) {
                 try {
                   database.updateJobControl(jobId, TranscriptionJobControl.Status.Canceled.name());
+                  continue;
                 } catch (TranscriptionDatabaseException ex) {
                   logger.warn("Could not cancel job '{}'.", jobId);
                 }


### PR DESCRIPTION
If an AmberScript transcription job fails – for example if there is no speech in the video – the service will recognize the error, write that to the database, but then still continue with trying to attach the workflow, even overwriting the error state written to the database again.

This is due to the code just executing the remainder of the code used for processing successful transcriptions. Instead, it should immediately continue with the next transcription job.

### How to test this patch

- Configure AmberScript in Opencast (see below)
- Ingest [goat.mp4](https://data.lkiesow.io/opencast/test-media/goat.mp4)
- The transcription will fail since the video contains no speech
- *before this patch*: the transcription service will mark the transcription as successful and launch the attach transcription workflow
- *after with patch*: the transcription service will mark the transcription as cancelled and not start any workflow

#### Amberscript configuration

- Download [amberscript-config-2.patch.txt](https://github.com/user-attachments/files/17822287/amberscript-config-2.patch.txt)
- `git apply amberscript-config.patch.txt`
- Set `<API_KEY>` in line 6 of `etc/org.opencastproject.transcription.amberscript.AmberscriptTranscriptionService.cfg`
- Build Opencast and use the `fast` workflow with azto-publication for testing


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
