### PR TITLE
Adding LTI-tools configuration to exclude Live Streams in the LTI-Series-Tool

### DIFF
--- a/etc/ui-config/mh_default_org/ltitools/config.json
+++ b/etc/ui-config/mh_default_org/ltitools/config.json
@@ -1,0 +1,3 @@
+{
+  "excludeLiveStreams" : false
+}

--- a/modules/lti/src/OpencastRest.ts
+++ b/modules/lti/src/OpencastRest.ts
@@ -150,7 +150,7 @@ export async function getConfig(): Promise<Config> {
 
 export function filterLiveEvents(sr: SearchEpisodeResults) {
     const filtered_results = sr.results.filter(result => !result.live);
-    const filtered_sr : SearchEpisodeResults = {results: filtered_results, total : filtered_results.length, limit : sr.limit, offset : sr.offset};
+    const filtered_sr : SearchEpisodeResults = {results: filtered_results, total : sr.total, limit : sr.limit, offset : sr.offset};
     return filtered_sr
 }
 


### PR DESCRIPTION
This PR adds a configuration file for the LTI-tools `etc/ui-config/mh_default_org/ltitools/config.json` and the required changes to exclude Live Streams in the LTI-series-tool when this is set in the configuration file. The configuration file includes the Boolean value `excludeLiveStreams` , which is by default false. When set to true Live Streams are filtered out and not shown in the LTI-series-Tools.