### PR TITLE
Update documentation on Consensus Building and Lazy Consensus after PR 6297

### DIFF
--- a/docs/guides/developer/docs/participate/decision-making/consensus-building.md
+++ b/docs/guides/developer/docs/participate/decision-making/consensus-building.md
@@ -11,15 +11,8 @@ successful project. However, there is a shorthand notation for showing support, 
 Sending out a Proposal
 ----------------------
 
-Proposals should be send to list. It is common to indicate proposals by including the
-string `[#proposal]` at the beginning of the subject to make it easier for the community to identify that the mail
-contains an important proposal.
-
-The list used should usually be the development list. In very rare cases, other lists may also be used: The users list
-when the matter discussed only targets adopters/uses. The committers list if the matter discussed needs to be kept
-private e.g. for personal or security reasons.
-
-Please avoid cross-posting a proposal on multiple lists. It will usually fracture the discussion.
+Proposals shall be filed as a pull request. It is common to indicate proposals by adding the
+label `proposal` to make it easier for the community to identify that the PR contains an important proposal.
 
 Expressing Approval or Disapproval
 ----------------------------------

--- a/docs/guides/developer/docs/participate/decision-making/lazy-consensus.md
+++ b/docs/guides/developer/docs/participate/decision-making/lazy-consensus.md
@@ -29,13 +29,15 @@ Sometimes a member of the community will believe a specific action is the correc
 that there will be consensus and may not wish to proceed the work without giving the community an opportunity to
 feedback. In these circumstances, they can make the proposal and state Lazy Consensus is in operation.
 
-Proposals should be sent to list, preferably the development list. It is common to indicate proposals by including the
-string `[#proposal]` at the beginning of the subject to make it easier for the community to identify that the mail
-contains an important proposal.
+Proposals shall be filed as a pull request. It is common to indicate proposals by adding the
+label `proposal` to make it easier for the community to identify that the PR contains an important proposal.
 
-This triggers the Lazy Consensus mechanism, by which the proposal is considered accepted if no one objects within 72
-hours after the proposal submission. The period of 72 hours is chosen because it accounts for different timezones and
-any non-Opencast commitments the community members may have.
+This triggers the Lazy Consensus mechanism, by which the proposal is considered accepted automatically:
+- if discussed at the dev meeting's PR discussions, without vetos
+- AND if no one objects within 72 hours, counting from the PR creation date
+
+The period of 72 hours is chosen because it accounts for different timezones and any non-Opencast commitments
+the community members may have.
 
 In this approach the original proposer is not insisting that there is a discussion around the proposal, nor is it
 requested that the community explicitly supports their actions. This differs from assuming lazy consensus since it
@@ -45,6 +47,6 @@ work begins.
 Silence is Consent
 ------------------
 
-People may choose to indicate their support for the actions taken with a +1 mail - quick and easy to read and reassuring
+People may choose to indicate their support for the actions taken with a +1 comment - quick and easy to read and reassuring
 for the implementer. However, remember, in a lazy consensus world silence is the equivalent to support. This can take
 some time to get used to.


### PR DESCRIPTION
The proposal in PR #6297 suggested moving email-based proposals and making them PRs instead. Since this proposal was accepted, we must update the corresponding documentation accordingly.

### How to test this patch

N/A


### Your pull request should…

* [x] have a concise title
* [ ] ~~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~~include migration scripts and documentation, if appropriate~~
* [ ] ~~pass automated tests~~
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] ~~explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch~~
