### PR TITLE
Don't fail theme index rebuild if user does not exist

### DIFF
--- a/modules/themes/src/main/java/org/opencastproject/themes/persistence/ThemesServiceDatabaseImpl.java
+++ b/modules/themes/src/main/java/org/opencastproject/themes/persistence/ThemesServiceDatabaseImpl.java
@@ -423,8 +423,10 @@ public class ThemesServiceDatabaseImpl extends AbstractIndexProducer implements 
     return (Optional<IndexTheme> indexThemeOpt) -> {
       IndexTheme indexTheme;
       indexTheme = indexThemeOpt.orElseGet(() -> new IndexTheme(theme.getId().get(), orgId));
-      String creator = StringUtils.isNotBlank(theme.getCreator().getName())
-              ? theme.getCreator().getName() : theme.getCreator().getUsername();
+      String creator = theme.getCreator() == null ? "?" : (
+          StringUtils.isNotBlank(theme.getCreator().getName())
+              ? theme.getCreator().getName()
+              : theme.getCreator().getUsername());
 
       indexTheme.setCreationDate(theme.getCreationDate());
       indexTheme.setDefault(theme.isDefault());


### PR DESCRIPTION
If the user who created a theme does no longer exist, the index rebuild will fail with a NullPointerException. This patch fixes the problem by providing an empty string instead.

```
2025-03-18T11:35:30,113 | ERROR | (AbstractIndexProducer:186) - Error updating the Themes index.
java.lang.NullPointerException: Cannot invoke "org.opencastproject.security.api.User.getName()" because the return value of "org.opencastproject.themes.Theme.getCreator()" is null
        at org.opencastproject.themes.persistence.ThemesServiceDatabaseImpl.lambda$getThemeUpdateFunction$9(ThemesServiceDatabaseImpl.java:426) ~[?:?]
        at org.opencastproject.themes.persistence.ThemesServiceDatabaseImpl.repopulate(ThemesServiceDatabaseImpl.java:316) ~[?:?]
        at org.opencastproject.elasticsearch.index.rebuild.IndexRebuildService.rebuildIndexInternal(IndexRebuildService.java:213) ~[?:?]
        at org.opencastproject.elasticsearch.index.rebuild.IndexRebuildService.rebuildIndex(IndexRebuildService.java:158) ~[?:?]
        at org.opencastproject.elasticsearch.index.endpoint.IndexEndpoint.lambda$rebuildIndex$5(IndexEndpoint.java:240) ~[?:?]
        at org.opencastproject.security.util.SecurityContext.lambda$runInContext$0(SecurityContext.java:68) ~[?:?]
        at org.opencastproject.security.util.SecurityContext.runInContext(SecurityContext.java:58) ~[?:?]
        at org.opencastproject.security.util.SecurityContext.runInContext(SecurityContext.java:67) ~[?:?]
        at org.opencastproject.elasticsearch.index.endpoint.IndexEndpoint.lambda$rebuildIndex$6(IndexEndpoint.java:237) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
        at java.lang.Thread.run(Thread.java:840) [?:?]
2025-03-18T11:35:30,113 | ERROR | (IndexEndpoint:242) - Repopulating the index failed
org.opencastproject.elasticsearch.index.rebuild.IndexRebuildException: Error updating the index for service Themes
        at org.opencastproject.themes.persistence.ThemesServiceDatabaseImpl.repopulate(ThemesServiceDatabaseImpl.java:332) ~[?:?]
        at org.opencastproject.elasticsearch.index.rebuild.IndexRebuildService.rebuildIndexInternal(IndexRebuildService.java:213) ~[?:?]
        at org.opencastproject.elasticsearch.index.rebuild.IndexRebuildService.rebuildIndex(IndexRebuildService.java:158) ~[?:?]
        at org.opencastproject.elasticsearch.index.endpoint.IndexEndpoint.lambda$rebuildIndex$5(IndexEndpoint.java:240) ~[?:?]
        at org.opencastproject.security.util.SecurityContext.lambda$runInContext$0(SecurityContext.java:68) ~[?:?]
        at org.opencastproject.security.util.SecurityContext.runInContext(SecurityContext.java:58) ~[?:?]
        at org.opencastproject.security.util.SecurityContext.runInContext(SecurityContext.java:67) ~[?:?]
        at org.opencastproject.elasticsearch.index.endpoint.IndexEndpoint.lambda$rebuildIndex$6(IndexEndpoint.java:237) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
        at java.lang.Thread.run(Thread.java:840) [?:?]
Caused by: java.lang.NullPointerException: Cannot invoke "org.opencastproject.security.api.User.getName()" because the return value of "org.opencastproject.themes.Theme.getCreator()" is null
        at org.opencastproject.themes.persistence.ThemesServiceDatabaseImpl.lambda$getThemeUpdateFunction$9(ThemesServiceDatabaseImpl.java:426) ~[?:?]
        at org.opencastproject.themes.persistence.ThemesServiceDatabaseImpl.repopulate(ThemesServiceDatabaseImpl.java:316) ~[?:?]
        ... 10 more
```

### How to test this patch

- Enable themes
- Create a user
- As that user, create a theme
- Delete the user
- Clear the index
- Rebuild the themes index


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
