### PR TITLE
Respect order of sort parameters for search queries

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -2665,7 +2665,7 @@ public abstract class AbstractEventEndpoint {
     }
 
     if (optSort.isSome()) {
-      Set<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(optSort.get());
+      ArrayList<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(optSort.get());
       for (SortCriterion criterion : sortCriteria) {
         switch (criterion.getFieldName()) {
           case EventIndexSchema.UID:

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AclEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AclEndpoint.java
@@ -88,7 +88,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import javax.ws.rs.DELETE;
 import javax.ws.rs.FormParam;
@@ -209,7 +208,7 @@ public class AclEndpoint {
 
     // Sort by name, description or role
     if (optSort.isSome()) {
-      final Set<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(optSort.get());
+      final ArrayList<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(optSort.get());
       Collections.sort(filteredAcls, new Comparator<ManagedAcl>() {
         @Override
         public int compare(ManagedAcl acl1, ManagedAcl acl2) {

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/CaptureAgentsEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/CaptureAgentsEndpoint.java
@@ -70,7 +70,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.Set;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.DELETE;
@@ -181,7 +180,7 @@ public class CaptureAgentsEndpoint {
 
     // Sort by status, name or last updated date
     if (optSort.isSome()) {
-      final Set<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(optSort.get());
+      final ArrayList<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(optSort.get());
       Collections.sort(filteredAgents, new Comparator<Agent>() {
         @Override
         public int compare(Agent agent1, Agent agent2) {

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/GroupsEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/GroupsEndpoint.java
@@ -77,7 +77,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.ws.rs.DELETE;
@@ -196,7 +195,7 @@ public class GroupsEndpoint {
     Optional<String> optNameFilter = Optional.ofNullable(filters.get(GroupsListQuery.FILTER_NAME_NAME));
     Optional<String> optTextFilter = Optional.ofNullable(filters.get(GroupsListQuery.FILTER_TEXT_NAME));
 
-    Set<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(sort);
+    ArrayList<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(sort);
 
     List<JpaGroup> results = jpaGroupRoleProvider.getGroups(optLimit, optOffset, optNameFilter, optTextFilter,
             sortCriteria);

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
@@ -135,7 +135,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.regex.Pattern;
 
 import javax.servlet.http.HttpServletResponse;
@@ -777,7 +776,7 @@ public class SeriesEndpoint {
       }
 
       if (optSort.isSome()) {
-        Set<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(optSort.get());
+        ArrayList<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(optSort.get());
         for (SortCriterion criterion : sortCriteria) {
 
           switch (criterion.getFieldName()) {

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ServicesEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ServicesEndpoint.java
@@ -61,7 +61,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import javax.servlet.http.HttpServletResponse;
@@ -170,7 +169,7 @@ public class ServicesEndpoint {
     int total = services.size();
 
     if (sortOpt.isSome()) {
-      Set<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(sortOpt.get());
+      ArrayList<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(sortOpt.get());
       if (!sortCriteria.isEmpty()) {
         try {
           SortCriterion sortCriterion = sortCriteria.iterator().next();

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ThemesEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ThemesEndpoint.java
@@ -93,7 +93,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.DELETE;
@@ -227,7 +226,7 @@ public class ThemesEndpoint {
     }
 
     if (optSort.isSome()) {
-      Set<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(optSort.get());
+      ArrayList<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(optSort.get());
       for (SortCriterion criterion : sortCriteria) {
         switch (criterion.getFieldName()) {
           case ThemeIndexSchema.NAME:

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/UsersEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/UsersEndpoint.java
@@ -256,7 +256,7 @@ public class UsersEndpoint {
 
     // Sort by name, description or role
     if (sort != null) {
-      final Set<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(sort);
+      final ArrayList<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(sort);
       filteredUsers.sort((user1, user2) -> {
         for (SortCriterion criterion : sortCriteria) {
           Order order = criterion.getOrder();

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -162,7 +162,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -890,7 +889,7 @@ public class EventsEndpoint implements ManagedService {
         }
 
         if (optSort.isSome()) {
-          Set<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(optSort.get());
+          ArrayList<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(optSort.get());
           for (SortCriterion criterion : sortCriteria) {
 
             switch (criterion.getFieldName()) {
@@ -969,7 +968,7 @@ public class EventsEndpoint implements ManagedService {
       }
     } else {
       if (optSort.isSome()) {
-        Set<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(optSort.get());
+        ArrayList<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(optSort.get());
         for (SortCriterion criterion : sortCriteria) {
 
           switch (criterion.getFieldName()) {

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/GroupsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/GroupsEndpoint.java
@@ -179,7 +179,7 @@ public class GroupsEndpoint {
     }
     Optional<String> optNameFilter = Optional.ofNullable(filters.get(GroupsListQuery.FILTER_NAME_NAME));
 
-    Set<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(sort);
+    ArrayList<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(sort);
 
     // sorting by members & roles is not supported by the database, so we do this afterwards
     Set<SortCriterion> deprecatedSortCriteria = new HashSet<>();

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
@@ -109,13 +109,13 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.Set;
 import java.util.TreeMap;
 
 import javax.servlet.http.HttpServletResponse;
@@ -307,7 +307,7 @@ public class SeriesEndpoint {
       }
 
       if (optSort.isSome()) {
-        Set<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(optSort.get());
+        ArrayList<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(optSort.get());
         for (SortCriterion criterion : sortCriteria) {
 
           switch (criterion.getFieldName()) {

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowDefinitionsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowDefinitionsEndpoint.java
@@ -66,7 +66,6 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -175,7 +174,7 @@ public class WorkflowDefinitionsEndpoint {
     // TODO: this seems to not function as intended
     ComparatorChain<WorkflowDefinition> comparator = new ComparatorChain<>();
     if (StringUtils.isNoneBlank(sort)) {
-      Set<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(sort);
+      ArrayList<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(sort);
       for (SortCriterion criterion : sortCriteria) {
         switch (criterion.getFieldName()) {
           case "identifier":

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/util/RestUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/util/RestUtils.java
@@ -48,11 +48,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.StringTokenizer;
 
 import javax.ws.rs.WebApplicationException;
@@ -221,8 +219,8 @@ public final class RestUtils {
    *          the parameter string to parse (will be checked if blank)
    * @return a set of sort criterion, never {@code null}
    */
-  public static Set<SortCriterion> parseSortQueryParameter(String sort) throws WebApplicationException {
-    Set<SortCriterion> sortOrders = new HashSet<>();
+  public static ArrayList<SortCriterion> parseSortQueryParameter(String sort) throws WebApplicationException {
+    ArrayList<SortCriterion> sortOrders = new ArrayList<>();
 
     if (StringUtils.isNotBlank(sort)) {
       StringTokenizer tokenizer = new StringTokenizer(sort, ",");

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/util/RestUtilsTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/util/RestUtilsTest.java
@@ -28,8 +28,7 @@ import org.opencastproject.util.requests.SortCriterion.Order;
 
 import org.junit.Test;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
 
 /**
  * Test methods for {@link RestUtils}
@@ -39,7 +38,7 @@ public class RestUtilsTest {
   /** Test method for {@link RestUtils#parseSortQueryParameter(String)} */
   @Test
   public void testParseSortQueryParameter() {
-    Set<SortCriterion> sortOrders = new HashSet<SortCriterion>();
+    ArrayList<SortCriterion> sortOrders = new ArrayList<SortCriterion>();
 
     sortOrders.add(new SortCriterion("name", Order.Descending));
     assertTrue(RestUtils.parseSortQueryParameter("name:DESC").equals(sortOrders));

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaGroupRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaGroupRoleProvider.java
@@ -493,7 +493,7 @@ public class JpaGroupRoleProvider implements AAIRoleProvider, GroupProvider, Gro
    * @return a list of groups
    */
   public List<JpaGroup> getGroups(Optional<Integer> limit, Optional<Integer> offset, Optional<String> nameFilter,
-          Optional<String> textFilter, Set<SortCriterion> sortCriteria) {
+          Optional<String> textFilter, ArrayList<SortCriterion> sortCriteria) {
     String orgId = securityService.getOrganization().getId();
     return db.exec(UserDirectoryPersistenceUtil.findGroupsQuery(orgId, limit, offset, nameFilter, textFilter,
         sortCriteria));

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserDirectoryPersistenceUtil.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserDirectoryPersistenceUtil.java
@@ -246,7 +246,7 @@ public final class UserDirectoryPersistenceUtil {
    */
   public static Function<EntityManager, List<JpaGroup>> findGroupsQuery(String orgId, Optional<Integer> limit,
       Optional<Integer> offset, Optional<String> nameFilter, Optional<String> textFilter,
-      Set<SortCriterion> sortCriteria) {
+      ArrayList<SortCriterion> sortCriteria) {
     return em -> {
       CriteriaBuilder cb = em.getCriteriaBuilder();
       final CriteriaQuery<JpaGroup> query = cb.createQuery(JpaGroup.class);


### PR DESCRIPTION
Fixes an issue where the sort order of the results of an elasticsearch query would be wrong if multiple sort parameters were specified.
Since the order of the sort parameters in a query matters, our code should respect the ordering of sort parameters. Hence I switched the unordered collection we were using for an ordered one.

### How to test this

Can for example be tested with a query like this: admin-ng/event/events.json?limit=10&offset=0&sort=title:DESC,uid:asc

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
