### PR TITLE
Fix 500 response for editor endpoints

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/util/RestUtil.java
+++ b/modules/common/src/main/java/org/opencastproject/util/RestUtil.java
@@ -321,6 +321,10 @@ public final class RestUtil {
       return Response.status(Response.Status.FORBIDDEN).entity(msg).build();
     }
 
+    public static Response unauthorized(Object entity) {
+      return Response.status(Response.Status.UNAUTHORIZED).entity(entity).build();
+    }
+
     public static Response conflict(String msg) {
       return Response.status(Response.Status.CONFLICT).entity(msg).build();
     }

--- a/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/EditorRestEndpointBase.java
+++ b/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/EditorRestEndpointBase.java
@@ -209,7 +209,10 @@ public abstract class EditorRestEndpointBase {
         return RestUtil.R.conflict(String.format("Event '%s' is %s", eventId, e.getMessage()));
       case WORKFLOW_ACTIVE:
         return RestUtil.R.locked();
+      case NOT_AUTHORIZED:
+        return RestUtil.R.unauthorized(String.format("Unauthorized for event '%s'", eventId));
       case WORKFLOW_NOT_FOUND:
+      case METADATA_UPDATE_FAIL:
       case NO_INTERNAL_PUBLICATION:
         return RestUtil.R.badRequest(e.getMessage());
       case UNABLE_TO_CREATE_CATALOG:


### PR DESCRIPTION
Two of the predefined error codes were missing from the response generation function. This adds them to the function, so that proper error codes may be returned instead of a generic 500.

Helps with https://github.com/opencast/opencast-editor/issues/1565.

### How to test this patch

- Go to the admin ui and open an event in the editor frontend
- Change the metadata to something invalid (e.g. empty title field, malformed date field)
- Try to save and process your changes
- Check response (in the ui or in the network tab of the web development tools of your browser)

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
