### PR TITLE
Wait for OpenSearch cluster state yellow or green

### DIFF
--- a/modules/elasticsearch-impl/src/main/java/org/opencastproject/elasticsearch/impl/AbstractElasticsearchIndex.java
+++ b/modules/elasticsearch-impl/src/main/java/org/opencastproject/elasticsearch/impl/AbstractElasticsearchIndex.java
@@ -472,10 +472,13 @@ public abstract class AbstractElasticsearchIndex implements SearchIndex {
     try {
       // test connection
       ClusterHealthRequest request = new ClusterHealthRequest();
-      request.waitForGreenStatus();
+      request.waitForYellowStatus();
       ClusterHealthResponse resp = client.cluster().health(request, RequestOptions.DEFAULT);
       if (resp.getStatus().equals(ClusterHealthStatus.GREEN)) {
         logger.debug("Connected to OpenSearch, cluster health is {}", resp.getStatus());
+        return true;
+      } else if (resp.getStatus().equals(ClusterHealthStatus.YELLOW)) {
+        logger.warn("Connected to OpenSearch, cluster health is {}", resp.getStatus());
         return true;
       }
       logger.debug("Connected to OpenSearch, but cluster health is {}", resp.getStatus());


### PR DESCRIPTION
This update changes the health check to accept a yellow status. A yellow state can occur during normal operations or due to issues like node failure, and it shouldn't prevent Opencast from starting.

### How to test this patch

Without the patch Opencast will remain on hold in step 6, patiently waiting for the cluster state to transition to green before proceeding, which will not happen.

1. Start the Elasticsearch Developer Container
2. Launch Opencast
3. Once the indexing is complete, go ahead and stop the Opencast application.
4. Set Replica Count
   - Update the replica count by executing the following command:
   ```bash
   curl -XPUT -H "Content-Type: application/json" 'http://localhost:9200/_all/_settings' -d '{"index.number_of_replicas" : "1"}'
   ```
5. Check for Cluster Health
   - Verify that the cluster state is yellow by running:
   ```bash
   curl 'http://localhost:9200/_cluster/health'
   ```
6. Now, start the Opencast again to confirm that it functions correctly with the updated settings.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
