### PR TITLE
Segment preview image URL fixed for Tobira

### DIFF
--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Item.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Item.java
@@ -339,7 +339,7 @@ class Item {
     return Arrays.stream(mp.getAttachments())
       .filter(a -> a.getFlavor().getSubtype().equals("segment+preview"))
       .map(s -> Jsons.obj(
-          Jsons.p("uri", s.toString()),
+          Jsons.p("uri", s.getURI().toString()),
           Jsons.p("startTime", MediaTimePointImpl.parseTimePoint(
               s.getReference().getProperty("time")
           ).getTimeInMilliseconds())


### PR DESCRIPTION
Segment preview image URL was incorretly read from mediapackage element by the tobira harvest implementation. All segment preview image URLs are printed in lower case due to toString() method from MediaPackageElement.

## How to reproduce
- Upload an video file with upper and lower case letter in the filename.
- Publish this event to engage
- Call endpoint /tobira/harvest
- loot at the URLs in the segments section

The URLs are lower case and may not work (on case sensitive filesystem like on Unix).

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
