### PR TITLE
Use legacy rest-docs per default

### DIFF
--- a/etc/org.opencastproject.organization-mh_default_org.cfg
+++ b/etc/org.opencastproject.organization-mh_default_org.cfg
@@ -112,7 +112,7 @@ prop.org.opencastproject.admin.help.documentation.url=https://docs.opencast.org
 # If the property is specified, the admin ui help menu will link to the documentation.
 # The value needs to be a URL if set.
 # Default: undefined
-prop.org.opencastproject.admin.help.restdocs.url=/rest-docs/index.html
+prop.org.opencastproject.admin.help.restdocs.url=/rest_docs.html
 
 # Link to the media module
 #


### PR DESCRIPTION
The new OpenAPI implementation has problems with the FormParams, which are not easily solvable, we may need to wait for the Karaf 4.4.7 update. In the meantime, we should use the old rest-docs implementation.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
