### PR TITLE
Log Publications Blocking Event Deletion

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/util/RetractionListener.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/util/RetractionListener.java
@@ -61,8 +61,9 @@ public final class RetractionListener implements WorkflowListener {
               workflow.getTitle(), workflow.getId(), workflow.getCreatorName());
     } else if (mediaPackage.getPublications() != null && mediaPackage.getPublications().length > 0) {
       logger.warn("The retract workflow \"{}\" (id: {}, created by: {}, media package {}) "
-                      + "has some non-retracted publications, refusing to orphan them.",
-              workflow.getTitle(), workflow.getId(), workflow.getCreatorName(), mediaPackage.getIdentifier().toString());
+              + "has some non-retracted publications, refusing to orphan them. Remaining publications: {}",
+          workflow.getTitle(), workflow.getId(), workflow.getCreatorName(), mediaPackage.getIdentifier(),
+          mediaPackage.getPublications());
     } else {
       final Retraction retraction = retractions.get(workflow.getId());
       SecurityUtil.runAs(securityService, retraction.getOrganization(), retraction.getUser(), () -> {


### PR DESCRIPTION
If you click on “Delete” in the admin interface, Opencast will try to delete the given event, but refuse to actually delete it if not all publications are retracted as part of the started workflow.

Unfortunately, Opencast does not tell you anything about what publications are blocking the deletion. That's annoying if you want to debug why an event is not being deleted.

This patch adds a list of publications blocking the deletion to the logs.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
