### PR TITLE
Allow removing subtitles

### DIFF
--- a/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/EditingData.java
+++ b/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/EditingData.java
@@ -128,11 +128,17 @@ public class EditingData {
     /** content of the subtitle */
     private final String subtitle;
     private final String[] tags;
+    private final boolean deleted;
 
     public Subtitle(String id, String subtitle, String[] tags) {
+      this(id, subtitle, tags,false);
+    }
+
+    public Subtitle(String id, String subtitle, String[] tags, boolean deleted) {
       this.id = id;
       this.subtitle = subtitle;
       this.tags = tags;
+      this.deleted = deleted;
     }
 
     public String getId() {
@@ -146,6 +152,11 @@ public class EditingData {
     public String[] getTags() {
       return tags;
     }
+
+    public boolean isDeleted() {
+      return deleted;
+    }
+
   }
 }
 

--- a/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
+++ b/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
@@ -543,7 +543,7 @@ public class EditorServiceImpl implements EditorService {
    *          the subtitles to be added
    * @throws IOException
    */
-  private MediaPackage addSubtitleTrack(MediaPackage mediaPackage, List<EditingData.Subtitle> subtitles)
+  private MediaPackage processSubtitleTrack(MediaPackage mediaPackage, List<EditingData.Subtitle> subtitles)
           throws IOException, IllegalArgumentException {
     for (EditingData.Subtitle subtitle : subtitles) {
       // Generate ID for new tracks
@@ -561,6 +561,14 @@ public class EditorServiceImpl implements EditorService {
       }
 
       Track track = mediaPackage.getTrack(trackId);
+
+      if (subtitle.isDeleted()) {
+        // If the subtitle is empty, remove the track
+        if (trackId != null) {
+          mediaPackage.remove(track);
+        }
+        continue;
+      }
 
       // Memorize uri of the previous track file for deletion
       URI oldTrackURI = null;
@@ -1130,7 +1138,7 @@ public class EditorServiceImpl implements EditorService {
 
     try {
       if (editingData.getSubtitles() != null) {
-        mediaPackage = addSubtitleTrack(mediaPackage, editingData.getSubtitles());
+        mediaPackage = processSubtitleTrack(mediaPackage, editingData.getSubtitles());
       }
     } catch (IOException e) {
       errorExit("Unable to add subtitle track to archive", mediaPackageId, ErrorStatus.UNKNOWN, e);


### PR DESCRIPTION
This allows the removal of a subtitle with the editor API. If a subtitle is marked as deleted it will be removed from the media package.

<!--
Explain what this pull request does.  If this fixes a bug, also explain how to reproduce the issue.
-->

<!--
If your pull request is targeting the legacy (second oldest release branch), explain why this patch is so important that
it needs to go into the legacy and can not go just into stable or develop.
-->

### How to test this patch

- Create a subtitle with the editor
- Open the dev tools and switch to the network tab
- Save the editor changes
- Edit the recorded `POST /editor/<MP_ID>/edit.json` request
- Replace the subtitles JSON from the request with the snippet below
```json
"subtitles":[{"id":"<SUBTITLE_ID>","subtitle":"","tags":[],"deleted":true}]
```
- Send the edited request
- Reload editor
- Subtitle is removed

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
