### PR TITLE
No opencast-plugin-paella-player-6 as install-feature

### DIFF
--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -123,7 +123,6 @@
               <feature>opencast-security-jwt</feature>
               <feature>opencast-plugin-admin-ng</feature>
               <feature>opencast-plugin-legacy-annotation</feature>
-              <feature>opencast-plugin-paella-player-6</feature>
               <feature>opencast-plugin-transcription-services</feature>
               <feature>opencast-plugin-userdirectory-brightspace</feature>
               <feature>opencast-plugin-userdirectory-canvas</feature>


### PR DESCRIPTION
This patch removes `opencast-plugin-paella-player-6` from the list of install-features. The plugin doesn't exist anymore in Opencast 16.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
