### PR TITLE
Don't fail removal on already deleted workflow

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -1497,14 +1497,24 @@ public class IndexServiceImpl implements IndexService {
       if (workflowInstances.isEmpty()) {
         notFoundWorkflow = true;
       } else {
+        var toRemove = workflowInstances.size();
         for (WorkflowInstance instance : workflowInstances) {
-          workflowService.stop(instance.getId());
-          workflowService.remove(instance.getId());
+          try {
+            workflowService.stop(instance.getId());
+            workflowService.remove(instance.getId());
+            toRemove--;
+          } catch (WorkflowDatabaseException e) {
+            if (e.getCause() instanceof  NotFoundException) {
+              // Someone already removed this. That's fine. Continue with the next workflow
+              logger.warn("Workflow {} has already been removed", instance.getId());
+            } else {
+              throw e;
+            }
+          }
         }
-        removedWorkflow = true;
+        removedWorkflow = toRemove == 0;
+        notFoundWorkflow = toRemove >= 1;
       }
-    } catch (NotFoundException e) {
-      notFoundWorkflow = true;
     } catch (UnauthorizedException e) {
       unauthorizedWorkflow = true;
     } catch (WorkflowException e) {


### PR DESCRIPTION
If you try to delete an event, but one of it's workflows has no job in the database because it has already been deleted for whatever reason, the whole process will fail. Since we want it to be deleted, this should just acknowledge that the event is already gone and continue.


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
