### PR TITLE
Adds sorting parameter to series ltitools

### DIFF
--- a/docs/guides/admin/docs/configuration/ltimodule.md
+++ b/docs/guides/admin/docs/configuration/ltimodule.md
@@ -105,6 +105,9 @@ custom parameters to be defined globally.
     - `annotate=true` if you want to display an annotate (annotation tool) button next to each episode
     - `download=true` to show a button next to each episode that allows for downloading individual video files
     - `lng=LANG` to force a language (the browser language is used otherwise)
+    - `sort=SORT` to sort the results in a specific way. May include any of the following dublin core metadata:
+      identifier, title, contributor, creator, modified.
+      Add ' asc' or ' desc' to specify the sort order (e.g. 'title desc').
 - To show an upload dialog, use `ltitools/index.html` as LTI `custom_tool` launch parameter
   and specify the following query parameters:
     - `subtool=upload`

--- a/modules/lti/src/OpencastRest.ts
+++ b/modules/lti/src/OpencastRest.ts
@@ -189,7 +189,8 @@ export async function searchEpisode(
     offset: number,
     episodeId?: string,
     seriesId?: string,
-    seriesName?: string): Promise<SearchEpisodeResults> {
+    seriesName?: string,
+    sort?: string): Promise<SearchEpisodeResults> {
     let urlSuffix = "";
     if (seriesId !== undefined)
         urlSuffix += "&sid=" + seriesId;
@@ -197,6 +198,8 @@ export async function searchEpisode(
         urlSuffix += "&sname=" + seriesName;
     if (episodeId !== undefined)
         urlSuffix += "&id=" + episodeId;
+    if (sort !== undefined)
+        urlSuffix += "&sort=" + sort;
     const url = `${hostAndPort()}/search/episode.json?limit=${limit}&offset=${offset}${urlSuffix}`;
     const response = await axios.get<any>(url);
     const resultsRaw = response.data["result"];

--- a/modules/lti/src/components/Series.tsx
+++ b/modules/lti/src/components/Series.tsx
@@ -136,7 +136,8 @@ class TranslatedSeries extends React.Component<SeriesProps, SeriesState> {
             (pageNumber - 1) * EPISONDES_PER_PAGE,
             undefined,
             typeof qs.series === "string" ? qs.series : undefined,
-            typeof qs.series_name === "string" ? qs.series_name : undefined
+            typeof qs.series_name === "string" ? qs.series_name : undefined,
+            typeof qs.sort === "string" ? qs.sort : undefined
         ).then((results) => this.setState({
             ...this.state,
             searchResults: results

--- a/modules/lti/src/components/Welcome.tsx
+++ b/modules/lti/src/components/Welcome.tsx
@@ -16,6 +16,7 @@ export function Welcome() {
                 <li>Use the <code>?edit=true</code> URL parameter to show an edit button next to each episode.</li>
                 <li>Use the <code>?annotate=true</code> URL parameter to show a annotate button next to each episode. This will open the annotation tool. The annotation tool must be installed and the user must have the proper access rights to use this tool.</li>
                 <li>Use the <code>?download=true</code> URL parameter to show a download button next to each episode.</li>
+                <li>Use the <code>?sort=[sort-parameter]</code> The sort order. May include any of the following dublin core metadata: identifier, title, contributor, creator, created, modified. Add &quot;asc&quot; or &quot;desc&quot; to specify the sort order (e.g. &quot;title desc&quot;).</li>
             </ul>
             <li>For upload integration, use the <a href="index.html?subtool=upload">Upload LTI Tool</a>. Note that you can specify these parameters:</li>
             <ul>

--- a/modules/lti/src/components/Welcome.tsx
+++ b/modules/lti/src/components/Welcome.tsx
@@ -16,7 +16,7 @@ export function Welcome() {
                 <li>Use the <code>?edit=true</code> URL parameter to show an edit button next to each episode.</li>
                 <li>Use the <code>?annotate=true</code> URL parameter to show a annotate button next to each episode. This will open the annotation tool. The annotation tool must be installed and the user must have the proper access rights to use this tool.</li>
                 <li>Use the <code>?download=true</code> URL parameter to show a download button next to each episode.</li>
-                <li>Use the <code>?sort=[sort-parameter]</code> The sort order. May include any of the following dublin core metadata: identifier, title, contributor, creator, created, modified. Add &quot;asc&quot; or &quot;desc&quot; to specify the sort order (e.g. &quot;title desc&quot;).</li>
+                <li>Use the <code>?sort=[sort-parameter]</code> URL parameter to define the sort order. May include any of the following dublin core metadata: identifier, title, contributor, creator, created, modified. Add &quot;asc&quot; or &quot;desc&quot; to specify the sort order (e.g. &quot;title desc&quot;).</li>
             </ul>
             <li>For upload integration, use the <a href="index.html?subtool=upload">Upload LTI Tool</a>. Note that you can specify these parameters:</li>
             <ul>

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
@@ -143,7 +143,7 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
               isRequired = false,
               type = RestParameter.Type.STRING,
               description = "The sort order.  May include any of the following dublin core metadata: "
-              + "identifier, title, contributor, creator, modified. "
+              + "identifier, title, contributor, creator, created, modified. "
               + "Add ' asc' or ' desc' to specify the sort order (e.g. 'title desc')."
           ),
           @RestParameter(
@@ -215,7 +215,8 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
 
     if (StringUtils.isNotEmpty(sort)) {
       var sortParam = StringUtils.split(sort.toLowerCase());
-      var validSort = Arrays.asList("identifier", "title", "contributor", "creator", "modified").contains(sortParam[0]);
+      var validSort = Arrays.asList("identifier", "title", "contributor", "creator", "created", "modified")
+              .contains(sortParam[0]);
       var validOrder = sortParam.length < 2 || Arrays.asList("asc", "desc").contains(sortParam[1]);
       if (sortParam.length > 2 || !validSort || !validOrder) {
         return Response.status(Response.Status.BAD_REQUEST)
@@ -283,7 +284,7 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
               isRequired = false,
               type = RestParameter.Type.STRING,
               description = "The sort order.  May include any of the following dublin core metadata: "
-                  + "title, contributor, creator, modified. "
+                  + "title, contributor, creator, created, modified. "
                   + "Add ' asc' or ' desc' to specify the sort order (e.g. 'title desc')."
           ),
           @RestParameter(
@@ -413,7 +414,7 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
 
     if (StringUtils.isNotEmpty(sort)) {
       var sortParam = StringUtils.split(sort.toLowerCase());
-      var validSort = Arrays.asList("title", "contributor", "creator", "modified").contains(sortParam[0]);
+      var validSort = Arrays.asList("title", "contributor", "creator", "created", "modified").contains(sortParam[0]);
       var validOrder = sortParam.length < 2 || Arrays.asList("asc", "desc").contains(sortParam[1]);
       if (sortParam.length > 2 || !validSort || !validOrder) {
         return Response.status(Response.Status.BAD_REQUEST)


### PR DESCRIPTION
This PR adds the option to specify sorting criteria to the series ltitools.

### How to test this patch

Before this PR, it was not possible to set a sorting order in the series ltitools. Calling for example https://stable.opencast.org/ltitools/index.html?subtool=series&sort=title would have no impact to the sorting. 

With the PR you should be able to make use of this parameter, either directly in the url or through the tool configuration of your LMS (as explained in https://docs.opencast.org/r/16.x/admin/#configuration/ltimodule/#specifying-lti-tools). 

I could not test the patch with an LMS yet, so feel free to test, if you have this option. 

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
