### PR TITLE
Fix adopter statistic breaking on non-set metadata

### DIFF
--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
@@ -306,8 +306,9 @@ public class ScheduledDataCollector extends TimerTask {
                     .mustNot(QueryBuilders.existsQuery(SearchResult.DELETED_DATE)));
         final SearchResultList results = searchService.search(q);
         long orgMilis = results.getHits().stream().map(
-                result -> EncodingSchemeUtils.decodeDuration(
-                    result.getDublinCore().getFirst(DublinCore.PROPERTY_EXTENT)))
+                result -> EncodingSchemeUtils.decodeDuration(Objects.toString(
+                    result.getDublinCore().getFirst(DublinCore.PROPERTY_EXTENT),
+                    "0")))
             .filter(Objects::nonNull)
             .reduce(Long::sum).orElse(0L);
         statisticData.setTotalMinutes(statisticData.getTotalMinutes() + (orgMilis / 1000 / 60));


### PR DESCRIPTION
The duration metadata field is not required for publication and therefor may not exists. This can lead to NullPointerExceptions when trying to generate the adopter statistics data.

```
2025-03-23T23:18:50,747 | ERROR | (ScheduledDataCollector:235) - Error occurred while processing adopter statistic data.
java.lang.NullPointerException: Cannot invoke "String.regionMatches(boolean, int, String, int, int)" because "<parameter2>" is null
        at org.joda.time.format.PeriodFormatterBuilder$Literal.parseInto(PeriodFormatterBuilder.java:1906) ~[!/:2.12.7]
        at org.joda.time.format.PeriodFormatterBuilder$Composite.parseInto(PeriodFormatterBuilder.java:2171) ~[!/:2.12.7]
        at org.joda.time.format.PeriodFormatterBuilder$Separator.parseInto(PeriodFormatterBuilder.java:2044) ~[!/:2.12.7]
        at org.joda.time.format.PeriodFormatter.parseMutablePeriod(PeriodFormatter.java:323) ~[!/:2.12.7]
        at org.joda.time.format.PeriodFormatter.parsePeriod(PeriodFormatter.java:309) ~[!/:2.12.7]
        at org.opencastproject.metadata.dublincore.EncodingSchemeUtils.decodeDuration(EncodingSchemeUtils.java:158) ~[!/:?]
        at org.opencastproject.adopter.statistic.ScheduledDataCollector.lambda$collectStatisticData$2(ScheduledDataCollector.java:309) ~[!/:?]
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197) ~[?:?]
        at java.util.AbstractList$RandomAccessSpliterator.forEachRemaining(AbstractList.java:720) ~[?:?]
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921) ~[?:?]
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
        at java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:662) ~[?:?]
        at org.opencastproject.adopter.statistic.ScheduledDataCollector.lambda$collectStatisticData$3(ScheduledDataCollector.java:312) ~[!/:?]
        at org.opencastproject.security.util.SecurityUtil.runAs(SecurityUtil.java:80) ~[!/:?]
        at org.opencastproject.adopter.statistic.ScheduledDataCollector.collectStatisticData(ScheduledDataCollector.java:294) ~[!/:?]
        at org.opencastproject.adopter.statistic.ScheduledDataCollector.run(ScheduledDataCollector.java:230) [!/:?]
        at java.util.TimerThread.mainLoop(Timer.java:566) [?:?]
        at java.util.TimerThread.run(Timer.java:516) [?:?]
```

This patch fixes the issue, so that adopter statistics are again sent to the registration server if the user opted in.

### How to test this patch

- Start Opencast
- Add workflow [no-duration.yaml.txt](https://github.com/user-attachments/files/19506473/no-duration.yaml.txt)
- Publish media: `curl -i -u admin:opencast http://localhost:8080/ingest/addMediaPackage/no-duration -F 'flavor=presenter/source' -F mediaUri=https://data.lkiesow.io/opencast/test-media/goat.mp4 -F title="I 🖤 Opencast"`
- Fill out adopter registration
- Restart Opencast
  - Before: You get the stack trace from above
  - After: No stack trace

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
