### PR TITLE
Handle workflows without creator

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -1911,7 +1911,7 @@ public abstract class AbstractEventEndpoint {
           Date created = instance.getDateCreated();
           String submitter = instance.getCreatorName();
 
-          User user = getUserDirectoryService().loadUser(submitter);
+          User user = submitter == null ? null : getUserDirectoryService().loadUser(submitter);
           String submitterName = null;
           String submitterEmail = null;
           if (user != null) {

--- a/modules/admin-ui/src/test/resources/eventWorkflows.json
+++ b/modules/admin-ui/src/test/resources/eventWorkflows.json
@@ -16,8 +16,8 @@
             "status": "EVENTS.EVENTS.DETAILS.WORKFLOWS.OPERATION_STATUS.INSTANTIATED",
             "submitted": "2014-06-05T15:00:00Z",
             "submitter": "",
-            "submitterName": "WithPermissions",
-            "submitterEmail": "with@permissions.com"
+            "submitterName": "",
+            "submitterEmail": ""
         },
         {
             "id": 3,
@@ -25,8 +25,8 @@
             "status": "EVENTS.EVENTS.DETAILS.WORKFLOWS.OPERATION_STATUS.INSTANTIATED",
             "submitted": "2014-06-05T15:00:00Z",
             "submitter": "",
-            "submitterName": "WithPermissions",
-            "submitterEmail": "with@permissions.com"
+            "submitterName": "",
+            "submitterEmail": ""
         }
     ]
 }


### PR DESCRIPTION
We have thousands of (older) workflows without creator in Opencast. Right now, trying to interact with the workflow parts of the event details in the admin interface causes huge stack traces in the logs while the UI just doesn't work.

This patch gracefully handles a creator being null.

```
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:315) [!/:9.4.54.v20240208]
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:173) [!/:9.4.54.v20240208]
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131) [!/:9.4.54.v20240208]
        at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:409) [!/:9.4.54.v20240208]
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:883) [!/:9.4.54.v20240208]
        at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1034) [!/:9.4.54.v20240208]
        at java.lang.Thread.run(Thread.java:840) [?:?]
Caused by: com.google.common.util.concurrent.UncheckedExecutionException: java.lang.NullPointerException
        at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2085) ~[?:?]
        at com.google.common.cache.LocalCache.get(LocalCache.java:4017) ~[?:?]
        at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:4040) ~[?:?]
        at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4989) ~[?:?]
        at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:4996) ~[?:?]
        at org.opencastproject.userdirectory.UserAndRoleDirectoryServiceImpl.loadUser(UserAndRoleDirectoryServiceImpl.java:265) ~[?:?]
        at org.opencastproject.adminui.endpoint.AbstractEventEndpoint.getEventWorkflows(AbstractEventEndpoint.java:1914) ~[?:?]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:569) ~[?:?]
        at org.apache.cxf.service.invoker.AbstractInvoker.performInvocation(AbstractInvoker.java:179) ~[?:?]
        at org.apache.cxf.service.invoker.AbstractInvoker.invoke(AbstractInvoker.java:96) ~[?:?]
        ... 139 more
Caused by: java.lang.NullPointerException
```

Removed 90% of the logs due to size limitations.
But this shows the relevant parts.

<!--
Explain what this pull request does.  If this fixes a bug, also explain how to reproduce the issue.
-->

<!--
If your pull request is targeting the legacy (second oldest release branch), explain why this patch is so important that
it needs to go into the legacy and can not go just into stable or develop.
-->

### How to test this patch

<!--
Explain how to test this patch. If this requires a particular set-up or configuration, explain that as well and provide
the necessary configuration if possible. The easier it is for others to test the patch, the faster this will get
reviewed and merged.
-->


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
