### PR TITLE
Add configuration option for jetty cache eviction

### DIFF
--- a/etc/jetty-opencast.xml
+++ b/etc/jetty-opencast.xml
@@ -20,7 +20,6 @@
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
-
   <!-- =========================================================== -->
   <!-- Set connectors -->
   <!-- =========================================================== -->
@@ -98,6 +97,19 @@
             </Item>
           </Array>
         </Set>
+      </New>
+    </Arg>
+  </Call>
+
+  <!-- =========================================================== -->
+  <!-- Configure Cache Eviction -->
+  <!-- by default the jetty session cache is never evicted (default value: -1) -->
+  <!-- setting the evictionPolicy to 0 results in cache eviction after session exit -->
+  <!-- =========================================================== -->
+  <Call name="addBean">
+    <Arg>
+      <New class="org.eclipse.jetty.server.session.AbstractSessionCacheFactory">
+        <Set name="evictionPolicy">0</Set>
       </New>
     </Arg>
   </Call>


### PR DESCRIPTION
Adding the option to set the session cache `evictionPolicy` to "evict on session exit" in the existing jetty configuration file: etc/jetty-opencast.xml 
This fixes the jetty exceptions "opencast already in cache" and "Create session failed" that show up when locally stopping and restarting Opencast and then interacting with the Admin UI. Apparently these exceptions are caused by the default setting of the jetty cache `evictionPolicy`, which is `NEVER_EVICT` (-1). By setting the `evictionPolicy` in the `AbstractSessionCacheFactory` to `EVICT_ON_SESSION_EXIT` (0) the old session will be removed from the cache when exiting the session.
When stopping and starting Opencast with this configuration a new session is started and the Admin UI will automatically load the login page when Opencast started. 

To load the opencast jetty configuration uncomment line 45 in etc/org.ops4j.pax.web.cfg (org.ops4j.pax.web.config.file=${karaf.etc}/jetty-opencast.xml).
