### PR TITLE
Add tobira auth callback

### DIFF
--- a/etc/org.opencastproject.tobira.impl.TobiraEndpoint.cfg
+++ b/etc/org.opencastproject.tobira.impl.TobiraEndpoint.cfg
@@ -1,0 +1,10 @@
+#
+# HTTP Header name that will contain the username
+#header=X-WEBAUTH-USER
+
+# Token used to authorize Tobira callback requests. If this token is set,
+# the callback endpoint will be enabled.
+#callbackToken=
+
+# Pattern to match the roles that are allowed to be part of the user outcome.
+#allowedRolesPattern=ROLE_TOBIRA_.*

--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -331,6 +331,7 @@
 
     <!-- Enable access to the Tobira module -->
     <sec:intercept-url pattern="/tobira/version" access="ROLE_ANONYMOUS" />
+    <sec:intercept-url pattern="/tobira/callback/*" method="GET" access="ROLE_ANONYMOUS" />
     <sec:intercept-url pattern="/tobira/**" access="ROLE_ADMIN" />
 
     <!-- Enable anonymous access to the annotation and the series endpoints -->

--- a/modules/tobira/pom.xml
+++ b/modules/tobira/pom.xml
@@ -48,6 +48,10 @@
       <artifactId>org.osgi.service.jaxrs</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-search-service-api</artifactId>
       <version>${project.version}</version>
@@ -78,6 +82,17 @@
       <version>${elasticsearch.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-userdirectory</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.metatype.annotations</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>
@@ -105,6 +120,11 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <extensions>true</extensions>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <ignoredUnusedDeclaredDependency>org.osgi:org.osgi.service.cm</ignoredUnusedDeclaredDependency>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>

--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/TobiraConfig.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/TobiraConfig.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.tobira.impl;
+
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.AttributeType;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+
+@ObjectClassDefinition(name = "Tobira API Configuration")
+public @interface TobiraConfig {
+
+
+  @AttributeDefinition(
+      name = "Tobira auth header name",
+      description = "HTTP Header name that will contain the username"
+  )
+  String headerName() default "X-WEBAUTH-USER";
+
+  @AttributeDefinition(
+      name = "Tobira Callback Token",
+      description = "The token to authorize the callback request.",
+      type = AttributeType.STRING
+  )
+  String callbackToken();
+
+  @AttributeDefinition(
+      name = "Allowed Roles Pattern",
+      description = "The pattern to match the roles that are allowed for the user outcome.",
+      type = AttributeType.STRING
+  )
+  String allowedRolesPattern() default "ROLE_TOBIRA_.*";
+}

--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/TobiraEndpoint.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/TobiraEndpoint.java
@@ -31,8 +31,12 @@ import org.opencastproject.db.DBSessionFactory;
 import org.opencastproject.playlists.PlaylistService;
 import org.opencastproject.search.api.SearchService;
 import org.opencastproject.security.api.AuthorizationService;
+import org.opencastproject.security.api.Role;
 import org.opencastproject.security.api.SecurityService;
+import org.opencastproject.security.api.User;
+import org.opencastproject.security.api.UserDirectoryService;
 import org.opencastproject.series.api.SeriesService;
+import org.opencastproject.userdirectory.UserIdRoleProvider;
 import org.opencastproject.util.Jsons;
 import org.opencastproject.util.doc.rest.RestParameter;
 import org.opencastproject.util.doc.rest.RestQuery;
@@ -50,6 +54,7 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsResource;
+import org.osgi.service.metatype.annotations.Designate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,6 +63,10 @@ import java.io.InputStream;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import javax.persistence.EntityManagerFactory;
 import javax.servlet.http.HttpServletRequest;
@@ -66,9 +75,11 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 
 /**
@@ -97,6 +108,7 @@ import javax.ws.rs.core.Response;
     service = TobiraEndpoint.class
 )
 @JaxrsResource
+@Designate(ocd = TobiraConfig.class)
 public class TobiraEndpoint {
   private static final Logger logger = LoggerFactory.getLogger(TobiraEndpoint.class);
 
@@ -129,7 +141,12 @@ public class TobiraEndpoint {
   private SecurityService securityService;
   private PlaylistService playlistService;
   private Workspace workspace;
+  private UserDirectoryService userDirectoryService;
+  private UserIdRoleProvider userIdRoleProvider;
 
+  private String callbackToken;
+  private Predicate<String> allowedRolesPattern;
+  private String headerName;
 
   /** The factory used to generate the entity manager */
   protected EntityManagerFactory emf = null;
@@ -141,8 +158,11 @@ public class TobiraEndpoint {
   private JsonObject cachedStats = new JsonObject();
 
   @Activate
-  public void activate(BundleContext bundleContext) {
+  public void activate(TobiraConfig tobiraConfig, BundleContext bundleContext) {
     logger.info("Activated Tobira API");
+    callbackToken = tobiraConfig.callbackToken();
+    headerName = tobiraConfig.headerName();
+    allowedRolesPattern = Pattern.compile(tobiraConfig.allowedRolesPattern()).asMatchPredicate();
     this.db = dbSessionFactory.createSession(emf);
   }
 
@@ -186,6 +206,11 @@ public class TobiraEndpoint {
   @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
+  }
+
+  @Reference
+  public void setUserDirectoryService(UserDirectoryService service) {
+    this.userDirectoryService = service;
   }
 
   @GET
@@ -267,6 +292,68 @@ public class TobiraEndpoint {
       logger.error("Unexpected exception in tobira/harvest", e);
       return Response.serverError().build();
     }
+  }
+
+  @GET
+  @Path("/callback/{token}")
+  @Produces(APPLICATION_JSON)
+  @RestQuery(
+      name = "callback",
+      description = "Auth callback API to get user information. This is used by Tobira to get user information.",
+      pathParameters = {
+          @RestParameter(
+              name = "token",
+              isRequired = true,
+              description = "The token to authorize the request.",
+              type = Type.STRING
+          )
+      },
+      responses = {
+          @RestResponse(description = "User Outcome Data", responseCode = HttpServletResponse.SC_OK)
+      },
+      returnDescription = "Returns user information"
+  )
+  public Response callback(@PathParam("token") String token, @Context HttpHeaders headers) {
+
+    if (callbackToken == null || !callbackToken.equals(token)) {
+      return badRequest("Invalid token or callback disabled");
+    }
+
+    List<String> username = headers.getRequestHeader(headerName);
+
+    if (username == null) {
+      return badRequest("No username header provided");
+    }
+
+    User user = null;
+
+    if (!username.isEmpty() && username.get(0) != null) {
+      user = userDirectoryService.loadUser(username.get(0));
+    }
+
+    Jsons.Obj outcome;
+
+    if (user == null) {
+      outcome = Jsons.obj(
+        Jsons.p("outcome", "no-user")
+      );
+    } else {
+      outcome = Jsons.obj(
+          Jsons.p("outcome", "user"),
+          Jsons.p("username", user.getUsername()),
+          Jsons.p("displayName", user.getName()),
+          Jsons.p("email", user.getEmail()),
+          Jsons.p("userRole",UserIdRoleProvider.getUserIdRole(user.getUsername())),
+          Jsons.p("roles", Jsons.arr(
+            user.getRoles().stream()
+                .map(Role::getName)
+                .filter(allowedRolesPattern)
+                .map(Jsons::v)
+                .collect(Collectors.toList())))
+      );
+    }
+
+    return Response.ok(outcome.toJson()).build();
   }
 
   private static Response badRequest(String msg) {


### PR DESCRIPTION
This introduces a new callback endpoint (`/tobira/callback/{token}`) that allows Tobira to retrieve user details based on the REMOTE_USER header.

<!--
Explain what this pull request does.  If this fixes a bug, also explain how to reproduce the issue.
-->

<!--
If your pull request is targeting the legacy (second oldest release branch), explain why this patch is so important that
it needs to go into the legacy and can not go just into stable or develop.
-->

### How to test this patch
Tobira test config:

```toml
[auth]
source = "callback:http://localhost:8080/tobira/callback/test123"
trusted_external_key = "tobira"
pre_auth_external_links = true
login_link = "/Shibboleth.sso/Login"
logout_link = "/Shibboleth.sso/Logout"

[auth.callback]
relevant_headers = ["REMOTE_USER"]
cache_duration="0"

```

Opencast test config org.opencastproject.tobira.impl.TobiraEndpoint.cfg:
```cfg
callbackToken=test123
allowedRolesPattern=ROLE_GR.*
```
Use the tobira graphql explorer http://127.0.0.1:3080/~graphiql

Query:

```graphql
query MyQuery {
  currentUser {
    username
    userRole
    roles
    email
    displayName
    canUseStudio
    canUseEditor
    canUpload
    canFindUnlisted
    canCreateUserRealm
  }
}
```
Headers:
```json
{
  "REMOTE_USER": "admin"
}
```


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
