### PR TITLE
Set sender value in sent emails if set

### DIFF
--- a/modules/kernel/src/main/java/org/opencastproject/kernel/mail/BaseSmtpService.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/mail/BaseSmtpService.java
@@ -151,6 +151,10 @@ public class BaseSmtpService {
     this.sender = sender;
   }
 
+  public String getSender() {
+    return this.sender;
+  }
+
   public void setSsl(boolean ssl) {
     this.ssl = ssl;
   }

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/mail/SmtpService.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/mail/SmtpService.java
@@ -304,6 +304,9 @@ public class SmtpService extends BaseSmtpService implements ManagedService {
     }
 
     MimeMessage message = createMessage();
+    if (StringUtils.isNotBlank(getSender())) {
+      message.addFrom(new InternetAddress[] { new InternetAddress(getSender()) });
+    }
     addRecipients(message, RecipientType.TO, to);
     addRecipients(message, RecipientType.CC, cc);
     addRecipients(message, RecipientType.BCC, bcc);


### PR DESCRIPTION
As reported in #6554, we're not setting the sender field in sent emails.  This is actually required per RFC 822.

Fixes #6554

<!--
Explain what this pull request does.  If this fixes a bug, also explain how to reproduce the issue.
-->

<!--
If your pull request is targeting the legacy (second oldest release branch), explain why this patch is so important that
it needs to go into the legacy and can not go just into stable or develop.
-->

### How to test this patch

Send some emails from @stefanosgeo's systems.  I can't reproduce, since gmail doesn't seem to care :D
<!--
Explain how to test this patch. If this requires a particular set-up or configuration, explain that as well and provide
the necessary configuration if possible. The easier it is for others to test the patch, the faster this will get
reviewed and merged.
-->


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [i] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] ~explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch~
