### PR TITLE
Add isOnline to admin ui service endpoint

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ServicesEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ServicesEndpoint.java
@@ -211,6 +211,10 @@ public class ServicesEndpoint {
     public static final String RUNNING_NAME = "running";
     /** Status model field name. */
     public static final String STATUS_NAME = "status";
+    /** Online model field name. */
+    public static final String ONLINE_NAME = "online";
+    /** Maintenance model field name. */
+    public static final String MAINTENANCE_NAME = "maintenance";
 
     /** Wrapped {@code ServiceStatistics} instance. */
     private final ServiceStatistics serviceStatistics;
@@ -296,6 +300,22 @@ public class ServicesEndpoint {
     }
 
     /**
+     * Returns whether the service is online.
+     * @return online status
+     */
+    public boolean getIsOnline() {
+      return serviceStatistics.getServiceRegistration().isOnline();
+    }
+
+    /**
+     * Returns whether the service is in maintenance.
+     * @return maintenance status
+     */
+    public boolean getisMaintenance() {
+      return serviceStatistics.getServiceRegistration().isInMaintenanceMode();
+    }
+
+    /**
      * Returns a map of all service fields.
      * @return a map of all service fields
      */
@@ -310,6 +330,8 @@ public class ServicesEndpoint {
       serviceMap.put(QUEUED_NAME, Integer.toString(getQueuedJobs()));
       serviceMap.put(RUNNING_NAME, Integer.toString(getRunningJobs()));
       serviceMap.put(STATUS_NAME, getStatus().name());
+      serviceMap.put(ONLINE_NAME, Boolean.toString(getIsOnline()));
+      serviceMap.put(MAINTENANCE_NAME, Boolean.toString(getisMaintenance()));
       return serviceMap;
     }
 
@@ -331,7 +353,9 @@ public class ServicesEndpoint {
               f(MEAN_QUEUE_TIME_NAME, v(getMeanQueueTime())), f(MEAN_RUN_TIME_NAME, v(getMeanRunTime())),
               f(NAME_NAME, v(getName(), Jsons.BLANK)), f(QUEUED_NAME, v(getQueuedJobs())),
               f(RUNNING_NAME, v(getRunningJobs())),
-              f(STATUS_NAME, v(SERVICE_STATUS_TRANSLATION_PREFIX + getStatus().name(), Jsons.BLANK)));
+              f(STATUS_NAME, v(SERVICE_STATUS_TRANSLATION_PREFIX + getStatus().name(), Jsons.BLANK)),
+              f(ONLINE_NAME, v(getIsOnline())),
+              f(MAINTENANCE_NAME, v(getisMaintenance())));
     }
   }
 

--- a/modules/admin-ui/src/test/resources/services.json
+++ b/modules/admin-ui/src/test/resources/services.json
@@ -12,6 +12,8 @@
       "nodeName": "node1",
       "name": "service1",
       "completed": 0,
+      "online": true,
+      "maintenance": false,
       "status": "SYSTEMS.SERVICES.STATUS.NORMAL"
     }, {
       "running": 0,
@@ -22,6 +24,8 @@
       "nodeName": "node1",
       "name": "service2",
       "completed": 5,
+      "online": true,
+      "maintenance": false,
       "status": "SYSTEMS.SERVICES.STATUS.ERROR"
     }, {
       "running": 2,
@@ -32,6 +36,8 @@
       "nodeName": "node2",
       "name": "service3",
       "completed": 20,
+      "online": true,
+      "maintenance": false,
       "status": "SYSTEMS.SERVICES.STATUS.NORMAL"
     }, {
       "running": 1,
@@ -42,6 +48,8 @@
       "nodeName": "node3",
       "name": "service4",
       "completed": 0,
+      "online": true,
+      "maintenance": false,
       "status": "SYSTEMS.SERVICES.STATUS.WARNING"
     }, {
       "running": 0,
@@ -52,6 +60,8 @@
       "nodeName": "node2",
       "name": "service5",
       "completed": 10,
+      "online": true,
+      "maintenance": false,
       "status": "SYSTEMS.SERVICES.STATUS.NORMAL"
     }, {
       "running": 0,
@@ -62,6 +72,8 @@
       "nodeName": "node4",
       "name": "service6",
       "completed": 0,
+      "online": true,
+      "maintenance": false,
       "status": "SYSTEMS.SERVICES.STATUS.NORMAL"
     }]
 }


### PR DESCRIPTION
Makes the "GET /services.json" endpoint return additional information on whether a service is online, offline or in maintenance. This can then be displayed in the admin ui to make it easier to discern whether the service is online, without having to first match it with its host in the servers table.

Intended to help with https://github.com/opencast/opencast-admin-interface/issues/1166.

This PR does **not** break the admin ui and can thus be merged anytime.

### How to test this patch

Check results from `/admin-ng/services/services.json` for the new fields. Compare to results from `/services/services.json`.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
