### PR TITLE
Fix security config to actually make `/tobira/version` public

### DIFF
--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -330,8 +330,8 @@
     <sec:intercept-url pattern="/editor-ui/**" access="ROLE_ADMIN, ROLE_USER" />
 
     <!-- Enable access to the Tobira module -->
-    <sec:intercept-url pattern="/tobira/**" access="ROLE_ADMIN" />
     <sec:intercept-url pattern="/tobira/version" access="ROLE_ANONYMOUS" />
+    <sec:intercept-url pattern="/tobira/**" access="ROLE_ADMIN" />
 
     <!-- Enable anonymous access to the annotation and the series endpoints -->
     <sec:intercept-url pattern="/series/**" method="GET" access="ROLE_ANONYMOUS, ROLE_CAPTURE_AGENT" />


### PR DESCRIPTION
This was the intention all along, but apparently no one tested it and the two entries were in the config in the wrong order.

### How to test this patch

```
curl https://develop.opencast.org/tobira/version -v
```

-> 302 redirect to login page

With this page:

```
curl localhost:8080/tobira/version
```

-> `{"version":"1.6"}`


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
