### PR TITLE
Migrate away from deprecated ::set-output in GitHub Actions

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -42,9 +42,9 @@ jobs:
       - name: Get the version
         id: get_version
         run: |
-          echo "::set-output name=VERSION::$GITHUB_REF" | sed 's_refs/tags/\([0-9]*\).\([0-9]*\)$_\1.\2_'
-          echo "::set-output name=VERSION_MAIN::$GITHUB_REF" | sed 's_refs/tags/\([0-9]*\).\([0-9]*\)$_\1_'
-          echo "::set-output name=VERSION_COMBINED::$GITHUB_REF" | sed 's_refs/tags/\([0-9]*\).\([0-9]*\)$_\1\2_'
+          echo "VERSION=$GITHUB_REF"          | sed 's_refs/tags/\([0-9]*\).\([0-9]*\)$_\1.\2_' >> $GITHUB_OUTPUT
+          echo "VERSION_MAIN=$GITHUB_REF"     | sed 's_refs/tags/\([0-9]*\).\([0-9]*\)$_\1_' >> $GITHUB_OUTPUT
+          echo "VERSION_COMBINED=$GITHUB_REF" | sed 's_refs/tags/\([0-9]*\).\([0-9]*\)$_\1\2_' >> $GITHUB_OUTPUT
 
       - name: create new release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
GitHub deprecated the `::set-output` to pass on values to different taks. This patch migrated the create release workflow to using the new environment files.

See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

*This needs to go into `r/16.x` since the workflow is executed when cutting new releases.*

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
