### PR TITLE
Avoid NPEs during wowza retraction

### DIFF
--- a/modules/distribution-service-streaming-wowza/src/main/java/org/opencastproject/distribution/streaming/wowza/WowzaStreamingDistributionService.java
+++ b/modules/distribution-service-streaming-wowza/src/main/java/org/opencastproject/distribution/streaming/wowza/WowzaStreamingDistributionService.java
@@ -54,6 +54,7 @@ import org.opencastproject.workspace.api.Workspace;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.osgi.framework.BundleContext;
@@ -980,13 +981,17 @@ public class WowzaStreamingDistributionService extends AbstractDistributionServi
 
     // Try to remove the parent folders, if possible
     File elementDir = elementFile.getParentFile();
-    if (elementDir != null && elementDir.exists() && elementDir.list() != null) {
-      if (elementDir.list().length == 0) {
-        if (!elementDir.delete()) {
-          logger.warn("Could not properly delete element directory: {}", elementDir);
+    if (elementDir != null && elementDir.exists()) {
+      try {
+        if (FileUtils.isEmptyDirectory(elementDir)) {
+          if (!elementDir.delete()) {
+            logger.warn("Could not properly delete element directory: {}", elementDir);
+          }
+        } else {
+          logger.warn("Element directory was not empty after deleting element. Skipping deletion: {}", elementDir);
         }
-      } else {
-        logger.warn("Element directory was not empty after deleting element. Skipping deletion: {}", elementDir);
+      } catch (IOException e) {
+        logger.warn("Unable to delete element directory: {}", elementDir);
       }
     } else {
       logger.warn("Element directory did not exist when trying to delete it: {}", elementDir);
@@ -994,13 +999,17 @@ public class WowzaStreamingDistributionService extends AbstractDistributionServi
 
     File mediapackageDir = elementDir.getParentFile();
     if (mediapackageDir != null && mediapackageDir.exists()) {
-      if (mediapackageDir.list().length == 0) {
-        if (!mediapackageDir.delete()) {
-          logger.warn("Could not properly delete mediapackage directory: {}", mediapackageDir);
+      try {
+        if (FileUtils.isEmptyDirectory(mediapackageDir)) {
+          if (!mediapackageDir.delete()) {
+            logger.warn("Could not properly delete mediapackage directory: {}", mediapackageDir);
+          }
+        } else {
+          logger.debug("Mediapackage directory was not empty after deleting element. Skipping deletion: {}",
+              mediapackageDir);
         }
-      } else {
-        logger.debug("Mediapackage directory was not empty after deleting element. Skipping deletion: {}",
-                mediapackageDir);
+      } catch (IOException e) {
+        logger.warn("Unable to delete mediapackage directory: {}", elementDir);
       }
     } else {
       logger.warn("Mediapackage directory did not exist when trying to delete it: {}", mediapackageDir);


### PR DESCRIPTION
Attempting to avoid NPEs experienced during partial retraction with wowza.  The original code shouldn't have been doing what it's doing, and I am unable to reproduce the issue locally, but hopefully this patch resolves things

<!--
Explain what this pull request does.  If this fixes a bug, also explain how to reproduce the issue.
-->

<!--
If your pull request is targeting the legacy (second oldest release branch), explain why this patch is so important that
it needs to go into the legacy and can not go just into stable or develop.
-->

Placing this into 16.x since the bug is being expressed in *15.x*, but I'm open to moving it up to 17 if that's the right thing.

Fixes: #5665

### How to test this patch

Have wowza, partially retract things

<!--
Explain how to test this patch. If this requires a particular set-up or configuration, explain that as well and provide
the necessary configuration if possible. The easier it is for others to test the patch, the faster this will get
reviewed and merged.
-->


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
