### PR TITLE
Add check in comment re-index to prevent 'No Value present' Exception

### DIFF
--- a/modules/event-comment/src/main/java/org/opencastproject/event/comment/persistence/EventCommentDatabaseServiceImpl.java
+++ b/modules/event-comment/src/main/java/org/opencastproject/event/comment/persistence/EventCommentDatabaseServiceImpl.java
@@ -427,7 +427,7 @@ public class EventCommentDatabaseServiceImpl extends AbstractIndexProducer imple
 
                       var updatedEventData = index.getEvent(eventId, orgId, securityService.getUser());
                       updatedEventData = getEventUpdateFunction(eventId).apply(updatedEventData);
-                      updatedEventRange.add(updatedEventData.get());
+                      updatedEventData.ifPresent(updatedEventRange::add);
 
                       if (updatedEventRange.size() >= n || i >= eventsWithComments.get(orgId).size()) {
                         index.bulkEventUpdate(updatedEventRange);


### PR DESCRIPTION
While rebuilding our comments index, the following error occurred several hundred times:

```
2025-03-18T15:49:25,975 | ERROR | (AbstractIndexProducer:174) - Unable to re-index comment of event x-x-x-x-x for organization mh_default_org, skipping.
java.util.NoSuchElementException: No value present
	at java.util.Optional.get(Optional.java:143) ~[?:?]
	at org.opencastproject.event.comment.persistence.EventCommentDatabaseServiceImpl.lambda$repopulate$5(EventCommentDatabaseServiceImpl.java:430) ~[?:?]
	at org.opencastproject.security.util.SecurityUtil.runAs(SecurityUtil.java:80) ~[?:?]
	at org.opencastproject.event.comment.persistence.EventCommentDatabaseServiceImpl.repopulate(EventCommentDatabaseServiceImpl.java:420) ~[?:?]
	at org.opencastproject.elasticsearch.index.rebuild.IndexRebuildService.rebuildIndexInternal(IndexRebuildService.java:213) ~[?:?]
	at org.opencastproject.elasticsearch.index.rebuild.IndexRebuildService.rebuildIndex(IndexRebuildService.java:178) ~[?:?]
	at org.opencastproject.elasticsearch.index.endpoint.IndexEndpoint.lambda$partiallyRebuildIndex$1(IndexEndpoint.java:159) ~[?:?]
	at org.opencastproject.security.util.SecurityContext.lambda$runInContext$0(SecurityContext.java:68) ~[?:?]
	at org.opencastproject.security.util.SecurityContext.runInContext(SecurityContext.java:58) ~[?:?]
	at org.opencastproject.security.util.SecurityContext.runInContext(SecurityContext.java:67) ~[?:?]
	at org.opencastproject.elasticsearch.index.endpoint.IndexEndpoint.lambda$partiallyRebuildIndex$2(IndexEndpoint.java:156) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
	at java.lang.Thread.run(Thread.java:840) [?:?]
```

This PR adds a present check to the corresponding code line.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
