### PR TITLE
Fix the multiple creation of subtitle files

### DIFF
--- a/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
+++ b/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
@@ -547,7 +547,7 @@ public class EditorServiceImpl implements EditorService {
           throws IOException, IllegalArgumentException {
     for (EditingData.Subtitle subtitle : subtitles) {
       // Generate ID for new tracks
-      String subtitleId = UUID.randomUUID().toString();
+      String subtitleId = subtitle.getId();
       String trackId = null;
 
       // Check if subtitle already exists


### PR DESCRIPTION
Fixes https://github.com/opencast/opencast-editor/issues/1550

Fixes a Bug, where multiple subtitle files get created.

### How to reproduce
- Activate the subitle editor in the editor-settings.toml
- Create a subtitle file by clicking on `+`
- Click on the "Finish" tab and click "Save"
- Click on the "Finish" tab and click "Save"
- Click on the "Finish" tab and click "Save"
- Click on the "Finish" tab and click "Save"
- Click on the "Finish" tab and click "Save"
- ...
- Reload with F5
- You have created multiple Subtitle Files

### How to test this patch
- Do the steps described above
- There should be only 1 subtitle File at the end
- To be sure, test also the following things:
  - Test the editing of subtitle files
  - Test the deletion of subtitle files
  - ... Upload
  - ... Download
  - ... the creation of multiple files (different Languages)
