### PR TITLE
Add user info to roles for admin ui

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -2274,7 +2274,6 @@ public abstract class AbstractEventEndpoint {
     JSONObject episodeAccessJson = new JSONObject();
     episodeAccessJson.put("current_acl", currentAcl.isSome() ? currentAcl.get().getId() : 0L);
     episodeAccessJson.put("acl", transformAccessControList(activeAcl, getUserDirectoryService()));
-//    episodeAccessJson.put("acl", AccessControlParser.toJsonSilent(activeAcl));
     episodeAccessJson.put("privileges", AccessInformationUtil.serializePrivilegesByRole(activeAcl));
     if (StringUtils.isNotBlank(optEvent.get().getWorkflowState())
             && WorkflowUtil.isActive(WorkflowInstance.WorkflowState.valueOf(optEvent.get().getWorkflowState())))

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -40,6 +40,7 @@ import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
 import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
+import static org.opencastproject.adminui.endpoint.EndpointUtil.transformAccessControList;
 import static org.opencastproject.index.service.util.RestUtils.conflictJson;
 import static org.opencastproject.index.service.util.RestUtils.notFound;
 import static org.opencastproject.index.service.util.RestUtils.notFoundJson;
@@ -2272,7 +2273,8 @@ public abstract class AbstractEventEndpoint {
 
     JSONObject episodeAccessJson = new JSONObject();
     episodeAccessJson.put("current_acl", currentAcl.isSome() ? currentAcl.get().getId() : 0L);
-    episodeAccessJson.put("acl", AccessControlParser.toJsonSilent(activeAcl));
+    episodeAccessJson.put("acl", transformAccessControList(activeAcl, getUserDirectoryService()));
+//    episodeAccessJson.put("acl", AccessControlParser.toJsonSilent(activeAcl));
     episodeAccessJson.put("privileges", AccessInformationUtil.serializePrivilegesByRole(activeAcl));
     if (StringUtils.isNotBlank(optEvent.get().getWorkflowState())
             && WorkflowUtil.isActive(WorkflowInstance.WorkflowState.valueOf(optEvent.get().getWorkflowState())))

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AclEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AclEndpoint.java
@@ -31,6 +31,8 @@ import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
 import static org.opencastproject.index.service.util.RestUtils.okJsonList;
+import static org.opencastproject.userdirectory.UserIdRoleProvider.getUserRolePrefix;
+import static org.opencastproject.userdirectory.UserIdRoleProvider.isSanitize;
 import static org.opencastproject.util.RestUtil.R.conflict;
 import static org.opencastproject.util.RestUtil.R.noContent;
 import static org.opencastproject.util.doc.rest.RestParameter.Type.INTEGER;
@@ -52,6 +54,8 @@ import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.Role;
 import org.opencastproject.security.api.RoleDirectoryService;
 import org.opencastproject.security.api.SecurityService;
+import org.opencastproject.security.api.User;
+import org.opencastproject.security.api.UserDirectoryService;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.data.Option;
 import org.opencastproject.util.doc.rest.RestParameter;
@@ -85,6 +89,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -135,6 +140,9 @@ public class AclEndpoint {
   // The role directory service
   private RoleDirectoryService roleDirectoryService;
 
+  /** The global user directory service */
+  protected UserDirectoryService userDirectoryService;
+
   /**
    * @param aclServiceFactory
    *          the aclServiceFactory to set
@@ -167,6 +175,11 @@ public class AclEndpoint {
 
   private AclService aclService() {
     return aclServiceFactory.serviceFor(securityService.getOrganization());
+  }
+
+  @Reference
+  public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
+    this.userDirectoryService = userDirectoryService;
   }
 
   @GET
@@ -280,6 +293,13 @@ public class AclEndpoint {
       jsonRole.put("type", role.getType().toString());
       jsonRole.put("description", role.getDescription());
       jsonRole.put("organization", role.getOrganizationId());
+      jsonRole.put("isSanitize", isSanitize());
+      if (!isSanitize()) {
+        User user = userDirectoryService.loadUser(role.getName().replaceFirst(getUserRolePrefix(), ""));
+        if (user != null) {
+          jsonRole.put("user", generateJsonUser(user));
+        }
+      }
       jsonRoles.add(jsonRole);
     }
 
@@ -401,5 +421,14 @@ public class AclEndpoint {
       return full(acl);
     }
   };
+
+  public Map<String, Object> generateJsonUser(User user) {
+    // Prepare the roles
+    Map<String, Object> userData = new HashMap<>();
+    userData.put("username", user.getUsername());
+    userData.put("name", user.getName());
+    userData.put("email", user.getEmail());
+    return userData;
+  }
 
 }

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/EndpointUtil.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/EndpointUtil.java
@@ -21,15 +21,24 @@
 
 package org.opencastproject.adminui.endpoint;
 
+import static org.opencastproject.userdirectory.UserIdRoleProvider.getUserRolePrefix;
+import static org.opencastproject.userdirectory.UserIdRoleProvider.isSanitize;
+
 import org.opencastproject.adminui.exception.JsonCreationException;
 import org.opencastproject.index.service.util.RestUtils;
 import org.opencastproject.list.impl.ResourceListQueryImpl;
 import org.opencastproject.list.query.StringListFilter;
+import org.opencastproject.security.api.AccessControlEntry;
+import org.opencastproject.security.api.AccessControlList;
+import org.opencastproject.security.api.User;
+import org.opencastproject.security.api.UserDirectoryService;
 
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -90,5 +99,57 @@ public final class EndpointUtil {
     for (var filter : RestUtils.parseFilter(filterString).entrySet()) {
       query.addFilter(new StringListFilter(filter.getKey(), filter.getValue()));
     }
+  }
+
+  /**
+   * Transform ACL into the format the admin ui frontend uses.
+   * We do this in the backend so we can attach information about users to user roles.
+   */
+  public static JSONArray transformAccessControList(AccessControlList acl, UserDirectoryService userDirectoryService) {
+    class TransformedAcl {
+      protected String role;
+      protected boolean read = false;
+      protected boolean write = false;
+      protected List<String> actions = new ArrayList();
+    }
+    Map<String, TransformedAcl> newPolicies = new HashMap();
+    JSONArray jsonEntryArray = new JSONArray();
+
+    for (AccessControlEntry entry : acl.getEntries()) {
+      if (!newPolicies.containsKey(entry.getRole())) {
+        TransformedAcl transformedEntry = new TransformedAcl();
+        transformedEntry.role = entry.getRole();
+        newPolicies.put(entry.getRole(), transformedEntry);
+      }
+
+      if ("read".equals(entry.getAction())) {
+        newPolicies.get(entry.getRole()).read = entry.isAllow();
+      } else if ("write".equals(entry.getAction())) {
+        newPolicies.get(entry.getRole()).write = entry.isAllow();
+      } else if (entry.isAllow()) {
+        newPolicies.get(entry.getRole()).actions.add(entry.getAction());
+      }
+    }
+
+    for (TransformedAcl policy : newPolicies.values()) {
+      JSONObject jsonEntry = new JSONObject();
+      jsonEntry.put("role", policy.role);
+      jsonEntry.put("read", policy.read);
+      jsonEntry.put("write", policy.write);
+      jsonEntry.put("actions", policy.actions);
+      if (!isSanitize()) {
+        User user = userDirectoryService.loadUser(policy.role.replaceFirst(getUserRolePrefix(), ""));
+        if (user != null) {
+          Map<String, Object> userData = new HashMap<>();
+          userData.put("username", user.getUsername());
+          userData.put("name", user.getName());
+          userData.put("email", user.getEmail());
+          jsonEntry.put("user", userData);
+        }
+      }
+      jsonEntryArray.add(jsonEntry);
+    }
+
+    return jsonEntryArray;
   }
 }

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
@@ -341,7 +341,6 @@ public class SeriesEndpoint {
       seriesAccessJson.put("current_acl", currentAcl.isSome() ? currentAcl.get().getId() : 0);
       seriesAccessJson.put("privileges", AccessInformationUtil.serializePrivilegesByRole(seriesAccessControl));
       seriesAccessJson.put("acl", transformAccessControList(seriesAccessControl, userDirectoryService));
-//      seriesAccessJson.put("acl", AccessControlParser.toJsonSilent(seriesAccessControl));
       seriesAccessJson.put("locked", hasProcessingEvents);
     } catch (SeriesException e) {
       logger.error("Unable to get ACL from series {}", seriesId, e);

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
@@ -37,6 +37,7 @@ import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
+import static org.opencastproject.adminui.endpoint.EndpointUtil.transformAccessControList;
 import static org.opencastproject.index.service.util.RestUtils.notFound;
 import static org.opencastproject.index.service.util.RestUtils.okJson;
 import static org.opencastproject.index.service.util.RestUtils.okJsonList;
@@ -90,6 +91,7 @@ import org.opencastproject.security.api.AccessControlParser;
 import org.opencastproject.security.api.Permissions;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
+import org.opencastproject.security.api.UserDirectoryService;
 import org.opencastproject.series.api.SeriesException;
 import org.opencastproject.series.api.SeriesService;
 import org.opencastproject.systems.OpencastConstants;
@@ -199,6 +201,7 @@ public class SeriesEndpoint {
   private ListProvidersService listProvidersService;
   private ElasticsearchIndex searchIndex;
   private AdminUIConfiguration adminUIConfiguration;
+  private UserDirectoryService userDirectoryService;
 
   /** Default server URL */
   private String serverUrl = "http://localhost:8080";
@@ -248,6 +251,12 @@ public class SeriesEndpoint {
   @Reference
   public void setAdminUIConfiguration(AdminUIConfiguration adminUIConfiguration) {
     this.adminUIConfiguration = adminUIConfiguration;
+  }
+
+  /** Sets the user directory service */
+  @Reference
+  public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
+    this.userDirectoryService = userDirectoryService;
   }
 
   @Activate
@@ -331,7 +340,8 @@ public class SeriesEndpoint {
               adminUIConfiguration.getMatchManagedAclRolePrefixes());
       seriesAccessJson.put("current_acl", currentAcl.isSome() ? currentAcl.get().getId() : 0);
       seriesAccessJson.put("privileges", AccessInformationUtil.serializePrivilegesByRole(seriesAccessControl));
-      seriesAccessJson.put("acl", AccessControlParser.toJsonSilent(seriesAccessControl));
+      seriesAccessJson.put("acl", transformAccessControList(seriesAccessControl, userDirectoryService));
+//      seriesAccessJson.put("acl", AccessControlParser.toJsonSilent(seriesAccessControl));
       seriesAccessJson.put("locked", hasProcessingEvents);
     } catch (SeriesException e) {
       logger.error("Unable to get ACL from series {}", seriesId, e);

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/UsersEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/UsersEndpoint.java
@@ -545,7 +545,7 @@ public class UsersEndpoint {
     return rolesSet;
   }
 
-  public Map<String, Object> generateJsonUser(User user) {
+  private Map<String, Object> generateJsonUser(User user) {
     // Prepare the roles
     Map<String, Object> userData = new HashMap<>();
     userData.put("username", user.getUsername());

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/UsersEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/UsersEndpoint.java
@@ -31,6 +31,8 @@ import static org.apache.http.HttpStatus.SC_FORBIDDEN;
 import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
 import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.http.HttpStatus.SC_OK;
+import static org.opencastproject.userdirectory.UserIdRoleProvider.getUserRolePrefix;
+import static org.opencastproject.userdirectory.UserIdRoleProvider.isSanitize;
 import static org.opencastproject.util.RestUtil.getEndpointUrl;
 import static org.opencastproject.util.UrlSupport.uri;
 import static org.opencastproject.util.doc.rest.RestParameter.Type.STRING;
@@ -313,6 +315,38 @@ public class UsersEndpoint {
     return Response.ok(gson.toJson(response)).build();
   }
 
+
+  @GET
+  @Path("usersforroles.json")
+  @Produces(MediaType.APPLICATION_JSON)
+  @RestQuery(
+      name = "usersforroles",
+      description = "Returns a list of users",
+      returnDescription = "Returns a JSON representation of the list of user accounts",
+      restParameters = {
+        @RestParameter(name = "roles", isRequired = false, description = "JSON Array", type = STRING),
+      },
+      responses = {
+          @RestResponse(responseCode = SC_OK, description = "The user accounts.")
+      })
+  public Response getsUsersForRoles(@QueryParam("roles") String roles) {
+    List<String> rolesList = gson.fromJson(roles, ArrayList.class);
+    Map<String, Map<String, Object>> roleUserMap = new HashMap<>();
+
+    for (String role : rolesList) {
+      if (!isSanitize()) {
+        User user = userDirectoryService.loadUser(role.replaceFirst(getUserRolePrefix(), ""));
+        if (user != null) {
+          roleUserMap.put(role, generateJsonUser(user));
+        } else {
+          roleUserMap.put(role, null);
+        }
+      }
+    }
+
+    return Response.ok(gson.toJson(roleUserMap)).build();
+  }
+
   @POST
   @Path("/")
   @RestQuery(name = "createUser", description = "Create a new  user", returnDescription = "The location of the new ressource", restParameters = {
@@ -511,7 +545,7 @@ public class UsersEndpoint {
     return rolesSet;
   }
 
-  private Map<String, Object> generateJsonUser(User user) {
+  public Map<String, Object> generateJsonUser(User user) {
     // Prepare the roles
     Map<String, Object> userData = new HashMap<>();
     userData.put("username", user.getUsername());

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/AbstractEventEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/AbstractEventEndpointTest.java
@@ -519,8 +519,8 @@ public class AbstractEventEndpointTest {
 
     // Fix ordering for embedded acl json string
     String expectedAclString = getAclString(eventAccessJson);
-    String aclString = getAclString(result.toJSONString());
-    assertThat(expectedAclString, SameJSONAs.sameJSONAs(aclString));
+    JSONArray aclString = getAclArray(result.toJSONString());
+    assertThat(expectedAclString, SameJSONAs.sameJSONAs(aclString.toJSONString()));
 
     JSONObject episodeAccess = (JSONObject) result.get("episode_access");
     episodeAccess.replace("acl", expectedAclString);
@@ -532,6 +532,12 @@ public class AbstractEventEndpointTest {
     JSONObject accessJson = (JSONObject) new JSONParser().parse(accessJsonString);
     JSONObject episodeAccess = (JSONObject) accessJson.get("episode_access");
     return (String) episodeAccess.get("acl");
+  }
+
+  private JSONArray getAclArray(String accessJsonString) throws ParseException {
+    JSONObject accessJson = (JSONObject) new JSONParser().parse(accessJsonString);
+    JSONObject episodeAccess = (JSONObject) accessJson.get("episode_access");
+    return (JSONArray) episodeAccess.get("acl");
   }
 
   @Test

--- a/modules/admin-ui/src/test/resources/eventAccess.json
+++ b/modules/admin-ui/src/test/resources/eventAccess.json
@@ -11,7 +11,7 @@
   ],
   "episode_access": {
     "current_acl": 0,
-    "acl": "{\"acl\":{\"ace\":[{\"allow\":true,\"role\":\"ROLE_ADMIN\",\"action\":\"read\"},{\"allow\":true,\"role\":\"ROLE_ADMIN\",\"action\":\"write\"}]}}",
+    "acl": "[{\"role\":\"ROLE_ADMIN\",\"read\":true,\"write\":true,\"actions\":[]}]",
     "privileges": {
       "ROLE_ADMIN": {
         "read": true,

--- a/modules/admin-ui/src/test/resources/roles.json
+++ b/modules/admin-ui/src/test/resources/roles.json
@@ -1,6 +1,6 @@
 [
-  { "name": "ROLE_ADMIN", "description": "", "organization": "mh_default_org", "type": "INTERNAL" },
-  { "name": "ROLE_ANONYMOUS", "description": "", "organization": "mh_default_org", "type": "SYSTEM" },
-  { "name": "ROLE_ADMIN_UI", "description": "", "organization": "mh_default_org", "type": "INTERNAL" },
-  { "name": "ROLE_API", "description": "", "organization": "mh_default_org", "type": "INTERNAL" }
+  { "name": "ROLE_ADMIN", "description": "", "organization": "mh_default_org", "type": "INTERNAL", "isSanitize":true },
+  { "name": "ROLE_ANONYMOUS", "description": "", "organization": "mh_default_org", "type": "SYSTEM", "isSanitize":true },
+  { "name": "ROLE_ADMIN_UI", "description": "", "organization": "mh_default_org", "type": "INTERNAL", "isSanitize":true },
+  { "name": "ROLE_API", "description": "", "organization": "mh_default_org", "type": "INTERNAL", "isSanitize":true }
 ]

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserIdRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserIdRoleProvider.java
@@ -107,6 +107,14 @@ public class UserIdRoleProvider implements RoleProvider, ManagedService {
     this.userDirectoryService = userDirectoryService;
   }
 
+  public static boolean isSanitize() {
+    return sanitize;
+  };
+
+  public static String getUserRolePrefix() {
+    return userRolePrefix;
+  };
+
   public static String getUserIdRole(String userName) {
     if (sanitize) {
       userName = SAFE_USERNAME.replaceFrom(userName, "_").toUpperCase();


### PR DESCRIPTION
Adds user information for user roles to admin ui GET endpoints. The frontend wants to render user roles like ROLE_USER_ARNE with user information like username and email, so instead of having to do perform multiple GET requests and then mix-and-matching roles and users in the frontend, it seemed prudent to change the backend instead.

To that end, ACLs are not sent as is anymore, but transformed into the format used by the frontend so that user information can be more easily attached.

**Requires frontend changes, otherwise this PR will break the frontend: https://github.com/opencast/opencast-admin-interface/pull/1006**

### How to test this patch

Check the frontend PR for more information on how to test this patch.
