### PR TITLE
Fix series table sorting for organizers column

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
@@ -786,7 +786,7 @@ public class SeriesEndpoint {
             case SeriesIndexSchema.CONTRIBUTORS:
               query.sortByContributors(criterion.getOrder());
               break;
-            case SeriesIndexSchema.CREATOR:
+            case SeriesIndexSchema.ORGANIZERS:
               query.sortByOrganizers(criterion.getOrder());
               break;
             case SeriesIndexSchema.CREATED_DATE_TIME:

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/SeriesEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/SeriesEndpointTest.java
@@ -99,7 +99,7 @@ public class SeriesEndpointTest {
     reader = new InputStreamReader(stream);
     expected = (JSONObject) new JSONParser().parse(reader);
 
-    actual = (JSONObject) parser.parse(given().queryParam("sort", "creator:DESC").expect().statusCode(HttpStatus.SC_OK)
+    actual = (JSONObject) parser.parse(given().queryParam("sort", "organizers:DESC").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON).when().get(rt.host("/series.json")).asString());
     Assert.assertEquals(expected, actual);
 
@@ -107,7 +107,7 @@ public class SeriesEndpointTest {
     reader = new InputStreamReader(stream);
     expected = (JSONObject) new JSONParser().parse(reader);
 
-    actual = (JSONObject) parser.parse(given().queryParam("sort", "creator:ASC").expect().statusCode(HttpStatus.SC_OK)
+    actual = (JSONObject) parser.parse(given().queryParam("sort", "organizers:ASC").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON).when().get(rt.host("/series.json")).asString());
     Assert.assertEquals(expected, actual);
     // Test Sort by Title


### PR DESCRIPTION
Sorting by the "organizers" column in the frontend resulted in a 400, meaning the sorting of the table did not change and the table would not be automatically updated until the sorting column was changed again. This patch should fix that.
Does not change anything about the way multi-value fields are sorted.

![Bildschirmfoto vom 2025-04-02 14-27-09](https://github.com/user-attachments/assets/76ed4391-f2ba-4ae2-9425-7a594ffce85c)

Fixes https://github.com/opencast/opencast-admin-interface/issues/1154.

### How to test this patch

Easiest way to test this is to open the admin ui and sort the series table by "organizers". Check if the sorting for your series changes, or check the response in your browsers networking tab.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
