### PR TITLE
Document GitHub Discussions on Docs Landing Page

### DIFF
--- a/docs/guides/.infrastructure/index.html.j2
+++ b/docs/guides/.infrastructure/index.html.j2
@@ -105,21 +105,18 @@
       </h3>
       <div class="row">
         <div class="col-md-6">
-          <h4>Mailing lists</h4>
-          <p>Discussions take place on several mailing lists:</p>
+          <h4>Discussions</h4>
+          <p>Discussions take place on GitHub:</p>
           <ul>
-            <li><a href="https://groups.google.com/a/opencast.org/forum/#!forum/security-notices">
-                security-notices@opencast.org</a> –
-                Security announcements (low frequency)</li>
+            <li><a href="https://github.com/orgs/opencast/discussions">
+                GitHub Discussions</a> –
+              Main discussion forum for Opencast</li>
+          </ul>
+          <p>There are also a few additional Google Groups mailing lists:</p>
+          <ul>
             <li><a href="https://groups.google.com/a/opencast.org/forum/#!forum/announcements">
                 announcements@opencast.org</a> –
                 Community announcements (low frequency)</li>
-            <li><a href="https://groups.google.com/a/opencast.org/forum/#!forum/users">
-                users@opencast.org</a> –
-                Users list</li>
-            <li><a href="https://groups.google.com/a/opencast.org/forum/#!forum/dev">
-                dev@opencast.org</a> –
-                Developers list</li>
             <li><a href="https://groups.google.com/a/opencast.org/forum/#!forum/anwender">
                 anwender@opencast.org</a> –
                 German speaking community list</li>
@@ -131,8 +128,8 @@
                 Opencast Annotation Tool list</li>
           </ul>
 
-          You can subscribe via Google Groups (linked above) or simply by sending a mail to
-          <em>[list]+subscribe@opencast.org</em> (e.g. <em>users+subscribe@opencast.org</em>).
+          You can subscribe via Google Groups (linked above) or simply by sending an e-mail to
+          <em>[list]+subscribe@opencast.org</em> (e.g. <em>lms+subscribe@opencast.org</em>).
         </div>
 
         <div class="col-md-6">


### PR DESCRIPTION
This patch updates the landing page of docs.opencast.org to add GitHub Discussions as new location for discussions and questions about Opencast.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
