### PR TITLE
Changing Logger Level for Jetty 

### DIFF
--- a/etc/org.ops4j.pax.logging.cfg
+++ b/etc/org.ops4j.pax.logging.cfg
@@ -37,6 +37,8 @@ log4j2.logger.felix.name = org.apache.felix
 log4j2.logger.felix.level = WARN
 log4j2.logger.cxf.name = org.apache.cxf
 log4j2.logger.cxf.level = WARN
+log4j2.logger.jetty.name = org.eclipse.jetty
+log4j2.logger.jetty.level = ERROR
 
 # Appenders configuration
 

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/DelegatingAuthenticationEntryPoint.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/DelegatingAuthenticationEntryPoint.java
@@ -63,7 +63,7 @@ public class DelegatingAuthenticationEntryPoint implements AuthenticationEntryPo
       // if the user attempted to access a url other than /, store this in the session so we can forward the user there
       // after a successful login
       String requestUri = null;
-      if (!request.getRequestURI().contains(".json")) {
+      if (!request.getRequestURI().contains("health") && !request.getRequestURI().contains("stats")) {
         requestUri = request.getRequestURI();
       }
       String queryString = request.getQueryString();

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/DelegatingAuthenticationEntryPoint.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/DelegatingAuthenticationEntryPoint.java
@@ -62,9 +62,12 @@ public class DelegatingAuthenticationEntryPoint implements AuthenticationEntryPo
     } else {
       // if the user attempted to access a url other than /, store this in the session so we can forward the user there
       // after a successful login
-      String requestUri = request.getRequestURI();
+      String requestUri = null;
+      if (!request.getRequestURI().contains(".json")) {
+        requestUri = request.getRequestURI();
+      }
       String queryString = request.getQueryString();
-      if (requestUri != null && !requestUri.isEmpty() & !"/".equals(requestUri)) {
+      if (requestUri != null && !requestUri.isEmpty() && !"/".equals(requestUri)) {
         if (queryString == null) {
           request.getSession().setAttribute(INITIAL_REQUEST_PATH, requestUri);
         } else {


### PR DESCRIPTION
Stopping and restarting Opencast, while having it open in the browser, leads to the following Jetty Warnings: `Session <sessionID> already in cache`  and  `Create session failed` .  This warning is triggered in the `DelegatingAuthenticationEntryPoint.java`  when the server tries to create a new session (via `HttpServletRequest.getSession()`) with the sessionID it got from the Cookie.

A similar issue was already reported to Jetty (e.g https://github.com/jetty/jetty.project/issues/4888), but it seems that at least within the Jetty version (9.4.57)  we are currently using for Opencast this warning is still occurring. (Reporting this issue again is not necessary, since jetty 9 is EOL since Jan 25)

As far as I understood, the session is maintained via cookies. After seeing in the opencast.log that after restarting the server the old session can be entered and the expiration timer is reset for it, I assume that the `Create session failed` warning does not have any negative consequences for the session maintenance. 

When stopping and restarting Opencast, while having it open in the browser, the user can see that network errors are occurring, at `System warnings and notifications`  on the menu bar. After a while the user is automatically forwarded to the login page, but after logging in the user is sometimes forwarded to `health.json` or `STATS.json . To avoid this I edited the user forwarding in the `DelegatingAuthenticationEntryPoint.java`.
