### PR TITLE
User Settings Now Working

### DIFF
--- a/docs/guides/admin/docs/releasenotes/user-settings.txt
+++ b/docs/guides/admin/docs/releasenotes/user-settings.txt
@@ -1,0 +1,1 @@
+PR 6622 added a oc_frontend_user_settings database table, which replaces the oc_user_settings table.  The older stable should be blank in all installs, and the relevant instructions are included in the database upgrade script for 18.0.

--- a/docs/upgrade/17_to_18/mysql5.sql
+++ b/docs/upgrade/17_to_18/mysql5.sql
@@ -1,0 +1,3 @@
+-- Drop table so it can be recreated.  Previous functionality was unused, and broken even if it was
+drop table oc_user_settings;
+

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/UserSettingsEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/UserSettingsEndpoint.java
@@ -31,6 +31,7 @@ import org.opencastproject.adminui.usersettings.UserSetting;
 import org.opencastproject.adminui.usersettings.UserSettings;
 import org.opencastproject.adminui.usersettings.UserSettingsService;
 import org.opencastproject.adminui.usersettings.persistence.UserSettingsServiceException;
+import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.UrlSupport;
 import org.opencastproject.util.data.Tuple;
@@ -90,12 +91,22 @@ public class UserSettingsEndpoint {
 
   private UserSettingsService userSettingsService;
 
+  private SecurityService securityService;
+
   /**
    * OSGi callback to set the service to retrieve user settings from.
    */
   @Reference
   public void setUserSettingsService(UserSettingsService userSettingsService) {
     this.userSettingsService = userSettingsService;
+  }
+
+  /**
+   * OSGi callback to set the security service
+   */
+  @Reference
+  public void setSecurityService(SecurityService securityService) {
+    this.securityService = securityService;
   }
 
   /** OSGi callback. */
@@ -136,10 +147,14 @@ public class UserSettingsEndpoint {
           @RestParameter(description = "The value representing this setting.", isRequired = true, name = "value", type = STRING) }, responses = { @RestResponse(responseCode = HttpServletResponse.SC_OK, description = "User setting has been created.") })
   public Response createUserSetting(@FormParam("key") String key, @FormParam("value") String value)
           throws NotFoundException {
+    String orgId = securityService.getOrganization().getId();
+    String username = securityService.getUser().getUsername();
     try {
       UserSetting newUserSetting = userSettingsService.addUserSetting(key, value);
       return Response.ok(newUserSetting.toJson().toJson(), MediaType.APPLICATION_JSON).build();
     } catch (UserSettingsServiceException e) {
+      logger.error("Could not add user setting username '{}' org: '{}' key: '{}' value: '{}'", username, orgId,
+          key, value);
       return Response.serverError().build();
     }
   }

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/usersettings/UserSettingsService.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/usersettings/UserSettingsService.java
@@ -40,6 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
 import javax.persistence.EntityManager;
@@ -217,20 +218,38 @@ public class UserSettingsService {
   public UserSetting addUserSetting(String key, String value) throws UserSettingsServiceException {
     String orgId = securityService.getOrganization().getId();
     String username = securityService.getUser().getUsername();
-    try {
-      return db.execTx(em -> {
-        UserSettingDto userSettingDto = new UserSettingDto();
-        userSettingDto.setKey(key);
-        userSettingDto.setValue(value);
-        userSettingDto.setUsername(username);
-        userSettingDto.setOrganization(orgId);
-        em.persist(userSettingDto);
-        return userSettingDto.toUserSetting();
-      });
-    } catch (Exception e) {
-      logger.error("Could not update user setting username '{}' org: '{}' key: '{}' value: '{}'", username, orgId, key,
-          value, e);
-      throw new UserSettingsServiceException(e);
+    Optional<UserSettingDto> userSettingOpt = db.exec(getUserSettingsByKeyQuery(key)).stream()
+        .filter(setting -> setting.getKey().equalsIgnoreCase(key))
+        .findFirst();
+    if (userSettingOpt.isPresent()) {
+      try {
+        return db.execTx(em -> {
+          UserSettingDto userSettingDto = userSettingOpt.get();
+          userSettingDto.setValue(value);
+          em.merge(userSettingDto);
+          return userSettingDto.toUserSetting();
+        });
+      } catch (Exception e) {
+        logger.error("Could not update user setting username '{}' org: '{}' key: '{}' value: '{}'", username, orgId,
+            key, value, e);
+        throw new UserSettingsServiceException(e);
+      }
+    } else {
+      try {
+        return db.execTx(em -> {
+          UserSettingDto userSettingDto = new UserSettingDto();
+          userSettingDto.setKey(key);
+          userSettingDto.setValue(value);
+          userSettingDto.setUsername(username);
+          userSettingDto.setOrganization(orgId);
+          em.persist(userSettingDto);
+          return userSettingDto.toUserSetting();
+        });
+      } catch (Exception e) {
+        logger.error("Could not add user setting username '{}' org: '{}' key: '{}' value: '{}'", username, orgId,
+            key, value, e);
+        throw new UserSettingsServiceException(e);
+      }
     }
   }
 

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/usersettings/UserSettingsService.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/usersettings/UserSettingsService.java
@@ -230,8 +230,6 @@ public class UserSettingsService {
           return userSettingDto.toUserSetting();
         });
       } catch (Exception e) {
-        logger.error("Could not update user setting username '{}' org: '{}' key: '{}' value: '{}'", username, orgId,
-            key, value, e);
         throw new UserSettingsServiceException(e);
       }
     } else {
@@ -246,8 +244,7 @@ public class UserSettingsService {
           return userSettingDto.toUserSetting();
         });
       } catch (Exception e) {
-        logger.error("Could not add user setting username '{}' org: '{}' key: '{}' value: '{}'", username, orgId,
-            key, value, e);
+
         throw new UserSettingsServiceException(e);
       }
     }

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/usersettings/persistence/UserSettingDto.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/usersettings/persistence/UserSettingDto.java
@@ -41,7 +41,8 @@ import javax.persistence.UniqueConstraint;
 @Table(name = "oc_user_settings", indexes = {
     @Index(name = "IX_oc_user_setting_organization", columnList = "organization")
   }, uniqueConstraints = {
-    @UniqueConstraint(columnNames = { "username", "organization" }) })
+    @UniqueConstraint(columnNames = { "setting_key", "username", "organization" })
+})
 @NamedQueries({
   @NamedQuery(name = "UserSettings.countByUserName", query = "SELECT COUNT(us) FROM UserSettings us WHERE us.username = :username AND us.organization = :org"),
   @NamedQuery(name = "UserSettings.findByIdAndUsernameAndOrg", query = "SELECT us FROM UserSettings us WHERE us.id = :id AND us.username = :username AND us.organization = :org"),

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/usersettings/persistence/UserSettingDto.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/usersettings/persistence/UserSettingDto.java
@@ -38,8 +38,8 @@ import javax.persistence.UniqueConstraint;
 
 /** Entity object for user settings. */
 @Entity(name = "UserSettings")
-@Table(name = "oc_user_settings", indexes = {
-    @Index(name = "IX_oc_user_setting_organization", columnList = "organization")
+@Table(name = "oc_frontend_user_settings", indexes = {
+    @Index(name = "IX_oc_frontend_user_settings_organization", columnList = "organization")
   }, uniqueConstraints = {
     @UniqueConstraint(columnNames = { "setting_key", "username", "organization" })
 })

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestUserSettingsEndpoint.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestUserSettingsEndpoint.java
@@ -25,6 +25,9 @@ import org.opencastproject.adminui.usersettings.UserSetting;
 import org.opencastproject.adminui.usersettings.UserSettings;
 import org.opencastproject.adminui.usersettings.UserSettingsService;
 import org.opencastproject.adminui.usersettings.persistence.UserSettingsServiceException;
+import org.opencastproject.security.api.DefaultOrganization;
+import org.opencastproject.security.api.SecurityService;
+import org.opencastproject.security.api.User;
 
 import org.easymock.Capture;
 import org.easymock.EasyMock;
@@ -77,6 +80,16 @@ public class TestUserSettingsEndpoint extends UserSettingsEndpoint {
 
   public TestUserSettingsEndpoint() throws Exception {
     setupUserSettingsService();
+
+    User user = EasyMock.createNiceMock(User.class);
+    EasyMock.expect(user.getUsername()).andReturn("test user").anyTimes();
+
+    SecurityService securityService = EasyMock.createNiceMock(SecurityService.class);
+    EasyMock.expect(securityService.getUser()).andReturn(user).anyTimes();
+    EasyMock.expect(securityService.getOrganization()).andReturn(new DefaultOrganization()).anyTimes();
+    EasyMock.replay(user, securityService);
+    this.setSecurityService(securityService);
+
     this.setUserSettingsService(userSettingsService);
   }
 }

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/usersettings/UserSettingsServiceTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/usersettings/UserSettingsServiceTest.java
@@ -32,10 +32,12 @@ import org.opencastproject.security.api.User;
 import org.opencastproject.security.api.UserDirectoryService;
 
 import org.easymock.Capture;
+import org.easymock.CaptureType;
 import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -169,19 +171,41 @@ public class UserSettingsServiceTest {
   @Test
   public void addUserSettingInputNormalValuesExpectsSavedSetting() throws UserSettingsServiceException {
     String key = "newKey";
-    String value = "newValue";
-    Capture<UserSettingDto> userSettingDto = EasyMock.newCapture();
+    String firstValue = "firstValue";
+    String secondValue = "secondValue";
+    Capture<UserSettingDto> initialUserSetting = EasyMock.newCapture(CaptureType.ALL);
     EntityTransaction tx = EasyMock.createNiceMock(EntityTransaction.class);
     EasyMock.replay(tx);
 
+    TypedQuery query = EasyMock.createNiceMock(TypedQuery.class);
+    EasyMock.expect(query.setParameter("key", key)).andReturn(query);
+    EasyMock.expect(query.setParameter("username", securityService.getUser().getUsername())).andReturn(query);
+    EasyMock.expect(query.setParameter("org", securityService.getOrganization().getId())).andReturn(query);
+    EasyMock.expect(query.getResultList()).andReturn(Collections.emptyList());
+
+    TypedQuery secondQuery = EasyMock.createNiceMock(TypedQuery.class);
+    EasyMock.expect(secondQuery.setParameter("key", key)).andReturn(secondQuery);
+    EasyMock.expect(secondQuery.setParameter("username", securityService.getUser().getUsername())).andReturn(secondQuery);
+    EasyMock.expect(secondQuery.setParameter("org", securityService.getOrganization().getId())).andReturn(secondQuery);
+    UserSettingDto rval = new UserSettingDto(1, key, firstValue, securityService.getUser().getUsername(), securityService.getOrganization().getId());
+    EasyMock.expect(secondQuery.getResultList()).andReturn(Collections.singletonList(rval));
+    EasyMock.replay(query, secondQuery);
+
+
     EntityManager em = EasyMock.createNiceMock(EntityManager.class);
-    EasyMock.expect(em.getTransaction()).andReturn(tx);
-    em.persist(EasyMock.capture(userSettingDto));
+    EasyMock.expect(em.createNamedQuery("UserSettings.findByKey", UserSettingDto.class)).andReturn(query);
     EasyMock.expectLastCall();
+    em.persist(EasyMock.capture(initialUserSetting));
+    EasyMock.expectLastCall();
+    EasyMock.expect(em.createNamedQuery("UserSettings.findByKey", UserSettingDto.class)).andReturn(secondQuery);
+    EasyMock.expectLastCall();
+    UserSettingDto rval2 = new UserSettingDto(1, key, secondValue, securityService.getUser().getUsername(), securityService.getOrganization().getId());
+    EasyMock.expect(em.merge(EasyMock.capture(initialUserSetting))).andReturn(rval2);
+    EasyMock.expect(em.getTransaction()).andReturn(tx).anyTimes();
     EasyMock.replay(em);
 
     EntityManagerFactory emf = EasyMock.createNiceMock(EntityManagerFactory.class);
-    EasyMock.expect(emf.createEntityManager()).andReturn(em);
+    EasyMock.expect(emf.createEntityManager()).andReturn(em).anyTimes();
     EasyMock.replay(emf);
 
     UserSettingsService userSettingsService = new UserSettingsService();
@@ -190,10 +214,13 @@ public class UserSettingsServiceTest {
     userSettingsService.setDBSessionFactory(getDbSessionFactory());
     userSettingsService.setUserDirectoryService(userDirectoryService);
     userSettingsService.activate(null);
-    userSettingsService.addUserSetting(key, value);
+    userSettingsService.addUserSetting(key, firstValue);
+    userSettingsService.addUserSetting(key, secondValue);
 
-    assertEquals(userSettingDto.getValues().get(0).getKey(), key);
-    assertEquals(userSettingDto.getValues().get(0).getValue(), value);
+    assertEquals(key, initialUserSetting.getValues().get(0).getKey());
+    assertEquals(firstValue, initialUserSetting.getValues().get(0).getValue());
+    assertEquals(key, initialUserSetting.getValues().get(1).getKey());
+    assertEquals(secondValue, initialUserSetting.getValues().get(1).getValue());
   }
 
   @Test


### PR DESCRIPTION
This PR get the user settings endpoints working properly

- **The addUserSetting method now checks to see if a key for that user already exists, and updates it if it does.  Previous behaviour led to db constraint issues since it was blindly inserting new, identical keys.  This does mean that you can no longer add duplicate keys, so if you need more than one thing stored under a given key you must marshall and unmarshall on the user's end.**
- **Previous behaviour worked correctly for the *first* key set by a user, but when more than one key was set you would see constraint violations.  Adding the key to the user+org tuple resolves the issue, and matches the logic in the service.**

Note that this PR updates the indexes on a presumably empty table (since the endpoints don't really work right at all anyway).

Fixes: #6565


### How to test this patch

Use the endpoints under `/admin-ng/user-settings` to set, unset, and update user settings.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] ~explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch~
