### PR TITLE
Fix scrollbar overlaying code in docs

### DIFF
--- a/docs/guides/admin/docs/css/extra.css
+++ b/docs/guides/admin/docs/css/extra.css
@@ -204,3 +204,11 @@ div.warn {
 .tippy-box[data-theme~='opencast'][data-placement^='top'] > .tippy-arrow::before {
   color: #24425c;
 }
+
+pre {
+  padding: 5px;
+}
+
+pre > code {
+  padding: 8px;
+}


### PR DESCRIPTION
This patch fixes the problem that in our documentation the scrollbars sometimes overlay the actual code which is pretty annoying if you want to copy parts of the code. And also, it doesn't look great :D

<img src=https://github.com/user-attachments/assets/b1904619-35a2-4a22-8837-d9614c6f730a width=300 />


### How to test this patch

- Build the docs locally
- The example screenshot is from the [install via RPMs page](https://docs.opencast.org/develop/admin/#installation/rpm-el/)

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
