### PR TITLE
Fix jQuery mime type

### DIFF
--- a/modules/common/src/main/resources/ui/restdocs/template.xhtml
+++ b/modules/common/src/main/resources/ui/restdocs/template.xhtml
@@ -277,7 +277,7 @@
 </main>
 
 <!-- JAVASCRIPT below here -->
-<script type=text/javascript src=js/jquery/dist/jquery.min.js></script>
+<script type=text/javascript src=scripts/jquery.min.js></script>
 <script type=text/javascript src=scripts/docs.js></script>
 
 </body>

--- a/modules/runtime-info-ui/pom.xml
+++ b/modules/runtime-info-ui/pom.xml
@@ -185,12 +185,12 @@
               <goal>copy-resources</goal>
             </goals>
             <configuration>
-              <outputDirectory>${basedir}/target/classes/ui/js/</outputDirectory>
+              <outputDirectory>${basedir}/target/classes/ui/scripts/</outputDirectory>
               <resources>
                 <resource>
-                  <directory>node_modules/</directory>
+                  <directory>node_modules/jquery/dist/</directory>
                   <includes>
-                    <include>jquery/dist/jquery.min.js</include>
+                    <include>jquery.min.js</include>
                   </includes>
                   <filtering>false</filtering>
                 </resource>


### PR DESCRIPTION
Due to recent changes related to the graphQL patches, jQuery was served as `application/octet-stream` which could lead to browsers no longer loading the library. This broke the REST docs. Just putting the library into the `scripts` folder fixes the issue since it's one of the hard-coded locations where mime type mapping is enabled. The previous location `/js/` was no such location.

This fixes #6383

### How to test this patch

- Go to the admin interface
- Click on the question mark in the top right corner and select rest docs
- Select any category and find a post request
- Click on "Testing form (click to reveal)"
- The test form should open

Additionally, you can check the content type of `jquery.min.js` in your browsers developer tools.


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
