### PR TITLE
Fix partial retract streaming elements

### DIFF
--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/RetractEngageWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/RetractEngageWorkflowOperationHandler.java
@@ -50,6 +50,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -135,23 +136,18 @@ public class RetractEngageWorkflowOperationHandler extends AbstractWorkflowOpera
    */
   protected List<Job> retractElements(Set<String> retractElementIds, MediaPackage searchMediaPackage) throws
           DistributionException {
-    List<Job> jobs = new ArrayList<Job>();
-    if (retractElementIds.size() > 0) {
-      Job retractDownloadDistributionJob
-          = downloadDistributionService.retract(CHANNEL_ID, searchMediaPackage, retractElementIds);
-      if (retractDownloadDistributionJob != null) {
-        jobs.add(retractDownloadDistributionJob);
-      }
+    if (retractElementIds.isEmpty()) {
+      return Collections.emptyList();
     }
+
+    List<Job> jobs = new ArrayList<>();
+
+    jobs.add(downloadDistributionService.retract(CHANNEL_ID, searchMediaPackage, retractElementIds));
+
     if (streamingDistributionService != null && streamingDistributionService.publishToStreaming()) {
-      for (MediaPackageElement element : searchMediaPackage.getElements()) {
-        Job retractStreamingJob = streamingDistributionService.retract(CHANNEL_ID, searchMediaPackage,
-                element.getIdentifier());
-        if (retractStreamingJob != null) {
-          jobs.add(retractStreamingJob);
-        }
-      }
+      jobs.add(streamingDistributionService.retract(CHANNEL_ID, searchMediaPackage, retractElementIds));
     }
+
     return jobs;
   }
 


### PR DESCRIPTION
The retract-partial operation removes all streaming distribution files instead of only the media package elements,
 which are requested for retracting.

The strange part of the retract operation is that we lose the information on which element belongs to which distribution, and we have to try all IDs for each distribution.

### How to test this patch

1. Setup Opencast with a streaming distribution
2. Add a video with subtitles (or create one via the editor)
3. Publish the video
4. Check if the subtitle is visible in the player
5. Run the workflow below and remove the caption
6. The publication should be broken, and the video is not playable
7. Apply the patch and repeat the steps 2 - 5,
8. Check if the video is playable and the subtitle is removed 

```yaml
---
id: remove-assets
title: Remove-assets
operations:
  - id: tag
    description: "Changing flavor of source elements: captions/delivery"
    configurations:
      - source-flavors: captions/delivery
      - target-tags: -archive

  - id: retract-partial
    description: "Retracting elements from Engage: captions/delivery" 
    configurations:
      - retract-flavors: captions/delivery
      - retract-tags: type:subtitle
      
 - id: snapshot
    description: Archive publishing information
    configurations:
      - source-tags: archive      
```

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
