### PR TITLE
Plugins with different modules on different distributions

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -173,9 +173,6 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-composer-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-conductor/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-cover-image-workflowoperation/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-crop-api/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-crop-ffmpeg/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-crop-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-dictionary-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-dictionary-regexp/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-distribution-service-api/${project.version}</bundle>
@@ -288,9 +285,6 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-cover-image-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-cover-image-remote/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-cover-image-workflowoperation/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-crop-api/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-crop-remote/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-crop-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-distribution-service-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-distribution-service-aws-s3-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-distribution-service-aws-s3-remote/${project.version}</bundle>
@@ -421,9 +415,6 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-cover-image-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-cover-image-remote/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-cover-image-workflowoperation/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-crop-api/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-crop-remote/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-crop-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-distribution-service-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-distribution-service-aws-s3-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-distribution-service-aws-s3/${project.version}</bundle>
@@ -557,8 +548,6 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-animate-impl/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-composer-ffmpeg/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-composer-service-api/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-crop-api/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-crop-ffmpeg/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-inspection-service-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-inspection-service-ffmpeg/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-silencedetection-api/${project.version}</bundle>
@@ -584,8 +573,6 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-cover-image-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-cover-image-impl/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-cover-image-workflowoperation/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-crop-api/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-crop-ffmpeg/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-dictionary-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-dictionary-regexp/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-execute-api/${project.version}</bundle>
@@ -762,6 +749,33 @@
     <feature>opencast-graphql-tp</feature>
     <bundle start-level="82">mvn:org.opencastproject/opencast-graphql/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-graphql-ui/${project.version}</bundle>
+  </feature>
+
+  <feature name="opencast-plugin-crop_allinone" version="${project.version}">
+    <conditional>
+      <condition>opencast-allinone</condition>
+    </conditional>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-crop-api/${project.version}</bundle>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-crop-ffmpeg/${project.version}</bundle>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-crop-workflowoperation/${project.version}</bundle>
+  </feature>
+
+  <feature name="opencast-plugin-crop_admin" version="${project.version}">
+    <conditional>
+      <condition>opencast-admin</condition>
+      <condition>opencast-adminpresentation</condition>
+    </conditional>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-crop-api/${project.version}</bundle>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-crop-remote/${project.version}</bundle>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-crop-workflowoperation/${project.version}</bundle>
+  </feature>
+
+  <feature name="opencast-plugin-crop_worker" version="${project.version}">
+    <conditional>
+      <condition>opencast-worker</condition>
+    </conditional>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-crop-api/${project.version}</bundle>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-crop-ffmpeg/${project.version}</bundle>
   </feature>
 
   <feature name="opencast-pluginmanager" version="${project.version}">

--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -120,6 +120,9 @@
             <installedFeatures>
               <feature>opencast-security-cas</feature>
               <feature>opencast-security-jwt</feature>
+              <feature>opencast-plugin-crop_allinone</feature>
+              <feature>opencast-plugin-crop_admin</feature>
+              <feature>opencast-plugin-crop_worker</feature>
               <feature>opencast-plugin-legacy-annotation</feature>
               <feature>opencast-plugin-transcription-services</feature>
               <feature>opencast-plugin-userdirectory-brightspace</feature>

--- a/docs/guides/admin/docs/releasenotes/distributed-plugins.txt
+++ b/docs/guides/admin/docs/releasenotes/distributed-plugins.txt
@@ -1,0 +1,2 @@
+- Opencast now supports distributed plugins
+- The crop service is now a plugin and disabled by default

--- a/etc/org.opencastproject.plugin.impl.PluginManagerImpl.cfg
+++ b/etc/org.opencastproject.plugin.impl.PluginManagerImpl.cfg
@@ -6,6 +6,7 @@
 ##
 
 # List of available plugins
+opencast-plugin-crop                        = off
 opencast-plugin-legacy-annotation           = off
 opencast-plugin-transcription-services      = off
 opencast-plugin-userdirectory-brightspace   = off

--- a/modules/plugin-manager/src/main/java/org/opencastproject/plugin/impl/PluginManagerImpl.java
+++ b/modules/plugin-manager/src/main/java/org/opencastproject/plugin/impl/PluginManagerImpl.java
@@ -155,8 +155,15 @@ public class PluginManagerImpl implements PluginManager {
             continue;
           }
 
+          // Get the base name of the plugin.
+          // We can have multiple variants of a plugin defining different modules for different distributions like:
+          // - opencast-plugin-xy_admin
+          // - opencast-plugin-xy_worker
+          // But we want both to be enabled if `opencast-plugin-xy = on` is set.
+          var baseName = feature.getName().split("_")[0];
+
           // Check if plugin is active
-          if (!activePlugins.contains(feature.getName())) {
+          if (!activePlugins.contains(baseName)) {
             logger.info("Skipping disabled plugin {}", feature);
             continue;
           }


### PR DESCRIPTION
Our plugin mechanism already allowed for plugins to only become active if certain Karaf features are present. This means you can have a plugin active in the configuration of all your servers, but it only becomes active on the admin since it only makes sense to run it there.

Unfortunately, this becomes problematic if you actually want to activate different modules on different servers if the plugin becomes active. This would be the usual case for things we run on the worker, where there would still be an api, a remote and a woh module on the admin.

This patch introduces the concept of plugin groups. This means that we can now define several plugins for different distributions like:

- opencast-plugin-xy_a
- opencast-plugin-xy_b

Which can have different activation rules, but which are all activated if you set `opencast-plugin-xy = on` in the plugin configuration.

As an example, this patch turns the crop service into a distributed plugin. The plugin is disabled by default since the service is not used by default in Opencast.

### How to test this patch

- Just enable `opencast-plugin-crop` in `etc/org.opencastproject.plugin.impl.PluginManagerImpl.cfg`
- This will load different modules in e.g. admin and worker


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
