### PR TITLE
Revert org.apache.santuario upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <rest-assured.version>4.4.0</rest-assured.version>
     <spring.version>3.1.4.RELEASE</spring.version>
     <spring-security.version>3.1.7.RELEASE</spring-security.version>
-    <xmlsec.version>4.0.2</xmlsec.version>
+    <xmlsec.version>2.2.6</xmlsec.version>
   </properties>
   <modules>
     <module>modules/admin-ui</module>


### PR DESCRIPTION
This reverts commit 77fab3349f36d71aa9aa9ea9b0614849b9bcb1b3, which upgraded org.apache.santuario.  The issue with this is that CAS will not start with the upgraded version since it requires `jakarta.xml.bind>=4.0.0` and that conflicts with... well, most of our other dependencies.

Fixes #6477.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [z] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
