### PR TITLE
Prevent errors when shutting down Opencast

### DIFF
--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/internal/RestServiceTracker.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/internal/RestServiceTracker.java
@@ -103,17 +103,20 @@ public class RestServiceTracker extends ServiceTracker<Object, Object> {
     @Override
     public void removedService(ServiceReference reference, Object service) {
         String serviceType = (String) reference.getProperty(RestConstants.SERVICE_TYPE_PROPERTY);
-        boolean publishFlag = (Boolean) reference.getProperty(RestConstants.SERVICE_PUBLISH_PROPERTY);
+        boolean publishFlag = Boolean.parseBoolean(Objects.toString(
+            reference.getProperty(RestConstants.SERVICE_PUBLISH_PROPERTY),
+            "true"));
 
         // Services that have the "publish" flag set to "true" have been registered before.
         if (publishFlag) {
             try {
                 serviceRegistry.unRegisterService(serviceType, serviceRegistry.getRegistryHostname());
             } catch (ServiceRegistryException e) {
-                logger.warn("Unable to unregister job producer of type " + serviceType + " on host " + serviceRegistry.getRegistryHostname());
+                logger.warn("Unable to unregister job producer of type {} on host {}",
+                    serviceType, serviceRegistry.getRegistryHostname());
             }
         } else {
-            logger.trace("Service " + reference + " was never registered");
+            logger.trace("Service {} was never registered", reference);
         }
 
         super.removedService(reference, service);


### PR DESCRIPTION
This patch fixes NullPointerExceptions spamming the Opencast log when shutting down Opencast due to a property which may be (and usually is) `null` being cast to a Boolean.

At the other places we read the value there is a default value of `true` if this is `null`. This patch adds it to the code for unregistering services as well, fixing the exceptions.

```
2025-03-28T01:15:30,845 | ERROR | (Main$2:361) - Bundle opencast-serviceregistry [176] EventDispatcher: Error during dispatch. (java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because the return value of "
org.osgi.framework.ServiceReference.getProperty(String)" is null)
java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because the return value of "org.osgi.framework.ServiceReference.getProperty(String)" is null
        at org.opencastproject.serviceregistry.internal.RestServiceTracker.removedService(RestServiceTracker.java:106) ~[?:?]
        at org.osgi.util.tracker.ServiceTracker$Tracked.customizerRemoved(ServiceTracker.java:969) ~[osgi.core-8.0.0.jar:?]
        at org.osgi.util.tracker.ServiceTracker$Tracked.customizerRemoved(ServiceTracker.java:871) ~[osgi.core-8.0.0.jar:?]
        at org.osgi.util.tracker.AbstractTracked.untrack(AbstractTracked.java:341) ~[osgi.core-8.0.0.jar:?]
        at org.osgi.util.tracker.ServiceTracker$Tracked.serviceChanged(ServiceTracker.java:911) ~[osgi.core-8.0.0.jar:?]
        at org.apache.felix.framework.EventDispatcher.invokeServiceListenerCallback(EventDispatcher.java:990) ~[?:?]
        at org.apache.felix.framework.EventDispatcher.fireEventImmediately(EventDispatcher.java:838) ~[?:?]
        at org.apache.felix.framework.EventDispatcher.fireServiceEvent(EventDispatcher.java:545) ~[?:?]
        at org.apache.felix.framework.Felix.fireServiceEvent(Felix.java:4863) ~[?:?]
        at org.apache.felix.framework.Felix.access$000(Felix.java:111) ~[?:?]
        at org.apache.felix.framework.Felix$1.serviceChanged(Felix.java:440) ~[?:?]
        at org.apache.felix.framework.ServiceRegistry.unregisterService(ServiceRegistry.java:170) ~[?:?]
        at org.apache.felix.framework.ServiceRegistrationImpl.unregister(ServiceRegistrationImpl.java:146) ~[?:?]
        at org.apache.felix.scr.impl.manager.AbstractComponentManager$3.unregister(AbstractComponentManager.java:952) ~[?:?]
        at org.apache.felix.scr.impl.manager.AbstractComponentManager$3.unregister(AbstractComponentManager.java:915) ~[?:?]
        at org.apache.felix.scr.impl.manager.RegistrationManager.changeRegistration(RegistrationManager.java:140) ~[?:?]
        at org.apache.felix.scr.impl.manager.AbstractComponentManager.unregisterService(AbstractComponentManager.java:994) ~[?:?]
        at org.apache.felix.scr.impl.manager.AbstractComponentManager.doDeactivate(AbstractComponentManager.java:844) ~[?:?]
        at org.apache.felix.scr.impl.manager.AbstractComponentManager.deactivateInternal(AbstractComponentManager.java:825) ~[?:?]
        at org.apache.felix.scr.impl.manager.AbstractComponentManager.dispose(AbstractComponentManager.java:589) ~[?:?]
        at org.apache.felix.scr.impl.manager.ConfigurableComponentHolder.disposeComponents(ConfigurableComponentHolder.java:722) ~[?:?]
        at org.apache.felix.scr.impl.BundleComponentActivator.dispose(BundleComponentActivator.java:492) ~[?:?]
        at org.apache.felix.scr.impl.Activator.disposeComponents(Activator.java:652) ~[?:?]
        at org.apache.felix.scr.impl.Activator.access$300(Activator.java:74) ~[?:?]
        at org.apache.felix.scr.impl.Activator$ScrExtension.destroy(Activator.java:490) ~[?:?]
        at org.apache.felix.scr.impl.AbstractExtender$1.run(AbstractExtender.java:216) ~[?:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572) ~[?:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java:317) ~[?:?]
        at org.apache.felix.scr.impl.AbstractExtender.destroyExtension(AbstractExtender.java:238) ~[?:?]
        at org.apache.felix.scr.impl.AbstractExtender.bundleChanged(AbstractExtender.java:132) ~[?:?]
        at org.apache.felix.scr.impl.Activator.bundleChanged(Activator.java:255) ~[?:?]
        at org.apache.felix.framework.EventDispatcher.invokeBundleListenerCallback(EventDispatcher.java:915) ~[?:?]
        at org.apache.felix.framework.EventDispatcher.fireEventImmediately(EventDispatcher.java:834) ~[?:?]
        at org.apache.felix.framework.EventDispatcher.fireBundleEvent(EventDispatcher.java:516) ~[?:?]
        at org.apache.felix.framework.Felix.fireBundleEvent(Felix.java:4847) ~[?:?]
        at org.apache.felix.framework.Felix.stopBundle(Felix.java:2812) ~[?:?]
        at org.apache.felix.framework.Felix.setActiveStartLevel(Felix.java:1584) ~[?:?]
        at org.apache.felix.framework.FrameworkStartLevelImpl.run(FrameworkStartLevelImpl.java:297) ~[?:?]
        at java.lang.Thread.run(Thread.java:1583) [?:?]
```

This fixes #6579

### How to test this patch

- Run Opencast
- `tail -f data/log/opencast.log`
- Shut down Opencast
- The exception above should no longer appear


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch