### PR TITLE
Update to admin interface release 2024-11-19

### DIFF
--- a/modules/admin-ui-interface/pom.xml
+++ b/modules/admin-ui-interface/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <interface.url>https://github.com/opencast/opencast-admin-interface/releases/download/2024-08-14/oc-admin-ui-2024-08-14.tar.gz</interface.url>
-    <interface.sha256>3369732faabb7be776b6b9320c7c59c4a9011ceffe69385e985f04eaa49f5e2d</interface.sha256>
+    <interface.url>https://github.com/opencast/opencast-admin-interface/releases/download/2024-11-19/oc-admin-ui-2024-11-19.tar.gz</interface.url>
+    <interface.sha256>ef7477b8eb45fec967540f758f57b881e87fcb4e15edceda7e98d3c24aea0294</interface.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
This patch updates the admin interface to its latest release (2024-11-19). This will likely be the last admin interface update for Opencast 16 before it becomes the legacy release.

### How to test this patch

- Build Opencast and go to the admin interface
- The interface itself has already been tested

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
