### PR TITLE
Fix typo in org.organization-mh_default_org.cfg

### DIFF
--- a/etc/org.opencastproject.organization-mh_default_org.cfg
+++ b/etc/org.opencastproject.organization-mh_default_org.cfg
@@ -184,7 +184,7 @@ prop.org.opencastproject.admin.mediamodule.url=${prop.org.opencastproject.engage
 # Default: false
 #prop.admin.themes.enabled=false
 
-# Enable the sttatistics views in the admin intterface.
+# Enable the statistics views in the admin interface.
 # Format: boolean
 # Default: false
 #prop.admin.statistics.enabled=false


### PR DESCRIPTION
Fixes a typo in a config file comment.
