### PR TITLE
Use system user for repopulate search index

### DIFF
--- a/modules/search-service-impl/pom.xml
+++ b/modules/search-service-impl/pom.xml
@@ -67,10 +67,6 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.component</artifactId>
     </dependency>
     <dependency>

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
@@ -21,8 +21,6 @@
 
 package org.opencastproject.search.impl;
 
-import static org.opencastproject.systems.OpencastConstants.DIGEST_USER_PROPERTY;
-
 import org.opencastproject.elasticsearch.index.ElasticsearchIndex;
 import org.opencastproject.elasticsearch.index.rebuild.AbstractIndexProducer;
 import org.opencastproject.elasticsearch.index.rebuild.IndexProducer;
@@ -41,6 +39,7 @@ import org.opencastproject.search.impl.persistence.SearchServiceDatabase;
 import org.opencastproject.search.impl.persistence.SearchServiceDatabaseException;
 import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.security.api.AuthorizationService;
+import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.OrganizationDirectoryService;
 import org.opencastproject.security.api.Permissions;
 import org.opencastproject.security.api.Role;
@@ -152,7 +151,7 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
   @Activate
   public void activate(final ComponentContext cc) throws IllegalStateException {
     createIndex();
-    systemUserName = cc.getBundleContext().getProperty(DIGEST_USER_PROPERTY);
+    systemUserName = SecurityUtil.getSystemUserName(cc);
   }
 
   private void createIndex() {
@@ -244,14 +243,14 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
   }
 
   private void indexMediaPackage(MediaPackage mediaPackage, AccessControlList acl)
-          throws SearchException, UnauthorizedException, SearchServiceDatabaseException {
-    indexMediaPackage(mediaPackage, acl, null, null, securityService.getOrganization().getId());
+          throws SearchException, SearchServiceDatabaseException {
+    indexMediaPackage(mediaPackage, acl, null, null);
   }
 
-  private void indexMediaPackage(MediaPackage mediaPackage, AccessControlList acl, Date modDate, Date delDate,
-      String orgId)
-          throws SearchException, UnauthorizedException, SearchServiceDatabaseException {
+  private void indexMediaPackage(MediaPackage mediaPackage, AccessControlList acl, Date modDate, Date delDate)
+          throws SearchException, SearchServiceDatabaseException {
     String mediaPackageId = mediaPackage.getIdentifier().toString();
+    String orgId = securityService.getOrganization().getId();
     //If the entry has been deleted then there's *probably* no dc file to load.
     DublinCoreCatalog dc = null == delDate
         ? DublinCoreUtil.loadEpisodeDublinCore(workspace, mediaPackage).orElse(DublinCores.mkSimple())
@@ -452,6 +451,9 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
 
   @Override
   public void repopulate() throws IndexRebuildException {
+    final Organization originalOrg = securityService.getOrganization();
+    final User originalUser = securityService.getUser();
+
     try {
       int total = persistence.countMediaPackages();
       int pageSize = 50;
@@ -465,6 +467,11 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
         page.forEach(tuple -> {
           try {
             MediaPackage mediaPackage = tuple.getA();
+            Organization organization = organizationDirectory.getOrganization(tuple.getB());
+            final var systemUser = SecurityUtil.createSystemUser(systemUserName, organization);
+            securityService.setUser(systemUser);
+            securityService.setOrganization(organization);
+
             String mediaPackageId = mediaPackage.getIdentifier().toString();
 
             AccessControlList acl = persistence.getAccessControlList(mediaPackageId);
@@ -476,8 +483,9 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
             logger.debug("Updating series ACL with merged access control list: {}", seriesAcl);
 
             current.getAndIncrement();
-            indexMediaPackage(mediaPackage, acl, modificationDate, deletionDate, tuple.getB());
-          } catch (SearchServiceDatabaseException | UnauthorizedException e) {
+
+            indexMediaPackage(mediaPackage, acl, modificationDate, deletionDate);
+          } catch (SearchServiceDatabaseException e) {
             logIndexRebuildError(logger, total, current.get(), e);
             //NB: Runtime exception thrown to escape the functional interfacing
             throw new RuntimeException("Internal Index Rebuild Failure", e);
@@ -493,6 +501,9 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
     } catch (SearchServiceDatabaseException | RuntimeException e) {
       logIndexRebuildError(logger, e);
       throw new IndexRebuildException("Index Rebuild Failure", e);
+    } finally {
+      securityService.setUser(originalUser);
+      securityService.setOrganization(originalOrg);
     }
   }
 


### PR DESCRIPTION
The previous fix from #6490 did not fully address the issue, as the `getSeries` service is dependent on the current organization context from the `securityService`. Consequently, related series were not retrievable.

To resolve this, a switch to the corresponding system user was implemented. This change ensures that the correct organization context is used, thereby granting all necessary permissions to reindex both series and events.

Fixes https://github.com/opencast/opencast/issues/6488

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
