### PR TITLE
Improved Paella player Matomo plugin documentation and default config

### DIFF
--- a/docs/guides/admin/docs/configuration/player/paella.player7/plugins/org.opencast.paella.matomo.userTrackingDataPlugin.md
+++ b/docs/guides/admin/docs/configuration/player/paella.player7/plugins/org.opencast.paella.matomo.userTrackingDataPlugin.md
@@ -1,7 +1,7 @@
 Paella plugin: org.opencast.paella.matomo.userTrackingDataPlugin
 ================================================================
 
-This plugin allows to use [Matomo service](https://matomo.org/) to track usage data. 
+This plugin allows to use [Matomo service](https://matomo.org/) to track usage data.
 
 The configurations for this plugin are done for each tenant. So you need to modify the `plugins`
 section of the [paella config file](../configuration.md).
@@ -10,44 +10,12 @@ section of the [paella config file](../configuration.md).
 Configuration
 -------------
 
-You need to enabled the `org.opencast.paella.matomo.userTrackingDataPlugin` plugin.
+You need to enabled both the `es.upv.paella.userEventTracker` and the `org.opencast.paella.matomo.userTrackingDataPlugin` plugin.
 
 ```json
 {
-    "org.opencast.paella.matomo.userTrackingDataPlugin": {
-        "enabled": true,
-        "context": [
-            "userTracking"
-        ],
-        "server": "//matomo.server.com/",
-        "siteId": "1",
-        "matomoGlobalLoaded": false,
-        "cookieType": "tracking",
-        "logUserId": true,
-        "events": {
-            "category": "PaellaPlayer",
-            "action": "${event}",
-            "name": "${videoId}"
-        },
-        "customDimensions": {
-            "1": "${videoId}",
-            "2": "${metadata.series} - ${metadata.seriestitle}",
-            "3": "${metadata.presenters}"
-        }
-    }    
-}
-```
-
-Configuration parameters:
-
-- **context**: [User event tracker](https://github.com/polimediaupv/paella-user-tracking) context to use.
-
-    Indicate which events should be captured.
-
-    Default contiguration:
-    ```json
     "es.upv.paella.userEventTracker": {
-        "enabled": false,
+        "enabled": true,
         "context": "userTracking",
         "events": [
             "PLAY",
@@ -57,7 +25,71 @@ Configuration parameters:
             "SEEK",
             "FULLSCREEN_CHANGED",
             "VOLUME_CHANGED",
-            "TIMEUPDATE",
+            "CAPTIONS_CHANGED",
+            "BUTTON_PRESS",
+            "SHOW_POPUP",
+            "HIDE_POPUP",
+            "ENTER_FULLSCREEN",
+            "EXIT_FULLSCREEN",
+            "VOLUME_CHANGED",
+            "CAPTIONS_ENABLED",
+            "CAPTIONS_DISABLED",
+            "LAYOUT_CHANGED",
+            "PLAYBACK_RATE_CHANGED",
+            "VIDEO_QUALITY_CHANGED",
+            "RESIZE_END"
+        ]
+    },
+    "org.opencast.paella.matomo.userTrackingDataPlugin": {
+        "enabled": true,
+        "context": [
+            "userTracking"
+        ],
+        "server": "//matomo.server.com/",
+        "siteId": "1",
+        "trackerUrl": {
+            "php": "matomo.php",
+            "js": "matomo.js"
+        },
+        "matomoGlobalLoaded": false,
+        "mediaAnalyticsTitle": "${videoId}",
+        "cookieType": "tracking",
+        "logUserId": true,
+        "events": {
+            "category": "PaellaPlayer",
+            "action": "${event}",
+            "name": "${eventData}"
+        },
+        "customDimensions": {
+            "1": "${videoId}",
+            "2": "${metadata.series} - ${metadata.seriestitle}",
+            "3": "${metadata.presenters}"
+        }
+    }
+}
+```
+
+**Configuration parameters:**
+
+- **context**: [User event tracker](https://github.com/polimediaupv/paella-user-tracking) context to use.
+
+    Corresponds to the `context` parameter of `es.upv.paella.userEventTracker`.
+    Indicates which events should be tracked.
+
+    Example contiguration:
+
+    ```
+    "es.upv.paella.userEventTracker": {
+        "enabled": true,
+        "context": "userTracking",
+        "events": [
+            "PLAY",
+            "PAUSE",
+            "STOP",
+            "ENDED",
+            "SEEK",
+            "FULLSCREEN_CHANGED",
+            "VOLUME_CHANGED",
             "CAPTIONS_CHANGED",
             "BUTTON_PRESS",
             "SHOW_POPUP",
@@ -74,30 +106,42 @@ Configuration parameters:
         ]
     }
     ```
-    
-- **server**: URL to matomo server
-- **siteId**: matomo siteId
-- **matomoGlobalLoaded**: If matomo library is loaded globally by site page or the plugin should load it.
+
+- **server**: URL to Matomo server
+
+- **siteId**: Matomo siteId
+
+- **trackerUrl**: Matomo JavaScript and PHP files loaded by the Paella player
+
+    Allows to define files other than the default `matomo.php` and `matomo.js` that are loaded by the player to track usage data.
+
+- **matomoGlobalLoaded**: If Matomo library is loaded globally by site page or the plugin should load it.
 
     Keep it to `false` in Opencast.
+
+- **mediaAnalyticsTitle**: Template variable that will be used as title information in the Matomo Media Analytics plugin.
+
+    Only relevant if you are using the Matomo Media Analytics plugin. It is recommended to use the `videoId` template variable to uniquely identify events in the Matomo Media Analytics plugin. If not set, the event title will be used.
 
 - **cookieType**: cookie type in the cookie consent plugIn.
 
     Keep it to `tracking` in Opencast.
 
-- **logUserId**: If Opecast user ID should be logued.
+- **logUserId**: If Opecast user ID should be logged.
+
 - **events**: If exists, user event interactions should be tracked.
 
     Valid values: Object with the category, action and name to track the events.
 
 - **customDimensions**: Custom dimensions to track.
 
-    Object. The key represents the matomo custom dimension id, the value the string to log (template vars can me used)
+    Object. The key represents the Matomo custom dimension id, the value the string to log (template vars can me used)
 
 
-Template Vars:
+**Available template Vars:**
 
 - **videoId**: Video ID
+
 - **metadata**: Metadata object. Metadata properties:
     - **title**
     - **subject**
@@ -115,4 +159,6 @@ Template Vars:
     - **UID**
     - **type**
 
-- **event**: Event name
+- **event**: Player event name (e.g. `paella:playbackRateChanged`)
+
+- **eventData**: A text representation of the data received by the player event (e.g. for the event `paella:playbackRateChanged` eventData = `2`)

--- a/etc/ui-config/mh_default_org/paella7/config.json
+++ b/etc/ui-config/mh_default_org/paella7/config.json
@@ -610,7 +610,6 @@
                 "SEEK",
                 "FULLSCREEN_CHANGED",
                 "VOLUME_CHANGED",
-                "TIMEUPDATE",
                 "CAPTIONS_CHANGED",
                 "BUTTON_PRESS",
                 "SHOW_POPUP",
@@ -654,13 +653,18 @@
             ],
             "server": "//matomo.server.com/",
             "siteId": "1",
+            "trackerUrl": {
+                "php": "matomo.php",
+                "js": "matomo.js"
+            },
             "matomoGlobalLoaded": false,
+            "mediaAnalyticsTitle": "${videoId}",
             "cookieType": "tracking",
             "logUserId": true,
             "events": {
                 "category": "PaellaPlayer",
                 "action": "${event}",
-                "name": "${videoId}"
+                "name": "${eventData}"
             },
             "customDimensions": {
                 "1": "${videoId}",


### PR DESCRIPTION
Some config parameters of the Paella player Matomo plugin were missing. Added them both to the default config and to the documentation.

### How to test this patch

Only the documentation and the default config for the Paella player Matomo plugin have been touched. As the Paella player Matomo plugin is disabled in the default config, no functionality has changed.


### Your pull request should…

* [x] have a concise title
* [ ] ~~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~~include migration scripts and documentation, if appropriate~~
* [x] pass automated tests
* [x] have a clean commit history
* [x [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
