### PR TITLE
Fix endpoint /ingest/addPartialTrack

### DIFF
--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
@@ -530,7 +530,7 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
               logger.debug("Unable to parse the 'mediaPackage' parameter: {}", ExceptionUtils.getMessage(e));
               return Response.serverError().status(Status.BAD_REQUEST).build();
             }
-          } else if ("startTime".equals(fieldName) && "/addPartialTrack".equals(request.getPathInfo())) {
+          } else if ("startTime".equals(fieldName) && "/ingest/addPartialTrack".equals(request.getPathInfo())) {
             String startTimeString = Streams.asString(item.openStream(), "UTF-8");
             logger.trace("startTime: {}", startTime);
             try {

--- a/modules/ingest-service-impl/src/test/java/org/opencastproject/ingest/endpoint/IngestRestServiceTest.java
+++ b/modules/ingest-service-impl/src/test/java/org/opencastproject/ingest/endpoint/IngestRestServiceTest.java
@@ -495,12 +495,12 @@ public class IngestRestServiceTest {
     restService.setIngestService(ingestService);
 
     MockHttpServletRequest request = newPartialMockRequest();
-    request.setPathInfo("/addTrack");
+    request.setPathInfo("/ingest/addTrack");
     Response response = restService.addMediaPackageTrack(request);
     assertEquals(Status.OK.getStatusCode(), response.getStatus());
 
     request = newPartialMockRequest();
-    request.setPathInfo("/addPartialTrack");
+    request.setPathInfo("/ingest/addPartialTrack");
     response = restService.addMediaPackageTrack(request);
     assertEquals(Status.OK.getStatusCode(), response.getStatus());
     EasyMock.verify(ingestService);


### PR DESCRIPTION
The endpoint was not throwing errors, but calling the methods for "addTrack" internally, leading to unexpected behaviour. For example, for partial tracks a smil file should be generated which was not happening.
This patch should fix that.

Targeting r/17.x because the issue was introduced with 17.0 I think.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
