### PR TITLE
Switch from `docker-compose` to `docker compose`

### DIFF
--- a/docs/scripts/devel-dependency-containers/readme.md
+++ b/docs/scripts/devel-dependency-containers/readme.md
@@ -2,14 +2,14 @@ Runtime Dependencies for Developers
 ===================================
 
 This directory contains container configurations for an easy way of starting the necessary runtime dependencies for
-Opencast as a developer. You can use `docker-compose` or `podman-compose` to launch everything necessary for the current
+Opencast as a developer. You can use `docker compose` or `podman-compose` to launch everything necessary for the current
 version:
 
 ```sh
 # Podman
 podman-compose up -d
 # Docker
-docker-compose up -d
+docker compose up -d
 ```
 
 To shut down all services again:
@@ -18,7 +18,7 @@ To shut down all services again:
 # Podman
 podman-compose down
 # Docker
-docker-compose down
+docker compose down
 ```
 
 You can use the `-f` flag to launch specific compose files with additional services if required.


### PR DESCRIPTION
The `docker-compose` tool has been replaced by Dockers `compose` command quite a while ago. We should update our documentation accordingly.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
