### PR TITLE
Disable series button in paella player

### DIFF
--- a/etc/ui-config/mh_default_org/paella7/config.json
+++ b/etc/ui-config/mh_default_org/paella7/config.json
@@ -504,7 +504,7 @@
         },
 
         "org.opencast.paella.episodesFromSeries": {
-            "enabled": true,
+            "enabled": false,
             "side": "right",
             "parentContainer": "videoContainer",
             "order": 30,


### PR DESCRIPTION
The player shows a series button in the top right corner of external embeddings, if this feature is enabled and other videos in the same series exist. I think this feature is not useful, especially in external embeddings and in learning management systems like Stud.IP.

Example from an external embedding:

![image](https://github.com/user-attachments/assets/4d97b511-4656-4788-9c34-05f51bc092a0)


This patch removes this button.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
