### PR TITLE
Replace Ubuntu 20.04 with 22.04 for GHA work

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   deploy-documentation:
     if: github.repository_owner == 'opencast'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/test-configuration.yml
+++ b/.github/workflows/test-configuration.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test-documentation-build.yml
+++ b/.github/workflows/test-documentation-build.yml
@@ -16,7 +16,7 @@ jobs:
 
   # Check documentation with markdownlint and build it using mkdocs
   documentation:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test-lti-tools.yml
+++ b/.github/workflows/test-lti-tools.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
GitHub is removing access to the Ubuntu 20.04 images on April 1 2025, so we need to replace them with something newer(ish).  Jumping to 22.04 makes the most sense, which is what this PR does.<!--
Explain what this pull request does.  If this fixes a bug, also explain how to reproduce the issue.
-->

<!--
If your pull request is targeting the legacy (second oldest release branch), explain why this patch is so important that
it needs to go into the legacy and can not go just into stable or develop.
-->

This needs to be in legacy since we are still supporting 16.x past April 1.

<!--
Explain how to test this patch. If this requires a particular set-up or configuration, explain that as well and provide
the necessary configuration if possible. The easier it is for others to test the patch, the faster this will get
reviewed and merged.
-->


### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
