### PR TITLE
Add "Show for new or existing" attribute to asset upload options

### DIFF
--- a/etc/listproviders/event.upload.asset.options.properties
+++ b/etc/listproviders/event.upload.asset.options.properties
@@ -21,6 +21,7 @@
 # - Attribute boolean "multiple" is for uploading multiple source track files to the same flavor
 # - Attribute "tags" adds one or multiple tags to the uploaded asset
 # - - Multiple tags are delimited by "," (no whitespace)
+# - Attribute "showForNewEvents" and "showForExistingEvents" specify in which modals the option should appear.
 #
 # EVENTS.EVENTS.NEW.UPLOAD_ASSET.WORKFLOWDEFID
 # - The workflow used when uploading assets to an existing mediapackage
@@ -34,7 +35,17 @@ list.name=eventUploadAssetOptions
 # Asset upload options are for new and existing events.
 # EVENTS.EVENTS.NEW.UPLOAD_ASSET.OPTION.CLASS_HANDOUT_NOTES={"id": "attachment_class_handout_notes", "type": "attachment", "flavorType": "attachment", "flavorSubType": "notes", "displayOrder":1}
 # EVENTS.EVENTS.NEW.UPLOAD_ASSET.OPTION.PREVIEW_IMAGE={"id":"attachment_preview_image", "type":"attachment", "flavorType": "presenter","flavorSubType": "search+preview", "displayOrder":2, "accept": ".bmp,.gif,.jpeg,.jpg,.png,.tif,.tiff"}
-# EVENTS.EVENTS.NEW.UPLOAD_ASSET.OPTION.SUBTITLES={"id": "track_subtitles_option", "type":"track", "flavorType": "captions","flavorSubType": "source", "tags": "generator:unknown", "displayOrder":3, "accept": ".vtt"}
+# EVENTS.EVENTS.NEW.UPLOAD_ASSET.OPTION.SUBTITLES={\
+#    "id": "track_subtitles_option",\
+#    "showForNewEvents": false,\
+#    "showForExistingEvents": true,\
+#    "type":"track",\
+#    "flavorType": "captions",\
+#    "flavorSubType": "source",\
+#    "tags": "generator:unknown",\
+#    "displayOrder":3,\
+#    "accept": ".vtt"\
+#  }
 EVENTS.EVENTS.NEW.UPLOAD_ASSET.WORKFLOWDEFID=publish-uploaded-assets
 
 # The video source track upload options are only for new events.


### PR DESCRIPTION
Adds the attributes `showForNewEvents` and `showForExistingEvents` to the event upload options, which influence what is displayed in the "Create Event" and "Event Details" modals in the admin ui. The main goal here is to let  users specify an asset upload option for existing events but not new events and vice versa.

**This accompanies the admin ui PR https://github.com/opencast/opencast-admin-interface/pull/698. This will not work without it.**

### Why is this targeting legacy?
- So it can go along with its related admin ui PR. Really this should point at whatever version its related admin ui PR gets merged into.
- This is a configuration only change that does not impact existing configuration at all.

### How to test this patch
The new attributes will only have any effect with the related admin ui PR. Please see the admin ui PR for more details on how to test it.