### PR TITLE
Unify constants for episode ID role access configuration

### DIFF
--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
@@ -32,6 +32,7 @@ import static org.opencastproject.security.api.SecurityConstants.EPISODE_ROLE_ID
 import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
 import static org.opencastproject.security.api.SecurityConstants.GLOBAL_CAPTURE_AGENT_ROLE;
 import static org.opencastproject.security.util.SecurityUtil.getEpisodeRoleId;
+import static org.opencastproject.systems.OpencastConstants.EPISODE_ID_ROLE_ACCESS_PROPERTY;
 
 import org.opencastproject.assetmanager.api.Asset;
 import org.opencastproject.assetmanager.api.AssetId;
@@ -177,7 +178,6 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
 
   private static final String MANIFEST_DEFAULT_NAME = "manifest";
 
-  private static final String CONFIG_EPISODE_ID_ROLE = "org.opencastproject.episode.id.role.access";
   private static boolean episodeIdRole = false;
 
   private CopyOnWriteArrayList<AssetManagerUpdateHandler> handlers = new CopyOnWriteArrayList<>();
@@ -224,7 +224,7 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
     includeUIRoles = BooleanUtils.toBoolean(Objects.toString(cc.getProperties().get("includeUIRoles"), null));
 
     episodeIdRole = BooleanUtils.toBoolean(Objects.toString(
-        cc.getBundleContext().getProperty(CONFIG_EPISODE_ID_ROLE), "false"));
+        cc.getBundleContext().getProperty(EPISODE_ID_ROLE_ACCESS_PROPERTY), "false"));
     logger.debug("Usage of episode ID roles is set to {}", episodeIdRole);
   }
 

--- a/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
+++ b/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
@@ -24,6 +24,7 @@ package org.opencastproject.authorization.xacml;
 import static org.opencastproject.mediapackage.MediaPackageElements.XACML_POLICY_EPISODE;
 import static org.opencastproject.mediapackage.MediaPackageElements.XACML_POLICY_SERIES;
 import static org.opencastproject.security.util.SecurityUtil.getEpisodeRoleId;
+import static org.opencastproject.systems.OpencastConstants.EPISODE_ID_ROLE_ACCESS_PROPERTY;
 import static org.opencastproject.util.data.Tuple.tuple;
 
 import org.opencastproject.mediapackage.Attachment;
@@ -94,7 +95,6 @@ public class XACMLAuthorizationService implements AuthorizationService {
   private MediaPackageSerializer serializer;
 
   private static final String CONFIG_MERGE_MODE = "merge.mode";
-  private static final String CONFIG_EPISODE_ID_ROLE = "org.opencastproject.episode.id.role.access";
 
   /** Definition of how merging of series and episode ACLs work */
   private static MergeMode mergeMode = MergeMode.OVERRIDE;
@@ -127,7 +127,7 @@ public class XACMLAuthorizationService implements AuthorizationService {
     logger.debug("Merge mode set to {}", mergeMode);
 
     episodeIdRole = BooleanUtils.toBoolean(Objects.toString(
-        cc.getBundleContext().getProperty(CONFIG_EPISODE_ID_ROLE), "false"));
+        cc.getBundleContext().getProperty(EPISODE_ID_ROLE_ACCESS_PROPERTY), "false"));
     logger.debug("Usage of episode ID roles is set to {}", episodeIdRole);
   }
 

--- a/modules/common/src/main/java/org/opencastproject/systems/OpencastConstants.java
+++ b/modules/common/src/main/java/org/opencastproject/systems/OpencastConstants.java
@@ -60,4 +60,6 @@ public interface OpencastConstants {
 
   /** The property key for the environment defined in the custom.properties */
   String ENVIRONMENT_NAME_PROPERTY = "org.opencastproject.environment.name";
+
+  String EPISODE_ID_ROLE_ACCESS_PROPERTY = "org.opencastproject.episode.id.role.access";
 }

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/ElasticsearchIndex.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/ElasticsearchIndex.java
@@ -21,6 +21,7 @@
 
 package org.opencastproject.elasticsearch.index;
 
+import static org.opencastproject.systems.OpencastConstants.EPISODE_ID_ROLE_ACCESS_PROPERTY;
 import static org.opencastproject.util.data.functions.Misc.chuck;
 
 import org.opencastproject.elasticsearch.api.SearchIndexException;
@@ -120,8 +121,6 @@ public class ElasticsearchIndex extends AbstractElasticsearchIndex {
 
   private ListProvidersService listProvidersService;
 
-  private static final String CONFIG_EPISODE_ID_ROLE = "org.opencastproject.episode.id.role.access";
-
   private boolean episodeIdRole = false;
 
   @Reference
@@ -151,7 +150,7 @@ public class ElasticsearchIndex extends AbstractElasticsearchIndex {
     }
 
     episodeIdRole = BooleanUtils.toBoolean(Objects.toString(
-        bundleContext.getProperty(CONFIG_EPISODE_ID_ROLE), "false"));
+        bundleContext.getProperty(EPISODE_ID_ROLE_ACCESS_PROPERTY), "false"));
     logger.debug("Usage of episode ID roles is set to {}", episodeIdRole);
   }
 

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
@@ -23,6 +23,7 @@ package org.opencastproject.search.impl;
 
 import static org.opencastproject.security.util.SecurityUtil.getEpisodeRoleId;
 import static org.opencastproject.systems.OpencastConstants.DIGEST_USER_PROPERTY;
+import static org.opencastproject.systems.OpencastConstants.EPISODE_ID_ROLE_ACCESS_PROPERTY;
 
 import org.opencastproject.elasticsearch.index.ElasticsearchIndex;
 import org.opencastproject.elasticsearch.index.rebuild.AbstractIndexProducer;
@@ -148,8 +149,6 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
 
   private ListProvidersService listProvidersService;
 
-  private static final String CONFIG_EPISODE_ID_ROLE = "org.opencastproject.episode.id.role.access";
-
   private boolean episodeIdRole = false;
 
   private String systemUserName = null;
@@ -170,7 +169,7 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
   @Activate
   public void activate(final ComponentContext cc) throws IllegalStateException {
     episodeIdRole = BooleanUtils.toBoolean(Objects.toString(
-        cc.getBundleContext().getProperty(CONFIG_EPISODE_ID_ROLE), "false"));
+        cc.getBundleContext().getProperty(EPISODE_ID_ROLE_ACCESS_PROPERTY), "false"));
     logger.debug("Usage of episode ID roles is set to {}", episodeIdRole);
 
     createIndex();

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
@@ -26,6 +26,7 @@ import static org.opencastproject.security.api.Permissions.Action.CONTRIBUTE;
 import static org.opencastproject.security.api.Permissions.Action.READ;
 import static org.opencastproject.security.api.Permissions.Action.WRITE;
 import static org.opencastproject.security.api.SecurityConstants.GLOBAL_CAPTURE_AGENT_ROLE;
+import static org.opencastproject.systems.OpencastConstants.EPISODE_ID_ROLE_ACCESS_PROPERTY;
 
 import org.opencastproject.db.DBSession;
 import org.opencastproject.db.DBSessionFactory;
@@ -83,8 +84,6 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
   /** JPA persistence unit name */
   public static final String PERSISTENCE_UNIT = "org.opencastproject.search.impl.persistence";
 
-  private static final String CONFIG_EPISODE_ID_ROLE = "org.opencastproject.episode.id.role.access";
-
   /** Logging utilities */
   private static final Logger logger = LoggerFactory.getLogger(SearchServiceDatabaseImpl.class);
 
@@ -124,7 +123,7 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
     this.populateSeriesData();
 
     episodeRoleId = BooleanUtils.toBoolean(Objects.toString(
-        cc.getBundleContext().getProperty(CONFIG_EPISODE_ID_ROLE), "false"));
+        cc.getBundleContext().getProperty(EPISODE_ID_ROLE_ACCESS_PROPERTY), "false"));
     logger.debug("Usage of episode ID roles is set to {}", episodeRoleId);
   }
 


### PR DESCRIPTION
#5056 introdued the feature to grant access to events by assigning the user a “magic role” based on the ID of the event.
It centralized the configuration to `etc/custom.properties` because it is needed in many different places.
However, every site of use got its own constant to refer to that property.

This patch replaces those with a central constant that lives where some of the others already live.
