### PR TITLE
 Update Documentation for Latest Docker Compose Usage

### DIFF
--- a/docs/guides/admin/docs/installation/docker-local.md
+++ b/docs/guides/admin/docs/installation/docker-local.md
@@ -48,10 +48,10 @@ You might want to edit the compose file and add extra volumes to include custom 
 At this point you are ready to start Opencast with the `up` command:
 
 ```sh
-$ docker-compose up
+$ docker compose up
 ```
 
-After downloading the necessary Docker images, `docker-compose` should start all relevant services and you should see
+After downloading the necessary Docker images, `docker compose` should start all relevant services and you should see
 the logging output. Alternatively, adding the `-d` flag will start Opencast in the background and hide the log messages.
 The admin UI is available at <http://localhost:8080>.
 


### PR DESCRIPTION
This pull request updates the documentation to clarify the usage of the docker compose up command, which is required due to the recent implementation of the `dockerfile_inline feature` in compose file. This feature is only supported in the latest version of Docker Compose. Please use the `docker compose up` command instead of `docker-compose up`.
I am currently employed at Elan and I have made these changes to ensure that new users receive accurate and up-to-date information.
