### PR TITLE
Fixes session timeout bug by upgrading pax-web

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -11,7 +11,15 @@
     <bundle>mvn:com.mysema.querydsl/querydsl-jpa/${querydsl.version}</bundle>
   </feature>
 
+  <!-- Update pax-web due to session timeout bug, see https://github.com/opencast/opencast/issues/6260 -->
+  <!-- REMOVE WITH KARAF 4.4.7 UPDATE -->
+  <repository>mvn:org.ops4j.pax.web/pax-web-features/8.0.29/xml/features</repository>
+
   <feature name="ext-core" version="${project.version}">
+    <!-- Update pax-web due to session timeout bug, see https://github.com/opencast/opencast/issues/6260 -->
+    <!-- REMOVE WITH KARAF 4.4.7 UPDATE -->
+    <feature version="8.0.29">pax-web-karaf</feature>
+
     <!-- Base features -->
     <feature>http</feature>
     <feature>http-whiteboard</feature>

--- a/assemblies/resources/build.xml
+++ b/assemblies/resources/build.xml
@@ -18,6 +18,11 @@
     <replace file="target/assembly/etc/config.properties" token="org.osgi.framework.system.packages= \" value="org.osgi.framework.system.packages= com.sun.image.codec.jpeg, com.sun.jndi.ldap, \"/>
     <!-- Disabled write permissions on karaf configuration by deactivating config saves -->
     <replaceregexp file="target/assembly/etc/config.properties" match="^felix.fileinstall.enableConfigSave .*=.*$" replace="felix.fileinstall.enableConfigSave = false" byline="true"/>
+
+    <!-- Update pax-web due to session timeout bug, see https://github.com/opencast/opencast/issues/6260 -->
+    <!-- REMOVE WITH KARAF 4.4.7 UPDATE -->
+    <replaceregexp file="target/assembly/system/org/apache/karaf/features/standard/4.4.4/standard-4.4.4-features.xml" flags="g" match="8\.0\.22" replace="8.0.29"/>
+    <replaceregexp file="target/assembly/etc/org.apache.karaf.features.cfg" flags="g" match="8\.0\.22" replace="8.0.29"/>
   </target>
 
   <target if="enableJobDispatching" name="job dispatching">


### PR DESCRIPTION
Issue #6260 describes the session timeout problems due to bugs in pax-web. This PR upgrade pax-web to a newer, not affected, version of pax-web. Please revert this patch on OC 16+ branch as it was handled by PR #6292.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
