### PR TITLE
Add asset manager endpoint to trigger event index update

### DIFF
--- a/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/AssetManager.java
+++ b/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/AssetManager.java
@@ -24,6 +24,7 @@ import org.opencastproject.assetmanager.api.query.AQueryBuilder;
 import org.opencastproject.assetmanager.api.query.RichAResult;
 import org.opencastproject.assetmanager.api.storage.AssetStore;
 import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.util.NotFoundException;
 
 import java.util.Date;
@@ -360,4 +361,12 @@ public interface AssetManager {
    * @return Number of events
    */
   long countEvents(String organization);
+
+  /**
+   * Trigger search index update for event.
+   *
+   * @param mediaPackageId
+   *          The event ID to trigger an index update for
+   */
+  void triggerIndexUpdate(String mediaPackageId) throws NotFoundException, UnauthorizedException;
 }

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
@@ -516,6 +516,24 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
             version, snapshot.getArchivalDate());
   }
 
+  @Override
+  public void triggerIndexUpdate(String mediaPackageId) throws NotFoundException, UnauthorizedException {
+
+    if (!securityService.getUser().hasRole("ROLE_ADMIN")) {
+      throw new UnauthorizedException("Only global administrators may trigger manual event updates.");
+    }
+    final AQueryBuilder q = createQuery();
+    final AResult r = q.select(q.snapshot()).where(q.mediaPackageId(mediaPackageId).and(q.version().isLatest())).run();
+
+    if (r.getSize() == 0) {
+      throw new NotFoundException("No event with ID `" + mediaPackageId + "`");
+    }
+
+    // Update event index with latest snapshot
+    var snapshot = r.getRecords().stream().findFirst().get().getSnapshot().get();
+    updateEventInIndex(snapshot);
+  }
+
   /**
    * Update the event in the Elasticsearch index.
    *

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/endpoint/AbstractAssetManagerRestEndpoint.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/endpoint/AbstractAssetManagerRestEndpoint.java
@@ -51,6 +51,7 @@ import org.opencastproject.rest.AbstractJobProducerEndpoint;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.util.Checksum;
 import org.opencastproject.util.ChecksumType;
+import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.data.Option;
 import org.opencastproject.util.doc.rest.RestParameter;
 import org.opencastproject.util.doc.rest.RestParameter.Type;
@@ -160,6 +161,40 @@ public abstract class AbstractAssetManagerRestEndpoint extends AbstractJobProduc
     try {
       getAssetManager().takeSnapshot(DEFAULT_OWNER, mediaPackage);
       return noContent();
+    } catch (Exception e) {
+      return handleException(e);
+    }
+  }
+
+  @POST
+  @Path("updateIndex")
+  @RestQuery(name = "updateIndex",
+      description = "Trigger search index update for event. The usage of this is limited to global administrators.",
+      restParameters = {
+          @RestParameter(
+              name = "id",
+              isRequired = true,
+              type = STRING,
+              description = "The event ID to trigger an index update for.")},
+      responses = {
+          @RestResponse(
+              description = "Update successfully triggered.",
+              responseCode = SC_NO_CONTENT),
+          @RestResponse(
+              description = "Not allowed to trigger update.",
+              responseCode = SC_FORBIDDEN),
+          @RestResponse(
+              description = "No such event found.",
+              responseCode = SC_NOT_FOUND)},
+      returnDescription = "No content is returned.")
+  public Response indexUpdate(@FormParam("id") final String id) {
+    try {
+      getAssetManager().triggerIndexUpdate(id);
+      return noContent();
+    } catch (UnauthorizedException e) {
+      return forbidden();
+    } catch (NotFoundException e) {
+      return notFound();
     } catch (Exception e) {
       return handleException(e);
     }


### PR DESCRIPTION
This patch adds a REST endpoint to allow admins to trigger index updates for single events. While this is usually not necessary (hence limiting this to admins), this can be really helpful when fixing broken events and avoids weird workarounds.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
