### PR TITLE
Fix incorrect episode count in LTI series tool

### DIFF
--- a/modules/lti/src/components/Series.tsx
+++ b/modules/lti/src/components/Series.tsx
@@ -242,7 +242,7 @@ class TranslatedSeries extends React.Component<SeriesProps, SeriesState> {
             const headingOpts = {
                 range: {
                     begin: Math.min(sr.offset + 1, sr.total),
-                    end: sr.offset + sr.limit
+                    end: Math.min(sr.offset + sr.limit, sr.total)
                 },
                 total: sr.total
             };


### PR DESCRIPTION
This patch fixes the episode count in the series LTI tool which would be higher than the actual number of events.

This fixes #6322

### How to test this patch

- Publish an event (do not publish more than 14 events)
- Go to http://localhost:8080/ltitools/index.html?subtool=series

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
