### PR TITLE
Handle Opencast starting up before index is available

### DIFF
--- a/docs/guides/admin/docs/configuration/searchindex/elasticsearch.md
+++ b/docs/guides/admin/docs/configuration/searchindex/elasticsearch.md
@@ -33,6 +33,7 @@ Additionally, the following settings can be configured in
 * `max.retry.attempts.update`
 * `retry.waiting.period.get`
 * `retry.waiting.period.update`
+* `retry.delay.on.startup`
 
 The identifier defines which index opencast is looking for. This might be interesting if you run an
 Elasticsearch cluster and want to follow a naming scheme. But you should be aware that the index actually consists of
@@ -44,6 +45,10 @@ are too many concurrent requests. The retry behavior can be configured different
 This way you could set more retry attempts for index updates because of the more serious consequences if those requests
 fail. The waiting period is used to not overwhelm the Elasticsearch with retry requests, making the problem worse. By
 default, no retry will be attempted.
+
+The `retry.delay.on.startup` defines how long Opencast will wait between retry attempts 
+when the connection to the index service fails on startup. The default is 10 seconds.
+
 
 Version
 -------

--- a/docs/guides/admin/docs/configuration/searchindex/elasticsearch.md
+++ b/docs/guides/admin/docs/configuration/searchindex/elasticsearch.md
@@ -47,7 +47,7 @@ fail. The waiting period is used to not overwhelm the Elasticsearch with retry r
 default, no retry will be attempted.
 
 The `retry.delay.on.startup` defines how long Opencast will wait between retry attempts 
-when the connection to the index service fails on startup. The default is 10 seconds.
+when the connection to the index fails on startup. The default is 10 seconds.
 
 
 Version

--- a/etc/org.opencastproject.elasticsearch.index.ElasticsearchIndex.cfg
+++ b/etc/org.opencastproject.elasticsearch.index.ElasticsearchIndex.cfg
@@ -29,3 +29,9 @@
 # How long to wait between retry attempts of update requests (in milliseconds).
 # Default: 1s
 #retry.waiting.period.update=1000
+
+# How long to wait between retry attempts when opencast failed to connect the
+# index service on startup (in milliseconds, so the default '10000' equals 10 Seconds).
+# Value has to be greater than 0.
+# Default: 10000
+#retry.delay.on.startup=10000

--- a/etc/org.opencastproject.elasticsearch.index.ElasticsearchIndex.cfg
+++ b/etc/org.opencastproject.elasticsearch.index.ElasticsearchIndex.cfg
@@ -31,7 +31,7 @@
 #retry.waiting.period.update=1000
 
 # How long to wait between retry attempts when opencast failed to connect the
-# index service on startup (in milliseconds, so the default '10000' equals 10 Seconds).
+# index on startup (in milliseconds, so the default '10000' equals 10 Seconds).
 # Value has to be greater than 0.
 # Default: 10000
 #retry.delay.on.startup=10000


### PR DESCRIPTION
This PR supercedes #5944, handling additional cases which caused the initial PR to hang or otherwise misbehave.

Fixes #5943

### How to test this patch

Make sure Opensearch is not running, then start Opencast an observe the waiting loop.  Play with the timing.  Then start Opensearch.

You may see exceptions related to circular dependencies.  These happen without that patch, and are their own separate issue.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] ~explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch~
