### PR TITLE
Fixing SFA pattern for search and livestream

### DIFF
--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceImpl.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceImpl.java
@@ -131,7 +131,8 @@ public final class SearchServiceImpl extends AbstractJobProducer implements Sear
 
   private final LoadingCache<Tuple<User, String>, Boolean> cache;
 
-  private static final Pattern staticFilePattern = Pattern.compile("^/([^/]+)/engage-player/([^/]+)/.*$");
+  private static final Pattern staticFilePattern =
+      Pattern.compile("^/([^/]+)/(?:engage-player|engage-live)/([^/]+)/.*$");
 
   /**
    * Creates a new instance of the search service.


### PR DESCRIPTION
<!--
Explain what this pull request does.  If this fixes a bug, also explain how to reproduce the issue.
-->

This PR adds `engage-live` to the static file auth regex so that publishing a live-streaming event with static file auth enabled actually works correctly.  Discovered testing #6385.

<!--
If your pull request is targeting the legacy (second oldest release branch), explain why this patch is so important that
it needs to go into the legacy and can not go just into stable or develop.
-->

This needs to go into legacy since legacy's live streaming is broken in SFA enabled usecases otherwise.

### How to test this patch

<!--
Explain how to test this patch. If this requires a particular set-up or configuration, explain that as well and provide
the necessary configuration if possible. The easier it is for others to test the patch, the faster this will get
reviewed and merged.
-->

With static file auth enabled (the default), try scheduling a live streaming event.  You should see something like this

```
2025-01-15T14:58:40,251 | INFO  | (StaticResourceServlet:116) - Added static file authorization for [^/([^/]+)/engage-player/([^/]+)/.*$]
2025-01-15T14:58:40,251 | INFO  | (StaticResourceServlet:169) - Serving static files from '/home/greg/opencast/upstream/build/opencast-dist-develop-16-SNAPSHOT/data/opencast/downloads'
2025-01-15T14:58:40,259 | WARN  | (WorkspaceImpl:484) - Received unexpected response status 403 while trying to download from http://localhost/static/mh_default_org/engage-live/590cd696-497a-4174-9131-43c9ffe3d9ce/security-policy-episode/xacml.xml
2025-01-15T14:58:40,273 | WARN  | (WorkspaceImpl:484) - Received unexpected response status 403 while trying to download from http://localhost/static/mh_default_org/engage-live/590cd696-497a-4174-9131-43c9ffe3d9ce/44874e87-3cc3-4f97-9e22-b3f59e8eac51/dublincore.xml
2025-01-15T14:58:40,274 | ERROR | (DublinCoreUtil:79) - Unable to load metadata from catalog 'http://localhost/static/mh_default_org/engage-live/590cd696-497a-4174-9131-43c9ffe3d9ce/44874e87-3cc3-4f97-9e22-b3f59e8eac51/dublincore.xml'
org.opencastproject.util.NotFoundException: null
        at org.opencastproject.workspace.impl.WorkspaceImpl.downloadIfNecessary(WorkspaceImpl.java:535) ~[?:?]
        at org.opencastproject.workspace.impl.WorkspaceImpl$2.xapply(WorkspaceImpl.java:557) ~[?:?]
        at org.opencastproject.workspace.impl.WorkspaceImpl$2.xapply(WorkspaceImpl.java:554) ~[?:?]
        at org.opencastproject.util.data.Function$X.apply(Function.java:104) ~[!/:?]
        at org.opencastproject.util.IoSupport.locked(IoSupport.java:478) ~[!/:?]
        at org.opencastproject.workspace.impl.WorkspaceImpl.get(WorkspaceImpl.java:402) ~[?:?]
        at org.opencastproject.workspace.impl.WorkspaceImpl.read(WorkspaceImpl.java:437) ~[?:?]
        at org.opencastproject.metadata.dublincore.DublinCoreUtil.loadDublinCore(DublinCoreUtil.java:76) ~[?:?]
        at org.opencastproject.metadata.dublincore.DublinCoreUtil.lambda$loadEpisodeDublinCore$0(DublinCoreUtil.java:64) ~[?:?]
        at java.util.Optional.map(Optional.java:265) ~[?:?]
        at org.opencastproject.metadata.dublincore.DublinCoreUtil.loadEpisodeDublinCore(DublinCoreUtil.java:64) ~[?:?]
        at org.opencastproject.search.impl.SearchServiceIndex.indexMediaPackage(SearchServiceIndex.java:256) ~[?:?]
        at org.opencastproject.search.impl.SearchServiceIndex.indexMediaPackage(SearchServiceIndex.java:248) ~[?:?]
        at org.opencastproject.search.impl.SearchServiceIndex.addSynchronously(SearchServiceIndex.java:243) ~[?:?]
        at org.opencastproject.search.impl.SearchServiceImpl.lambda$process$0(SearchServiceImpl.java:263) ~[?:?]
        at org.opencastproject.security.util.SecurityUtil.runAs(SecurityUtil.java:79) [!/:?]
        at org.opencastproject.search.impl.SearchServiceImpl.process(SearchServiceImpl.java:261) [!/:?]
        at org.opencastproject.job.api.AbstractJobProducer$JobRunner.call(AbstractJobProducer.java:314) [!/:?]
        at org.opencastproject.job.api.AbstractJobProducer$JobRunner.call(AbstractJobProducer.java:273) [!/:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at java.lang.Thread.run(Thread.java:829) [?:?]
```


### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
