### PR TITLE
Fix OCR transcriptions in Paella player

### DIFF
--- a/modules/engage-paella-player-7/src/js/EpisodeConversor.js
+++ b/modules/engage-paella-player-7/src/js/EpisodeConversor.js
@@ -278,25 +278,6 @@ function getStreams(episode, config) {
   return streams;
 }
 
-function processSegments(episode, manifest) {
-  const { segments } = episode;
-  if (segments) {
-    manifest.transcriptions = manifest.transcriptions || [];
-    if (!Array.isArray(segments.segment)) {
-      segments.segment = [segments.segment];
-    }
-    segments.segment.forEach(({ index, previews, text, time, duration}) => {
-      manifest.transcriptions.push({
-        index,
-        preview: previews?.preview?.$,
-        text,
-        time,
-        duration
-      });
-    });
-  }
-}
-
 // Extract the player preview to show prior to loading videos
 export function getVideoPreview(mediapackage, config) {
   const { attachments } = mediapackage;
@@ -459,6 +440,61 @@ function getCaptions(episode) {
   return captions;
 }
 
+function processTranscriptions(episode, manifest) {
+  var catalog = episode.mediapackage.metadata.catalog;
+  if (!(catalog instanceof Array)) { catalog = catalog ? [catalog] : []; }
+  // catalog contains also the path to the transcriptions XML file
+  catalog.forEach(async (potentialTranscriptions) => {
+    try {
+      if ('mpeg-7/text' === potentialTranscriptions.type) {
+        // Fetch the transcriptions XML file
+        const response = await fetch(potentialTranscriptions.url);
+
+        if (response.ok) {
+          const xml_data = await response.text();
+          const parser = new DOMParser();
+          const xmlDoc = parser.parseFromString(xml_data, 'application/xml');
+          manifest.transcriptions = [];
+          // get all VideoSegment elements which contain time and text of transcriptions
+          const videoSegments = xmlDoc.getElementsByTagName('VideoSegment');
+          for (let i = 0; i < videoSegments.length; i++) {
+            const segment = videoSegments[i];
+            // get and calculate time of VideoSegment in seconds
+            const time = segment.getElementsByTagName('MediaRelTimePoint')[0].textContent;
+            const timeRE = /T(\d+):(\d+):(\d+)/.exec(time);
+            if (timeRE !== null) {
+              const h = Number(timeRE[1]) * 60 * 60;
+              const m = Number(timeRE[2]) * 60;
+              const s = Number(timeRE[3]);
+              const t = h + m + s;
+              // each VideoSegment contains multiple Text elements for the same time
+              const texts = segment.getElementsByTagName('Text');
+              let concatenatedText = '';
+              for (let j = 0; j < texts.length; j++) {
+                if (texts[j].textContent != undefined) {
+                  concatenatedText += texts[j].textContent + ' ';
+                }
+              }
+              if (concatenatedText.trim() !== '') {
+                // search for the preview image with the same time
+                const preview = manifest.frameList.frames.find((preview) => preview.time === t);
+                manifest.transcriptions.push({
+                  id: `frame_${t}`,
+                  mimetype: preview.mimetype ?? '',
+                  time: t,
+                  preview: preview.url ?? '',
+                  text: concatenatedText.trim()
+                });
+              }
+            }
+          }
+        }
+      }
+    }
+    catch (err) {/**/}
+  });
+}
+
 export function episodeToManifest(ocResponse, config) {
   const searchResults = ocResponse['result'];
   if (searchResults?.length === 1) {
@@ -474,9 +510,7 @@ export function episodeToManifest(ocResponse, config) {
     };
 
     processAttachments(episode, result, config);
-    processSegments(episode, result, config);
-
-
+    processTranscriptions(episode, result);
 
     return result;
   }

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.transcriptionsPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.transcriptionsPlugin.js
@@ -75,8 +75,8 @@ export default class TranscriptionsPlugin extends PopUpButtonPlugin {
     this.transcriptions
     .filter(t => {  // filter trimming
       if (videoContainer.isTrimEnabled) {
-        return ((t.time / 1000) > videoContainer.trimStart)
-          && ((t.time / 1000) < videoContainer.trimEnd);
+        return (t.time > videoContainer.trimStart)
+          && (t.time < videoContainer.trimEnd);
       }
       return true;
     })
@@ -93,7 +93,7 @@ export default class TranscriptionsPlugin extends PopUpButtonPlugin {
     .forEach(t => {
       const id = `transcriptionItem${t.index}`;
       const trimmingOffset = videoContainer.isTrimEnabled ? videoContainer.trimStart : 0;
-      const instant = (t.time / 1000) - trimmingOffset;
+      const instant = t.time - trimmingOffset;
       const transcriptionItem = createElementWithHtmlText(`
         <li>
           <img id="${id}" src="${t.preview}" alt="${t.text}"/>
@@ -102,7 +102,7 @@ export default class TranscriptionsPlugin extends PopUpButtonPlugin {
       this._transcriptionsContainer);
       transcriptionItem.addEventListener('click', async evt => {
         const trimmingOffset = videoContainer.isTrimEnabled ? videoContainer.trimStart : 0;
-        this.player.videoContainer.setCurrentTime((t.time / 1000) - trimmingOffset);
+        this.player.videoContainer.setCurrentTime(t.time - trimmingOffset);
         evt.stopPropagation();
       });
     });


### PR DESCRIPTION
fixes #6330

As OCR transcriptions in the Paella player have been broken since Opencast 16, this PR targets r/16.x.

In Opencast 16, /search/episode.json no longer returns the OCR transcription data directly.
This PR now retrieves the transcription XML file and transforms the data to make it readable by the Paella player.

### How to test this patch

1. Configure Opencast to create OCR slide transcriptions (this is the case for a default installation).
2. Create a new event with a presentation video and publish it (video must contain slides or text)
3. Open the Paella player and play the video.
4. Open the transcriptions menu in the Paella player and check the text and preview images.


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~~include migration scripts and documentation, if appropriate~~
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
