### PR TITLE
Fix search index rebuild

### DIFF
--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
@@ -245,10 +245,11 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
 
   private void indexMediaPackage(MediaPackage mediaPackage, AccessControlList acl)
           throws SearchException, UnauthorizedException, SearchServiceDatabaseException {
-    indexMediaPackage(mediaPackage, acl, null, null);
+    indexMediaPackage(mediaPackage, acl, null, null, securityService.getOrganization().getId());
   }
 
-  private void indexMediaPackage(MediaPackage mediaPackage, AccessControlList acl, Date modDate, Date delDate)
+  private void indexMediaPackage(MediaPackage mediaPackage, AccessControlList acl, Date modDate, Date delDate,
+      String orgId)
           throws SearchException, UnauthorizedException, SearchServiceDatabaseException {
     String mediaPackageId = mediaPackage.getIdentifier().toString();
     //If the entry has been deleted then there's *probably* no dc file to load.
@@ -275,7 +276,6 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
       }).filter(Objects::nonNull).collect(Collectors.toList());
     }
 
-    String orgId = securityService.getOrganization().getId();
     SearchResult item = new SearchResult(SearchService.IndexEntryType.Episode, dc, acl, orgId, mediaPackage,
         null != modDate ? modDate.toInstant() : Instant.now(),
         null != delDate ? delDate.toInstant() : null);
@@ -476,7 +476,7 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
             logger.debug("Updating series ACL with merged access control list: {}", seriesAcl);
 
             current.getAndIncrement();
-            indexMediaPackage(mediaPackage, acl, modificationDate, deletionDate);
+            indexMediaPackage(mediaPackage, acl, modificationDate, deletionDate, tuple.getB());
           } catch (SearchServiceDatabaseException | UnauthorizedException e) {
             logIndexRebuildError(logger, total, current.get(), e);
             //NB: Runtime exception thrown to escape the functional interfacing


### PR DESCRIPTION
The organization ID was previously retrieved inside `indexMediaPackage`, causing issues during search index rebuilding. This patch updates the method signature to explicitly pass the organization ID as a parameter, ensuring the correct organization context is maintained throughout the indexing process.

- Modify `indexMediaPackage` to accept `orgId` as a parameter
- Ensure correct `orgId` is passed from `addSynchronously` and `repopulate`

Fixes #6488

<!--
Explain what this pull request does.  If this fixes a bug, also explain how to reproduce the issue.
-->

<!--
If your pull request is targeting the legacy (second oldest release branch), explain why this patch is so important that
it needs to go into the legacy and can not go just into stable or develop.
-->

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
