### PR TITLE
Switch to OpenMetrics

### DIFF
--- a/modules/metrics-exporter/src/main/java/org/opencastproject/metrics/impl/MetricsExporter.java
+++ b/modules/metrics-exporter/src/main/java/org/opencastproject/metrics/impl/MetricsExporter.java
@@ -216,7 +216,7 @@ public class MetricsExporter {
 
     // collect metrics
     final StringWriter writer = new StringWriter();
-    TextFormat.write004(writer, registry.metricFamilySamples());
+    TextFormat.writeOpenMetrics100(writer, registry.metricFamilySamples());
     return Response.ok().entity(writer.toString()).build();
   }
 

--- a/modules/metrics-exporter/src/test/java/org/opencastproject/metrics/impl/MetricsExporterTest.java
+++ b/modules/metrics-exporter/src/test/java/org/opencastproject/metrics/impl/MetricsExporterTest.java
@@ -101,7 +101,7 @@ public class MetricsExporterTest {
 
     // test exporter
     final String body = exporter.metrics().getEntity().toString();
-    Assert.assertTrue(body.contains("opencast_job_load_max{host=\"opencast.org\",} 12.3"));
-    Assert.assertTrue(body.contains("opencast_asset_manager_events{organization=\"mh_default_org\",} 5.0"));
+    Assert.assertTrue(body.contains("opencast_job_load_max{host=\"opencast.org\"} 12.3"));
+    Assert.assertTrue(body.contains("opencast_asset_manager_events{organization=\"mh_default_org\"} 5.0"));
   }
 }


### PR DESCRIPTION
This patch makes our metrics endpoint deliver metrics in the OpenMetrics format. The Prometheus format and OpenMetrics are nearly identical, but the latter is an open standard after all and Prometheus can read both.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
