### PR TITLE
Added default padding and default duration to editor service with cfg

### DIFF
--- a/etc/org.opencastproject.editor.EditorServiceImpl.cfg
+++ b/etc/org.opencastproject.editor.EditorServiceImpl.cfg
@@ -94,3 +94,15 @@
 # This Property sets the time (in seconds) after which the editor should refresh the lock on a mediapackage.
 # Default: 60
 #lock.refresh.after.seconds=60
+
+# Default values for  trim segments in the editor.
+# Default: In milliseconds
+#
+# This property sets the length of the default trim segment at the beginning and end of each video
+# Default: 3000
+default.padding.length = 3000
+
+# This property sets the minimum duration of the video to add default trim segments to. If the video is shorter than 
+# this duration, no default trimm segment will be added to it.
+# Default: 6000
+min.video.duration = 6000

--- a/etc/org.opencastproject.editor.EditorServiceImpl.cfg
+++ b/etc/org.opencastproject.editor.EditorServiceImpl.cfg
@@ -102,7 +102,7 @@
 # Default: 3000
 default.padding.length = 3000
 
-# This property sets the minimum duration of the video to add default trim segments to. If the video is shorter than 
+# This property sets the minimum duration of the video to add default trim segments to. If the video is shorter than
 # this duration, no default trimm segment will be added to it.
 # Default: 6000
 min.video.duration = 6000

--- a/etc/org.opencastproject.editor.EditorServiceImpl.cfg
+++ b/etc/org.opencastproject.editor.EditorServiceImpl.cfg
@@ -100,9 +100,9 @@
 #
 # This property sets the length of the default trim segment at the beginning and end of each video
 # Default: 3000
-default.padding.length = 3000
+#default.padding.length = 3000
 
 # This property sets the minimum duration of the video to add default trim segments to. If the video is shorter than
 # this duration, no default trimm segment will be added to it.
 # Default: 6000
-min.video.duration = 6000
+#min.video.duration = 6000

--- a/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
+++ b/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
@@ -577,7 +577,7 @@ public class EditorServiceImpl implements EditorService {
       }
 
       Track track = mediaPackage.getTrack(trackId);
-      
+
       if (subtitle.isDeleted()) {
         // If the subtitle is empty, remove the track
         if (trackId != null) {

--- a/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
+++ b/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
@@ -194,7 +194,7 @@ public class EditorServiceImpl implements EditorService {
   private static final List<MediaPackageElementFlavor> DEFAULT_THUMBNAIL_PRIORITY_FLAVOR = new ArrayList<>();
   private static final int DEFAULT_LOCK_TIMEOUT_SECONDS = 300; // ( 5 mins )
   private static final int DEFAULT_LOCK_REFRESH_SECONDS = 60;  // ( 1 min )
-  private static final String DEFAULT_PADDING_LENGTH = "0"; // (0 secs)
+  private static final String DEFAULT_PADDING_LENGTH = "3000"; // (0 secs)
   private static final String DEFAULT_MIN_VIDEO_DURATION = "6000"; // (6 secs)
 
   public static final String OPT_PREVIEW_SUBTYPE = "preview.subtype";


### PR DESCRIPTION

### Describe the bug
In version 8.x, a video and audio synchronization issue https://github.com/opencast/opencast/issues/1351 was identified when playing videos after trimming. The issue stemmed from the lack of default buffers at the beginning and end of the video. This caused desynchronization because network camera videos, often encoded in formats like H264, can capture data between keyframes. When processed by FFmpeg, this lack of buffers resulted in audio and video being out of sync.

This issue was addressed by introducing a default buffer of 3 seconds at both the beginning and end of a video. However, this fix was not carried forward into the newer versions of Opencast which introduced a new editor, resulting in a regression of the sync issue.

This fix reinstates the previously implemented solution for issue https://github.com/opencast/opencast/issues/1351, and resolves the regression in newer versions.

**Related references:**

- Original issue: [#1351](https://github.com/opencast/opencast/issues/1351)
- Fix in 8.x : [PR #1354](https://github.com/opencast/opencast/pull/1354)

**Environment Information**
Identified and tested in Opencast 16.x

### To reproduce
- Open the editor in a version later than 13.x.
- Observe that there is no default buffer of 3 seconds at the beginning and end of the video.
- Delete segments from the video.
- Save the edited video and play it back.
- Observe the video and audio are not synchronized.


### How to test this patch
- Open the editor with the fix applied in a version later than 13.x.
- Verify that a default 3-second buffer is automatically added at the beginning and end of the video.
- Delete segments from the video.
- Save the edited video.
- Play back the video to confirm that the video and audio tracks are synchronized correctly.


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
