### PR TITLE
Remove incorrect JDK support statement

### DIFF
--- a/docs/guides/admin/docs/installation/debs.md
+++ b/docs/guides/admin/docs/installation/debs.md
@@ -24,12 +24,6 @@ Currently Supported
 * Ubuntu 18.04 and newer amd64
 
 
-Supported JDKs
---------------
-
-For Opencast 10 and newer we support JDK 11 only.
-
-
 Activate Repository
 -------------------
 


### PR DESCRIPTION
This patch removes the section about supported Java versions from the Debian guide. The information is incorrect and we have a dedicated section for this by now.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
