### PR TITLE
Enable partial matching in SearchRestService

### DIFF
--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
@@ -189,7 +189,7 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
     }
 
     if (StringUtils.isNotEmpty(text)) {
-      query.must(QueryBuilders.matchQuery("fulltext", text));
+      query.must(QueryBuilders.wildcardQuery("fulltext", "*" + text.toLowerCase() + "*"));
     }
 
     var user = securityService.getUser();
@@ -379,7 +379,7 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
     }
 
     if (StringUtils.isNotEmpty(text)) {
-      query.must(QueryBuilders.matchQuery("fulltext", text));
+      query.must(QueryBuilders.wildcardQuery("fulltext", "*" + text.toLowerCase() + "*"));
     }
 
     var user = securityService.getUser();


### PR DESCRIPTION
With OC < 16.x you could search for episodes and series in the OC Media Module with only parts of the title matching. Since OC 16.x this behaviour changed so that results are only shown if a complete word matches the search-input. 

This PR restores partial matching by including wildcards before and after the search input. 

The patch appears to work well, though I am unsure how it affects performance on very large datasets — feedback is welcome.

### How to test this patch

Go to https://develop.opencast.org/engage/ui/index.html and search for "Espress". Even though there is an episode with the title "Espresso" no result is shown. 
Now replicate this in an Opencast instance with this patch applied, and verify that the expected result is returned.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
