### PR TITLE
Workaround for "laggy" servers table in admin ui

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ServerEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ServerEndpoint.java
@@ -55,6 +55,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -146,6 +147,7 @@ public class ServerEndpoint {
   }
 
   private class Server {
+    protected long id;
     protected boolean online;
     protected boolean maintenance;
     protected String hostname;
@@ -155,12 +157,17 @@ public class ServerEndpoint {
     protected long queued;
   }
 
+  private class CachedServer {
+    protected long running;
+    protected long queued;
+  }
+
   private static final Logger logger = LoggerFactory.getLogger(ServerEndpoint.class);
 
   private ServiceRegistry serviceRegistry;
 
   private long lastUpdated = 0;
-  private final List<Server> serverData = new ArrayList<>();
+  private final Map<Long, CachedServer> cachedServerData = new HashMap<>();
 
   /** OSGi callback for the service registry. */
   @Reference
@@ -267,29 +274,47 @@ public class ServerEndpoint {
    *          If the host data could not be retrieved
    */
   private synchronized List<Server> getServerData() throws ServiceRegistryException {
-    // Check if cache is still valid
-    if (lastUpdated + CACHE_SECONDS > Instant.now().getEpochSecond()) {
-      logger.debug("Using server data cache.");
-      return serverData;
-    }
+    List<Server> serverData = new ArrayList<>();
 
-    // Update cache
-    serverData.clear();
-    logger.debug("Updating server data");
-    HostStatistics statistics = serviceRegistry.getHostStatistics();
     for (HostRegistration host : serviceRegistry.getHostRegistrations()) {
       // Calculate statistics per server
       Server server = new Server();
+      server.id = host.getId();
       server.online = host.isOnline();
       server.maintenance = host.isMaintenanceMode();
       server.hostname = host.getBaseUrl();
       server.nodeName = host.getNodeName();
       server.cores = host.getCores();
-      server.running = statistics.runningJobs(host.getId());
-      server.queued = statistics.queuedJobs(host.getId());
       serverData.add(server);
     }
-    lastUpdated = Instant.now().getEpochSecond();
+
+    // Check if cache is still valid
+    if (lastUpdated + CACHE_SECONDS < Instant.now().getEpochSecond()) {
+      // Update cache
+      cachedServerData.clear();
+      logger.debug("Updating server data");
+      HostStatistics statistics = serviceRegistry.getHostStatistics();
+      for (HostRegistration host : serviceRegistry.getHostRegistrations()) {
+        // Calculate statistics per server
+        CachedServer server = new CachedServer();
+        server.running = statistics.runningJobs(host.getId());
+        server.queued = statistics.queuedJobs(host.getId());
+        cachedServerData.put(host.getId(), server);
+      }
+      lastUpdated = Instant.now().getEpochSecond();
+    }
+
+    // Add info from cache
+    for (int i = 0; i < serverData.size(); i++) {
+      Optional<CachedServer> cachedServer = Optional.ofNullable(cachedServerData.get(serverData.get(i).id));
+      if (cachedServer.isPresent()) {
+        Server server = serverData.get(i);
+        server.running = cachedServer.get().running;
+        server.queued = cachedServer.get().queued;
+        serverData.set(i, server);
+      }
+    }
+
     return serverData;
   }
 

--- a/modules/admin-ui/src/test/resources/servers.json
+++ b/modules/admin-ui/src/test/resources/servers.json
@@ -4,6 +4,7 @@
   "offset": 0,
   "results": [
     {
+      "id": 99467145,
       "cores": 8,
       "hostname": "host1",
       "maintenance": false,
@@ -13,6 +14,7 @@
       "running": 2
     },
     {
+      "id": 99467146,
       "cores": 4,
       "hostname": "host2",
       "maintenance": true,
@@ -22,6 +24,7 @@
       "running": 4
     },
     {
+      "id": 99467147,
       "cores": 2,
       "hostname": "host3",
       "maintenance": false,
@@ -31,6 +34,7 @@
       "running": 2
     },
     {
+      "id": 99467148,
       "cores": 6,
       "hostname": "host4",
       "maintenance": true,


### PR DESCRIPTION
Fixes https://github.com/opencast/opencast-admin-interface/issues/689.

Fixes the issue that toggling maintenance mode for a server in the admin ui is only reflected in the ui after 0 to 60 seconds. The changes should now be reflected immediately.

What is happening:
The backend is caching all server data it returns to the frontend, updating it only after at least 60 seconds have passed. This is due to the statistics queries being expensive enough to potentially take down the database if many users have the servers table open in the frontend ui. Problem is, all non-statistics data like maintenance status is cached as well. This patch removes all non-statistics data from the cache, so that it can always be up-to-date.

### How to test this patch
- Open the servers table in the admin ui and set/unset maintenance mode.
- Attempt to ddos your Opencast by opening the server table many times (ideally with an Opencast that has many jobs in its database).

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
