### PR TITLE
Disable editor button in paella player

### DIFF
--- a/etc/ui-config/mh_default_org/paella7/config.json
+++ b/etc/ui-config/mh_default_org/paella7/config.json
@@ -493,7 +493,7 @@
         },
 
         "org.opencast.paella.editorPlugin": {
-            "enabled": true,
+            "enabled": false,
             "side": "right",
             "parentContainer": "videoContainer",
             "order": 20,


### PR DESCRIPTION
The player shows an editor button in the top right corner of external embeddings, if this feature is enabled and the user has right permission on the video. This allows users to edit the video in iFrames, which in my opinion is not intended.

Example in Stud.IP-Courseware:

![image](https://github.com/user-attachments/assets/2a100ed1-206e-4036-bc99-074abef71db7)
 


This patch disables the editor button.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
