### PR TITLE
Check acl against search entity

### DIFF
--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
@@ -242,7 +242,7 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
     }
     var mediaPackageId = mediaPackage.getIdentifier().toString();
 
-    checkMPWritePermission(mediaPackageId);
+    checkSearchEntityWritePermission(mediaPackageId);
 
     logger.debug("Attempting to add media package {} to search index", mediaPackageId);
     final var acls = new AccessControlList[1];
@@ -358,12 +358,11 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
     }
   }
 
-  private void checkMPWritePermission(final String mediaPackageId) throws SearchException {
+  private void checkSearchEntityWritePermission(final String mediaPackageId) throws SearchException {
     User user = securityService.getUser();
     try {
-      MediaPackage mp = persistence.getMediaPackage(mediaPackageId);
       AccessControlList acl = persistence.getAccessControlList(mediaPackageId);
-      if (!authorizationService.hasPermission(mp, Permissions.Action.WRITE.toString())) {
+      if (!authorizationService.hasPermission(acl, Permissions.Action.WRITE.toString())) {
         boolean isAdmin = user.getRoles().stream()
             .map(Role::getName)
             .anyMatch(r -> r.equals(SecurityConstants.GLOBAL_ADMIN_ROLE));
@@ -392,7 +391,7 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
    */
   public boolean deleteSynchronously(final String mediaPackageId) throws SearchException {
 
-    checkMPWritePermission(mediaPackageId);
+    checkSearchEntityWritePermission(mediaPackageId);
 
     String deletionString = DateTimeFormatter.ISO_INSTANT.format(Instant.now());
 

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
@@ -182,7 +182,6 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
         String accessControlXml = searchEntity.get().getAccessControl();
 
         // allow ca users to retract live publications without putting them into the ACL
-        User user = securityService.getUser();
         if (!(searchMp.isLive() && currentUser.hasRole(GLOBAL_CAPTURE_AGENT_ROLE)) && accessControlXml != null) {
           AccessControlList acl = AccessControlParser.parseAcl(accessControlXml);
           if (!AccessControlUtil.isAuthorized(acl, currentUser, currentOrg, WRITE.toString(), mediaPackageId)) {
@@ -359,7 +358,6 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
         } else {
           // Ensure this user is allowed to update this media package
           // If user has ROLE_EPISODE_<ID>_WRITE, no further permission checks are necessary
-          User user = securityService.getUser();
           String accessControlXml = entity.get().getAccessControl();
           if (accessControlXml != null && entity.get().getDeletionDate() == null) {
             AccessControlList accessList = AccessControlParser.parseAcl(accessControlXml);
@@ -441,7 +439,6 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
           throw new NotFoundException("No media package with id=" + mediaPackageId + " exists");
         }
         // Ensure this user is allowed to read this media package
-        User user = securityService.getUser();
         String accessControlXml = searchEntity.get().getAccessControl();
         if (accessControlXml != null) {
           AccessControlList acl = AccessControlParser.parseAcl(accessControlXml);
@@ -476,7 +473,6 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
           throw new NotFoundException("No media package with id=" + mediaPackageId + " exists");
         }
         // Ensure this user is allowed to read this media package
-        User user = securityService.getUser();
         String accessControlXml = searchEntity.get().getAccessControl();
         if (accessControlXml != null) {
           AccessControlList acl = AccessControlParser.parseAcl(accessControlXml);
@@ -528,7 +524,6 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
           throw new NotFoundException("No media package with id=" + mediaPackageId + " exists");
         }
         // Ensure this user is allowed to read this media package
-        User user = securityService.getUser();
         String accessControlXml = searchEntity.get().getAccessControl();
         if (accessControlXml != null) {
           AccessControlList acl = AccessControlParser.parseAcl(accessControlXml);


### PR DESCRIPTION
Updated the Access Control List checking mechanism to utilize the search entity instead of relying on the filesystem.

This change ensures that ACL validation is effectively performed during retraction processes, even when filesystem data is no longer available and only search index/database table data remains.

<!--
Explain what this pull request does.  If this fixes a bug, also explain how to reproduce the issue.
-->

<!--
If your pull request is targeting the legacy (second oldest release branch), explain why this patch is so important that
it needs to go into the legacy and can not go just into stable or develop.
-->

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
