### PR TITLE
Disable login button in paella player

### DIFF
--- a/etc/ui-config/mh_default_org/paella7/config.json
+++ b/etc/ui-config/mh_default_org/paella7/config.json
@@ -485,7 +485,7 @@
 
         "/* videocontainer toolbar */": "*********************************************************",
         "org.opencast.paella.loginPlugin": {
-            "enabled": true,
+            "enabled": false,
             "side": "right",
             "parentContainer": "videoContainer",
             "order": 10,


### PR DESCRIPTION
The player shows a login button in the top right corner of external embeddings, if this feature is enabled and the user is not logged in. I think this function is not helpful, but rather confusing in most cases.

This patch disables this feature in the player.

![image](https://github.com/user-attachments/assets/f4239bca-2ff5-4002-abb1-ed782bf94c9f)


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
