### PR TITLE
Allow Byte-Order-Marks in WEBVTT subtitles

### DIFF
--- a/modules/subtitle-parser/pom.xml
+++ b/modules/subtitle-parser/pom.xml
@@ -18,6 +18,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/modules/subtitle-parser/src/main/java/org/opencastproject/subtitleparser/webvttparser/WebVTTParser.java
+++ b/modules/subtitle-parser/src/main/java/org/opencastproject/subtitleparser/webvttparser/WebVTTParser.java
@@ -22,6 +22,8 @@ package org.opencastproject.subtitleparser.webvttparser;
 
 import org.opencastproject.subtitleparser.SubtitleParsingException;
 
+import org.apache.commons.io.input.BOMInputStream;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -64,11 +66,14 @@ public class WebVTTParser {
   }
 
   public WebVTTSubtitle parse(InputStream is) throws IOException, SubtitleParsingException {
+    // Wrap input stream into Apache Commons IO BOMInputStream
+    BOMInputStream bomIn = new BOMInputStream(is, false);
+
     // Create subtitle object
     WebVTTSubtitle subtitle = new WebVTTSubtitle();
 
     // Read each line
-    BufferedReader webvttReader = new BufferedReader(new InputStreamReader(is, this.charset));
+    BufferedReader webvttReader = new BufferedReader(new InputStreamReader(bomIn, this.charset));
     String line = "";
 
     // File should start with "WEBVTT" on the first line

--- a/modules/subtitle-parser/src/test/java/org/opencastproject/subtitleparser/webvttparser/WebVTTTest.java
+++ b/modules/subtitle-parser/src/test/java/org/opencastproject/subtitleparser/webvttparser/WebVTTTest.java
@@ -38,10 +38,12 @@ import java.net.URISyntaxException;
  */
 public class WebVTTTest {
   protected String inputFilePath;
+  protected String inputFileWithBom;
   protected String outputFilePath;
 
   public WebVTTTest() throws URISyntaxException {
     inputFilePath = new File(getClass().getResource("/testresources/example.vtt").toURI()).getAbsolutePath();
+    inputFileWithBom = new File(getClass().getResource("/testresources/example-bom.vtt").toURI()).getAbsolutePath();
     outputFilePath = new File("target/testoutput/output.vtt").getAbsolutePath();
   }
 
@@ -61,9 +63,23 @@ public class WebVTTTest {
   }
 
   @Test
+  public void parseBomWithoutException() throws IOException, SubtitleParsingException {
+    WebVTTParser parser = new WebVTTParser();
+    parser.parse(new FileInputStream(inputFileWithBom));
+  }
+
+  @Test
   public void parseCorrectly() throws IOException, SubtitleParsingException {
     WebVTTParser parser = new WebVTTParser();
     WebVTTSubtitle subtitle = parser.parse(new FileInputStream(inputFilePath));
+
+    assertExampleVtt(subtitle);
+  }
+
+  @Test
+  public void parseBomCorrectly() throws IOException, SubtitleParsingException {
+    WebVTTParser parser = new WebVTTParser();
+    WebVTTSubtitle subtitle = parser.parse(new FileInputStream(inputFileWithBom));
 
     assertExampleVtt(subtitle);
   }

--- a/modules/subtitle-parser/src/test/resources/testresources/example-bom.vtt
+++ b/modules/subtitle-parser/src/test/resources/testresources/example-bom.vtt
@@ -1,0 +1,30 @@
+﻿WEBVTT There can be additional characters here
+kind: the best kind
+
+REGION
+There could be some region text here
+
+STYLE
+::cue(b) {
+  color: peachpuff;
+}
+
+REGION
+There could be some region text here
+So much region text
+
+x-o7MdlMG-qDMsG6oWbDm
+00:00.000 --> 00:05.000 vertical:undefined align:undefined size:undefined% line:undefined% position:undefined%
+Test Cue 1
+
+00:05.000 --> 00:06.000 vertical:undefined align:undefined size:undefined% line:undefined% position:undefined%
+Test Cue 2
+
+NOTE comment blocks can be used everywhere
+
+00:11.123 --> 00:14.456
+- Never drink liquid nitrogen.
+
+00:15.500 --> 00:19.500
+- It will perforate your stomach.
+- You could die.


### PR DESCRIPTION
Explain what this pull request does.  If this fixes a bug, also explain how to reproduce the issue.

According to the spec, WEBVTT may start with
"An optional U+FEFF BYTE ORDER MARK (BOM) character."

Reference: https://www.w3.org/TR/webvtt1/#file-structure

This commit will remove the Byte-Order-Mark in the parsed representation of the WebVTT file as it is optional.

Resolves #6366

### How to test this patch

1. Run the unit tests for the opencast-subtitle-parser module.
2. Cut subtitles contained in a WEBVTT with Byte-Order-Mark using the editor WOH. For instance, allow uploading subtitles in the Admin UI, upload the contained `modules/subtitle-parser/src/test/resources/testresources/example-bom.vtt` to an Opencast event, change the editor workflow to cut subtitles by changing the following lines in https://github.com/opencast/opencast/blob/develop/etc/workflows/partial-publish.xml#L50

```diff
-  <configuration key="source-flavors">*/work</configuration>
+  <configuration key="source-flavors">*/work,captions/*</configuration>
```

3. Open the Opencast Editor, set cutting marks and process the cut recording.


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] ~explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch~
