### PR TITLE
Allow sorting events by UID

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -2668,6 +2668,9 @@ public abstract class AbstractEventEndpoint {
       Set<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(optSort.get());
       for (SortCriterion criterion : sortCriteria) {
         switch (criterion.getFieldName()) {
+          case EventIndexSchema.UID:
+            query.sortByUID(criterion.getOrder());
+            break;
           case EventIndexSchema.TITLE:
             query.sortByTitle(criterion.getOrder());
             break;

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/event/EventSearchQuery.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/event/EventSearchQuery.java
@@ -1134,6 +1134,15 @@ public class EventSearchQuery extends AbstractSearchQuery {
     return getSortOrder(EventIndexSchema.TITLE);
   }
 
+  public EventSearchQuery sortByUID(Order order) {
+    withSortOrder(EventIndexSchema.UID, order);
+    return this;
+  }
+
+  public Order getUIDSortOrder() {
+    return getSortOrder(EventIndexSchema.UID);
+  }
+
   /**
    * Defines the sort order for the recording date.
    *


### PR DESCRIPTION
Adds the option to sort results for an event search query by unique identifier. Elasticsearch does not guarantee the ordering of results if no sorting is specified, thus this option may be useful if guaranteed ordering is required, but the schema by which is sorted does not matter.

My motivation here is to use this in the admin ui frontend. This will not break the admin ui frontend.

### How to test this patch

Install this patch in your Opencast, then test this by making requests against the `admin-ng/events.json` endpoint using `uid:asc` or `uid:desc`. You can use the rest docs for this https://stable.opencast.org/docs.html?path=/admin-ng/event#getevents-18.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
