### PR TITLE
Get ghost user in comment reply if user doesn't exist

### DIFF
--- a/modules/event-comment/src/main/java/org/opencastproject/event/comment/persistence/EventCommentDto.java
+++ b/modules/event-comment/src/main/java/org/opencastproject/event/comment/persistence/EventCommentDto.java
@@ -380,7 +380,7 @@ public class EventCommentDto {
     EventComment comment = EventComment.create(Option.option(id), eventId, organization, text, user, reason,
             resolvedStatus, creationDate, modificationDate);
     for (EventCommentReplyDto reply : replies) {
-      comment.addReply(reply.toCommentReply(userDirectoryService));
+      comment.addReply(reply.toCommentReply(userDirectoryService, organizationDirectoryService, organization));
     }
     return comment;
   }

--- a/modules/event-comment/src/main/java/org/opencastproject/event/comment/persistence/EventCommentReplyDto.java
+++ b/modules/event-comment/src/main/java/org/opencastproject/event/comment/persistence/EventCommentReplyDto.java
@@ -22,8 +22,11 @@
 package org.opencastproject.event.comment.persistence;
 
 import org.opencastproject.event.comment.EventCommentReply;
+import org.opencastproject.security.api.OrganizationDirectoryService;
 import org.opencastproject.security.api.User;
 import org.opencastproject.security.api.UserDirectoryService;
+import org.opencastproject.security.impl.jpa.JpaOrganization;
+import org.opencastproject.security.impl.jpa.JpaUser;
 import org.opencastproject.util.data.Option;
 
 import java.util.Date;
@@ -194,8 +197,17 @@ public class EventCommentReplyDto {
    *
    * @return the business object model of this comment reply
    */
-  public EventCommentReply toCommentReply(UserDirectoryService userDirectoryService) {
+  public EventCommentReply toCommentReply(UserDirectoryService userDirectoryService,
+      OrganizationDirectoryService organizationDirectoryService,
+      String organization) {
     User user = userDirectoryService.loadUser(author);
+    if (user == null) {
+      JpaOrganization org = null;
+      try {
+        org = (JpaOrganization) organizationDirectoryService.getOrganization(organization);
+      } catch (Exception ignore) { }
+      user = new JpaUser(author, null, org, author, "ghost@localhost", "ghost", false);
+    }
     return EventCommentReply.create(Option.option(id), text, user, creationDate, modificationDate);
   }
 


### PR DESCRIPTION
While rebuilding our comments index, the following error occurred several times because the user has been removed:

```
2025-03-18T15:45:03,338 | ERROR | (EventCommentDatabaseServiceImpl:296) - Could not retreive comments for event x-x-x-x-x
java.lang.IllegalArgumentException: author must not be null
	at org.opencastproject.util.RequireUtil.notNull(RequireUtil.java:76) ~[?:?]
	at org.opencastproject.event.comment.EventCommentReply.<init>(EventCommentReply.java:105) ~[?:?]
	at org.opencastproject.event.comment.EventCommentReply.create(EventCommentReply.java:99) ~[?:?]
	at org.opencastproject.event.comment.persistence.EventCommentReplyDto.toCommentReply(EventCommentReplyDto.java:199) ~[?:?]
	at org.opencastproject.event.comment.persistence.EventCommentDto.toComment(EventCommentDto.java:383) ~[?:?]
	at org.opencastproject.event.comment.persistence.EventCommentDatabaseServiceImpl.lambda$getComments$2(EventCommentDatabaseServiceImpl.java:288) ~[?:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197) ~[?:?]
	at java.util.Vector$VectorSpliterator.forEachRemaining(Vector.java:1470) ~[?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921) ~[?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682) ~[?:?]
	at org.opencastproject.event.comment.persistence.EventCommentDatabaseServiceImpl.getComments(EventCommentDatabaseServiceImpl.java:294) ~[?:?]
	at org.opencastproject.event.comment.persistence.EventCommentDatabaseServiceImpl.lambda$repopulate$5(EventCommentDatabaseServiceImpl.java:425) ~[?:?]
	at org.opencastproject.security.util.SecurityUtil.runAs(SecurityUtil.java:80) ~[?:?]
	at org.opencastproject.event.comment.persistence.EventCommentDatabaseServiceImpl.repopulate(EventCommentDatabaseServiceImpl.java:420) ~[?:?]
	at org.opencastproject.elasticsearch.index.rebuild.IndexRebuildService.rebuildIndexInternal(IndexRebuildService.java:213) ~[?:?]
	at org.opencastproject.elasticsearch.index.rebuild.IndexRebuildService.rebuildIndex(IndexRebuildService.java:178) ~[?:?]
	at org.opencastproject.elasticsearch.index.endpoint.IndexEndpoint.lambda$partiallyRebuildIndex$1(IndexEndpoint.java:159) ~[?:?]
	at org.opencastproject.security.util.SecurityContext.lambda$runInContext$0(SecurityContext.java:68) ~[?:?]
	at org.opencastproject.security.util.SecurityContext.runInContext(SecurityContext.java:58) ~[?:?]
	at org.opencastproject.security.util.SecurityContext.runInContext(SecurityContext.java:67) ~[?:?]
	at org.opencastproject.elasticsearch.index.endpoint.IndexEndpoint.lambda$partiallyRebuildIndex$2(IndexEndpoint.java:156) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
	at java.lang.Thread.run(Thread.java:840) [?:?]
```

These changes create a new ghost user based on #4739. I didn't test these changes.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
