### PR TITLE
Allow live events to be published by the CA user

### DIFF
--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
@@ -314,7 +314,7 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
   private void checkMPWritePermission(final String mediaPackageId) throws SearchException {
     User user = securityService.getUser();
     try {
-      if (!persistence.exist(mediaPackageId)) {
+      if (!persistence.isAvailable(mediaPackageId)) {
         throw new NotFoundException();
       }
       AccessControlList acl = persistence.getAccessControlList(mediaPackageId);

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabase.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabase.java
@@ -164,9 +164,11 @@ public interface SearchServiceDatabase {
    *           if exception occurs
    * @throws NotFoundException
    *           if media package with specified id is not found
+   * @throws UnauthorizedException
+   *           if the current user is not authorized to perform this action
    */
   void deleteMediaPackage(String mediaPackageId, Date deletionDate) throws SearchServiceDatabaseException,
-          NotFoundException;
+          NotFoundException, UnauthorizedException;
 
   /**
    * Store (or update) media package.
@@ -185,4 +187,5 @@ public interface SearchServiceDatabase {
   void storeMediaPackage(MediaPackage mediaPackage, AccessControlList acl, Date now)
           throws SearchServiceDatabaseException, UnauthorizedException;
 
+  boolean exist(String mediaPackageId) throws SearchServiceDatabaseException;
 }

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabase.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabase.java
@@ -187,5 +187,12 @@ public interface SearchServiceDatabase {
   void storeMediaPackage(MediaPackage mediaPackage, AccessControlList acl, Date now)
           throws SearchServiceDatabaseException, UnauthorizedException;
 
-  boolean exist(String mediaPackageId) throws SearchServiceDatabaseException;
+  /**
+   * Checks if a mediapackage is available.
+   *
+   * @param mediaPackageId The ID of the {@link MediaPackage} for which the availability is to be checked
+   * @return True if two conditions are met: The mediapackage exists in the database and the deletion date is not set
+   * @throws SearchServiceDatabaseException if an exception occurs
+   */
+  boolean isAvailable(String mediaPackageId) throws SearchServiceDatabaseException;
 }

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
@@ -479,7 +479,12 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
     }
   }
 
-  public boolean exist(String mediaPackageId) throws SearchServiceDatabaseException {
+  /**
+   * {@inheritDoc}
+   *
+   * @see org.opencastproject.search.impl.persistence.SearchServiceDatabase#isAvailable(String)
+   */
+  public boolean isAvailable(String mediaPackageId) throws SearchServiceDatabaseException {
     try {
       return db.execTxChecked(em -> {
         Optional<SearchEntity> searchEntity = getSearchEntityQuery(mediaPackageId).apply(em);

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
@@ -157,7 +157,7 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
    */
   @Override
   public void deleteMediaPackage(String mediaPackageId, Date deletionDate) throws SearchServiceDatabaseException,
-          NotFoundException {
+          NotFoundException, UnauthorizedException {
     try {
       db.execTxChecked(em -> {
         Optional<SearchEntity> searchEntity = getSearchEntityQuery(mediaPackageId).apply(em);
@@ -185,7 +185,7 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
         searchEntity.get().setModificationDate(deletionDate);
         em.merge(searchEntity.get());
       });
-    } catch (NotFoundException e) {
+    } catch (NotFoundException | UnauthorizedException e) {
       throw e;
     } catch (Exception e) {
       logger.error("Could not delete episode {}: {}", mediaPackageId, e.getMessage());
@@ -368,6 +368,8 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
           em.merge(entity.get());
         }
       });
+    } catch (UnauthorizedException e) {
+      throw e;
     } catch (Exception e) {
       logger.error("Could not update media package: {}", e.getMessage());
       throw new SearchServiceDatabaseException(e);
@@ -385,7 +387,7 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
     try {
       return db.execTxChecked(em -> {
         Optional<SearchEntity> episodeEntity = getSearchEntityQuery(mediaPackageId).apply(em);
-        if (episodeEntity.isEmpty()) {
+        if (episodeEntity.isEmpty() || episodeEntity.get().getDeletionDate() != null) {
           throw new NotFoundException("No episode with id=" + mediaPackageId + " exists");
         }
         // Ensure this user is allowed to read this episode
@@ -473,6 +475,18 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
       throw e;
     } catch (Exception e) {
       logger.error("Could not get deletion date {}: {}", mediaPackageId, e.getMessage());
+      throw new SearchServiceDatabaseException(e);
+    }
+  }
+
+  public boolean exist(String mediaPackageId) throws SearchServiceDatabaseException {
+    try {
+      return db.execTxChecked(em -> {
+        Optional<SearchEntity> searchEntity = getSearchEntityQuery(mediaPackageId).apply(em);
+        return searchEntity.stream().anyMatch(entity -> entity.getDeletionDate() == null);
+      });
+    } catch (Exception e) {
+      logger.error("Error while checking if mediapackage {} exists in database: {}", mediaPackageId, e.getMessage());
       throw new SearchServiceDatabaseException(e);
     }
   }

--- a/modules/search-service-impl/src/test/java/org/opencastproject/search/impl/persistence/SearchServicePersistenceTest.java
+++ b/modules/search-service-impl/src/test/java/org/opencastproject/search/impl/persistence/SearchServicePersistenceTest.java
@@ -170,7 +170,7 @@ public class SearchServicePersistenceTest {
       exception = true;
     }
     Assert.assertTrue(exception);
-    Assert.assertFalse(searchDatabase.exist(mediaPackage.getIdentifier().toString()));
+    Assert.assertFalse(searchDatabase.isAvailable(mediaPackage.getIdentifier().toString()));
     Assert.assertEquals(deletionDate, searchDatabase.getDeletionDate(mediaPackage.getIdentifier().toString()));
 
     Stream<Tuple<MediaPackage, String>> allMediaPackages = searchDatabase.getAllMediaPackages(50, 0);

--- a/modules/search-service-impl/src/test/java/org/opencastproject/search/impl/persistence/SearchServicePersistenceTest.java
+++ b/modules/search-service-impl/src/test/java/org/opencastproject/search/impl/persistence/SearchServicePersistenceTest.java
@@ -162,7 +162,15 @@ public class SearchServicePersistenceTest {
 
     Date deletionDate = new Date();
     searchDatabase.deleteMediaPackage(mediaPackage.getIdentifier().toString(), deletionDate);
-    episode = searchDatabase.getMediaPackage(mediaPackage.getIdentifier().toString());
+
+    exception = false;
+    try {
+      episode = searchDatabase.getMediaPackage(mediaPackage.getIdentifier().toString());
+    } catch (NotFoundException notFoundException) {
+      exception = true;
+    }
+    Assert.assertTrue(exception);
+    Assert.assertFalse(searchDatabase.exist(mediaPackage.getIdentifier().toString()));
     Assert.assertEquals(deletionDate, searchDatabase.getDeletionDate(mediaPackage.getIdentifier().toString()));
 
     Stream<Tuple<MediaPackage, String>> allMediaPackages = searchDatabase.getAllMediaPackages(50, 0);


### PR DESCRIPTION
Fixes #6386

Some recently implemented permission checks prevent the Capture Agent (CA) user from retracting and publishing live events. This commit introduces the following changes:

- LiveScheduleServiceImpl: The existing behavior of promoting the CA user to the System User when retrieving live media packages has been extended to also apply when retracting live media packages. This ensures that necessary actions can be performed during both retrieval and retraction, despite stricter permission checks.

- SearchServiceIndex: Previously, the write permission check for the CA user would fail when attempting to publish a new media package with the workflow operation `publish-engage`. This was because the index service checked the ACL of the previously deleted live media package.

  - A new `exists` method has been implemented, which returns `false` both for media packages that never existed and those that have been deleted.
  - This change ensures the CA user always has write permission for publishing new media packages.

### How to Reproduce
Schedule a live event and use a workflow, that straight away publishes the live event after recording. You should see errors while retracting the live event after the recording finishes. Later, you will see the workflow fail at the publish-engage step.

### Why it's important to go into this branch
We have the strategy, to always use the 2nd latest Opencast. In Version 16, the live events are not working without this commit.

### How to test this patch
You need to configure a capture agent and enable live events via workflows. With this commit, everything should work correctly.