### PR TITLE
Properly handle Tobira harvest of events with streaming-only tracks

### DIFF
--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Item.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Item.java
@@ -30,7 +30,6 @@ import org.opencastproject.mediapackage.MediaPackageElement;
 import org.opencastproject.mediapackage.Track;
 import org.opencastproject.mediapackage.TrackSupport;
 import org.opencastproject.mediapackage.VideoStream;
-import org.opencastproject.metadata.dublincore.DCMIPeriod;
 import org.opencastproject.metadata.dublincore.DublinCore;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
 import org.opencastproject.metadata.dublincore.DublinCoreUtil;
@@ -146,8 +145,7 @@ class Item {
           //NB: This is an else case, so we ignore the item(s) in the stream
           .orElseGet(() -> {
             String dcExtent = event.getDublinCore().getFirst(DublinCore.PROPERTY_EXTENT);
-            DCMIPeriod p = EncodingSchemeUtils.decodeMandatoryPeriod(dcExtent);
-            return Math.max(0L, p.getEnd().getTime() - p.getStart().getTime());
+            return Math.max(0L, EncodingSchemeUtils.decodeMandatoryDuration(dcExtent));
           });
 
       this.obj = Jsons.obj(


### PR DESCRIPTION
As reported on Matrix, in streaming-only publications (ie, only `engage-streaming` video tracks) Tobira's harvester throws an exception like this:

```
2025-04-03T11:10:19,768 | ERROR | (Harvest:168) - Error reading event '2c38219d-4caa-45cc-8f92-0fc93b6f8e73' (skipping...)
java.lang.IllegalArgumentException: Cannot decode to DCMIPeriod: PT2M
        at org.opencastproject.metadata.dublincore.EncodingSchemeUtils.decodeMandatoryPeriod(EncodingSchemeUtils.java:359) ~[?:?]
        at org.opencastproject.tobira.impl.Item.lambda$new$10(Item.java:149) ~[?:?]
        at java.util.OptionalLong.orElseGet(OptionalLong.java:234) ~[?:?]
        at org.opencastproject.tobira.impl.Item.<init>(Item.java:147) ~[?:?]
        at org.opencastproject.tobira.impl.Harvest.lambda$harvest$0(Harvest.java:165) ~[?:?]
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197) ~[?:?]
[...]
```

The root cause here is that `EncodingSchemeUtils`'s `decodeMandatoryPeriod` doesn't speak ISO8601 Period, despite sounding an *awful lot* like it should.  Instead it throws an exception.

So we're switching to `decodeMandatoryDuration` instead, which works as expected.

This should be in 16.x since it's probably not *that* rare for adopters to have streaming-only publications, and we should probably support that properly for Tobira as well.

### How to test this patch

I tested by removing the `Arrays.stream` chunk and just setting the duration to the `orElseGet` chunk, but I suppose you could also publish a streaming-only event too :)

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
