### PR TITLE
RPM » Fix repository path

### DIFF
--- a/.github/workflows/rpms-create-repository.yml
+++ b/.github/workflows/rpms-create-repository.yml
@@ -52,5 +52,6 @@ jobs:
           then
             mkdir ${{ matrix.arch }}
             createrepo_c ${{ matrix.arch }}
-            s3cmd put -P --recursive noarch x86_64 s3://${S3PATH}/
+            cd ${{ matrix.arch }}
+            s3cmd put -P --recursive repodata s3://${S3PATH}/
           fi


### PR DESCRIPTION
> You may still remember that we talked about me porting the RPM build structure to this repository. That means, these pull requests usually don't need a review and I'll just meger it. That being said, if someone is actually interested, I'm happy if you take a look at these (and maybe even help).

This patch fixes the path of the newly created repository. We want it to be something like `noarch/repodata` not `noarch/noarch/repodata`.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
