### PR TITLE
Remove mentions of SysV Init scripts

### DIFF
--- a/docs/guides/admin/docs/installation/source-linux.md
+++ b/docs/guides/admin/docs/installation/source-linux.md
@@ -155,21 +155,3 @@ Start Opencast and make it run automatically:
     systemctl start opencast.service
     systemctl enable opencast.service
 
-### Using SysV-Init
-
-> Note that this option is for compatibility to older systems. If you have the choice of either using the Systemd unit
-> file or the Init script, it is recommended to use the Systemd unit file.
-
-Make sure the path to Opencast is set correctly:
-
-    vim docs/scripts/service/etc-init.d-opencast
-
-1. Install init script:
-
-        cp docs/scripts/service/etc-init.d-opencast /etc/init.d/opencast
-
-2. Enable service using `chkconfig` or `update-rc.d`
-
-3. Start Opencast using
-
-        service opencast start

--- a/docs/guides/developer/docs/participate/infrastructure/packaging.md
+++ b/docs/guides/developer/docs/participate/infrastructure/packaging.md
@@ -43,10 +43,6 @@ The following locations should be used for Opencast and its related data:
 * `/tmp/opencast`:
   Temporary data which are not necessarily preserved between reboots. This includes the felix-cache and other temporary
   data.
-* `/usr/sbin/opencast`:
-  Opencast startscript
-* `/etc/init.d/opencast`
-  SysV-Initscript (if necessary)
 
 
 Reasoning for these Locations


### PR DESCRIPTION
This PR removes the remaining mentions of sysv init scripts.  They're gone in 17.x, possibly earlier.  Also removed a reference to sbin, which (from what I can see) neither the debs nor the rpms use.

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] ~explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch~
