### PR TITLE
Remove superfluous slash in endpoint URL when loading series from Engage UI

### DIFF
--- a/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
+++ b/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
@@ -801,7 +801,7 @@ function($, bootbox, _, alertify, jsyaml) {
   function loadSeries(cleanGrid, rest, callback) {
     log('Loading Series with: ' + rest);
     active = 'series';
-    var requestUrl = restEndpoint + '/series.json'
+    var requestUrl = restEndpoint + 'series.json'
       + '?limit=' + bufferEntries + '&offset=' + (page - 1) * bufferEntries + '&' + rest;
     $.ajax({
       url: requestUrl,


### PR DESCRIPTION
This fixes a bug when loading the list of series in Engage UI which is broken due to a double slash in the URL (`restEndpoint` already has a trailing slah, also see the code in `loadEpisodes`). The issue can be reproduced by navigating to the Series overview in Engage UI, e.g. https://stable.opencast.org/engage/ui/index.html?s=1 and checked in the browser's Developer Tools which show a request to an endpoint containing a double slash (https://stable.opencast.org/search//series.json?limit=18&offset=0&=) resulting in a 404 error.