### PR TITLE
Introduce configuration "atLeastOne" for getting tags and flavors

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/segmentpreviews-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/segmentpreviews-woh.md
@@ -12,15 +12,15 @@ previous discovered segments.
 Parameter Table
 ---------------
 
-|configuration keys|example|description|
-|------------------|-------|-----------|
-|source-flavor|presenter/source|Specifies which media should be processed.|
-|target-flavor|presenter/work|Specifies the flavor the new files will get.|
-|source-tags    |engage    |Specifies which media should be processed.     |
-|target-tags    |engage    |Specifies the tags the new files will get.     |
-|encoding-profile    |search-cover.http    |The encoding profile to use.     |
-|reference-flavor    |presentation/work    |Flavor of the segments to use.     |
-|reference-tags    |engage    |Tags of the segments to use.     |
+| configuration keys | example           | description                                                                                |
+|--------------------|-------------------|--------------------------------------------------------------------------------------------|
+| source-flavor      | presenter/source  | Specifies which media should be processed. At least one source flavor or tag is required.  |
+| target-flavor      | presenter/work    | Specifies the flavor the new files will get.                                               |
+| source-tags        | engage            | Specifies which media should be processed.  At least one source flavor or tag is required. |
+| target-tags        | engage            | Specifies the tags the new files will get.                                                 |
+| encoding-profile   | search-cover.http | The encoding profile to use.                                                               |
+| reference-flavor   | presentation/work | Flavor of the segments to use.                                                             |
+| reference-tags     | engage            | Tags of the segments to use.                                                               |
 
 Operation Example
 -----------------

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SegmentPreviewsWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SegmentPreviewsWorkflowOperationHandler.java
@@ -193,7 +193,7 @@ public class SegmentPreviewsWorkflowOperationHandler extends AbstractWorkflowOpe
     // Read the configuration properties
     ConfiguredTagsAndFlavors tagsAndFlavors = getTagsAndFlavors(wi,
         Configuration.atLeastOne, Configuration.many, Configuration.one);
-    MediaPackageElementFlavor sourceVideoFlavor = tagsAndFlavors.getSingleSrcFlavor();
+    List<MediaPackageElementFlavor> sourceVideoFlavors = tagsAndFlavors.getSrcFlavors();
     List<String> sourceTagSet = tagsAndFlavors.getSrcTags();
     ConfiguredTagsAndFlavors.TargetTags targetImageTags = tagsAndFlavors.getTargetTags();
     MediaPackageElementFlavor targetImageFlavor = tagsAndFlavors.getSingleTargetFlavor();
@@ -208,7 +208,9 @@ public class SegmentPreviewsWorkflowOperationHandler extends AbstractWorkflowOpe
 
     // Select the tracks based on the tags and flavors
     TrackSelector trackSelector = new TrackSelector();
-    trackSelector.addFlavor(sourceVideoFlavor);
+    for (MediaPackageElementFlavor flavor : sourceVideoFlavors) {
+      trackSelector.addFlavor(flavor);
+    }
     for (String tag : sourceTagSet) {
       trackSelector.addTag(tag);
     }

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SegmentPreviewsWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SegmentPreviewsWorkflowOperationHandler.java
@@ -225,7 +225,7 @@ public class SegmentPreviewsWorkflowOperationHandler extends AbstractWorkflowOpe
 
     if (videoTrackSet.size() == 0) {
       logger.debug("Mediapackage {} has no suitable tracks to extract images based on tags {} and flavor {}",
-              mediaPackage, sourceTagSet, sourceVideoFlavor);
+              mediaPackage, sourceTagSet, sourceVideoFlavors);
       return createResult(mediaPackage, Action.CONTINUE);
     } else {
 

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SegmentPreviewsWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SegmentPreviewsWorkflowOperationHandler.java
@@ -192,7 +192,7 @@ public class SegmentPreviewsWorkflowOperationHandler extends AbstractWorkflowOpe
 
     // Read the configuration properties
     ConfiguredTagsAndFlavors tagsAndFlavors = getTagsAndFlavors(wi,
-        Configuration.many, Configuration.one, Configuration.many, Configuration.one);
+        Configuration.atLeastOne, Configuration.many, Configuration.one);
     MediaPackageElementFlavor sourceVideoFlavor = tagsAndFlavors.getSingleSrcFlavor();
     List<String> sourceTagSet = tagsAndFlavors.getSrcTags();
     ConfiguredTagsAndFlavors.TargetTags targetImageTags = tagsAndFlavors.getTargetTags();

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/AbstractWorkflowOperationHandler.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/AbstractWorkflowOperationHandler.java
@@ -69,7 +69,7 @@ public abstract class AbstractWorkflowOperationHandler implements WorkflowOperat
 
   /** Config for Tag Parsing operation */
   protected enum Configuration {
-    none, one, many
+    none, one, atLeastOne, many
   };
 
   public static final String TARGET_FLAVORS = "target-flavors";
@@ -372,14 +372,60 @@ public abstract class AbstractWorkflowOperationHandler implements WorkflowOperat
   }
 
   /**
+   * Uses one {@code configuration} for both source tags and flavors, in case the WOH does not care whether the source
+   * entities are identified by tags or flavors.
+   *
+   * @see AbstractWorkflowOperationHandler#getTagsAndFlavors(WorkflowInstance, Configuration, Configuration,
+   *      Configuration, Configuration)
+   */
+  protected ConfiguredTagsAndFlavors getTagsAndFlavors(WorkflowInstance workflow, Configuration srcTagsAndFlavors,
+      Configuration targetTags, Configuration targetFlavors) throws WorkflowOperationException {
+    ConfiguredTagsAndFlavors tagsAndFlavors = getTagsAndFlavors(
+        workflow,
+        Configuration.many,
+        Configuration.many,
+        targetTags,
+        targetFlavors);
+
+    switch(srcTagsAndFlavors) {
+      case none:
+        if (!tagsAndFlavors.getSrcFlavors().isEmpty() || !tagsAndFlavors.getSrcTags().isEmpty()) {
+          throw new WorkflowOperationException("No source tags or flavors may be set.");
+        }
+        break;
+      case one:
+        if (tagsAndFlavors.getSrcFlavors().size() + tagsAndFlavors.getSrcTags().size() != 1) {
+          throw new WorkflowOperationException("Exactly one source tag or flavor must be set.");
+        }
+        break;
+      case atLeastOne:
+        if (tagsAndFlavors.getSrcFlavors().size() + tagsAndFlavors.getSrcTags().size() < 1) {
+          throw new WorkflowOperationException("At least one source tag or flavor must be set.");
+        }
+        break;
+      case many:
+        break;
+      default:
+        throw new WorkflowOperationException("Couldn't process srcTagsAndFlavors configuration option!");
+    }
+
+    return tagsAndFlavors;
+  }
+
+  /**
    * Returns a ConfiguredTagsAndFlavors instance, which includes all specified source/target tags and flavors if they
-   * are valid. Lists can be empty, if no values were specified! This is to enable WOHs to individually check if a
-   * given tag/flavor was set. This also means that you should use Configuration.many as parameter, if a tag/flavor is
-   * optional.
-   * @param srcTags none, one or many
-   * @param srcFlavors none, one or many
-   * @param targetFlavors none, one or many
-   * @param targetTags none, one or many
+   * are valid.
+   * Lists can be empty, if no values were specified! This is to enable WOHs to individually check if a given tag/flavor
+   * was set.
+   * This also means that you should use Configuration.many as parameter, if a tag/flavor is optional.
+   * None: Must not be specified
+   * One: Exactly one must be specified
+   * AtLeastOne: At least one must be specified
+   * Many: An arbitrary amount may be specified
+   * @param srcTags none, one, atLeastOne or many
+   * @param srcFlavors none, one, atLeastOne or many
+   * @param targetFlavors none, one, atLeastOne or many
+   * @param targetTags none, one, atLeastOne or many
    * @return ConfiguredTagsAndFlavors object including lists for the configured tags/flavors
    */
   protected ConfiguredTagsAndFlavors getTagsAndFlavors(WorkflowInstance workflow, Configuration srcTags,
@@ -390,23 +436,25 @@ public abstract class AbstractWorkflowOperationHandler implements WorkflowOperat
     MediaPackageElementFlavor flavor;
 
     List<String> srcTagList = new ArrayList<>();
-    String srcTag;
     switch(srcTags) {
       case none:
         break;
       case one:
-        srcTag = StringUtils.trimToNull(operation.getConfiguration(SOURCE_TAG));
+        String srcTag = StringUtils.trimToNull(operation.getConfiguration(SOURCE_TAG));
         if (srcTag == null) {
           throw new WorkflowOperationException("Configuration key '" + SOURCE_TAG + "' must be set");
         }
         srcTagList.add(srcTag);
         break;
-      case many:
-        srcTagList = asList(StringUtils.trimToNull(operation.getConfiguration(SOURCE_TAGS)));
-        srcTag = StringUtils.trimToNull(operation.getConfiguration(SOURCE_TAG));
-        if (srcTagList.isEmpty() && srcTag != null) {
-          srcTagList.add(srcTag);
+      case atLeastOne:
+        srcTagList = getTags(operation, SOURCE_TAGS, SOURCE_TAG);
+        if (srcTagList.isEmpty()) {
+          throw new WorkflowOperationException("Configuration key '" + SOURCE_TAGS + "' or '" + SOURCE_TAG
+              + "' must be set");
         }
+        break;
+      case many:
+        srcTagList = getTags(operation, SOURCE_TAGS, SOURCE_TAG);
         break;
       default:
         throw new WorkflowOperationException("Couldn't process srcTags configuration option!");
@@ -414,12 +462,11 @@ public abstract class AbstractWorkflowOperationHandler implements WorkflowOperat
     tagsAndFlavors.setSrcTags(srcTagList);
 
     List<MediaPackageElementFlavor> srcFlavorList = new ArrayList<>();
-    String singleSourceFlavor;
     switch(srcFlavors) {
       case none:
         break;
       case one:
-        singleSourceFlavor = StringUtils.trimToNull(operation.getConfiguration(SOURCE_FLAVOR));
+        String singleSourceFlavor = StringUtils.trimToNull(operation.getConfiguration(SOURCE_FLAVOR));
         if (singleSourceFlavor == null) {
           throw new WorkflowOperationException("Configuration key '" + SOURCE_FLAVOR + "' must be set");
         }
@@ -430,20 +477,15 @@ public abstract class AbstractWorkflowOperationHandler implements WorkflowOperat
         }
         srcFlavorList.add(flavor);
         break;
+      case atLeastOne:
+        srcFlavorList = getFlavors(operation, SOURCE_FLAVORS, SOURCE_FLAVOR);
+        if (srcFlavorList.isEmpty()) {
+          throw new WorkflowOperationException("Configuration key '" + SOURCE_FLAVORS + "' or '" + SOURCE_FLAVOR
+              + "' must be set");
+        }
+        break;
       case many:
-        List<String> srcFlavorString = asList(StringUtils.trimToNull(operation.getConfiguration(SOURCE_FLAVORS)));
-        singleSourceFlavor = StringUtils.trimToNull(operation.getConfiguration(SOURCE_FLAVOR));
-        if (srcFlavorString.isEmpty() && singleSourceFlavor != null) {
-          srcFlavorString.add(singleSourceFlavor);
-        }
-        for (String elem : srcFlavorString) {
-          try {
-            flavor = MediaPackageElementFlavor.parseFlavor(elem);
-            srcFlavorList.add(flavor);
-          } catch (IllegalArgumentException e) {
-            throw new WorkflowOperationException(elem + " is not a valid flavor!");
-          }
-        }
+        srcFlavorList = getFlavors(operation, SOURCE_FLAVORS, SOURCE_FLAVOR);
         break;
       default:
         throw new WorkflowOperationException("Couldn't process srcFlavors configuration option!");
@@ -451,24 +493,28 @@ public abstract class AbstractWorkflowOperationHandler implements WorkflowOperat
     tagsAndFlavors.setSrcFlavors(srcFlavorList);
 
     ConfiguredTagsAndFlavors.TargetTags targetTagMap = new ConfiguredTagsAndFlavors.TargetTags();
-    String targetTag;
+    List<String> targetTagList = new ArrayList<>();
     switch(targetTags) {
       case none:
         break;
       case one:
-        targetTag = StringUtils.trimToNull(operation.getConfiguration(TARGET_TAG));
+        String targetTag = StringUtils.trimToNull(operation.getConfiguration(TARGET_TAG));
         if (targetTag == null) {
           throw new WorkflowOperationException("Configuration key '" + TARGET_TAG + "' must be set");
         }
         targetTagMap = parseTargetTagsByType(List.of(targetTag));
         break;
-      case many:
-        List<String> targetTagList = asList(StringUtils.trimToNull(operation.getConfiguration(TARGET_TAGS)));
-        targetTagMap = parseTargetTagsByType(targetTagList);
-        targetTag = StringUtils.trimToNull(operation.getConfiguration(TARGET_TAG));
-        if (targetTagList.isEmpty() && targetTag != null) {
-          targetTagMap = parseTargetTagsByType(List.of(targetTag));
+      case atLeastOne:
+        targetTagList = getTags(operation, TARGET_TAGS, TARGET_TAG);
+        if (targetTagList.isEmpty()) {
+          throw new WorkflowOperationException("Configuration key '" + TARGET_TAGS + "' or '" + TARGET_TAG
+              + "' must be set");
         }
+        targetTagMap = parseTargetTagsByType(targetTagList);
+        break;
+      case many:
+        targetTagList = getTags(operation, TARGET_TAGS, TARGET_TAG);
+        targetTagMap = parseTargetTagsByType(targetTagList);
         break;
       default:
         throw new WorkflowOperationException("Couldn't process target-tag configuration option!");
@@ -476,12 +522,11 @@ public abstract class AbstractWorkflowOperationHandler implements WorkflowOperat
     tagsAndFlavors.setTargetTags(targetTagMap);
 
     List<MediaPackageElementFlavor> targetFlavorList = new ArrayList<>();
-    String singleTargetFlavor;
     switch(targetFlavors) {
       case none:
         break;
       case one:
-        singleTargetFlavor = StringUtils.trimToNull(operation.getConfiguration(TARGET_FLAVOR));
+        String singleTargetFlavor = StringUtils.trimToNull(operation.getConfiguration(TARGET_FLAVOR));
         if (singleTargetFlavor == null) {
           throw new WorkflowOperationException("Configuration key '" + TARGET_FLAVOR + "' must be set");
         }
@@ -492,20 +537,15 @@ public abstract class AbstractWorkflowOperationHandler implements WorkflowOperat
         }
         targetFlavorList.add(flavor);
         break;
+      case atLeastOne:
+        targetFlavorList = getFlavors(operation, TARGET_FLAVORS, TARGET_FLAVOR);
+        if (targetTagList.isEmpty()) {
+          throw new WorkflowOperationException("Configuration key '" + TARGET_FLAVORS + "' or '" + TARGET_FLAVOR
+              + "' must be set");
+        }
+        break;
       case many:
-        List<String> targetFlavorString = asList(StringUtils.trimToNull(operation.getConfiguration(TARGET_FLAVORS)));
-        singleTargetFlavor = StringUtils.trimToNull(operation.getConfiguration(TARGET_FLAVOR));
-        if (targetFlavorString.isEmpty() && singleTargetFlavor != null) {
-          targetFlavorString.add(singleTargetFlavor);
-        }
-        for (String elem : targetFlavorString) {
-          try {
-            flavor = MediaPackageElementFlavor.parseFlavor(elem);
-          } catch (IllegalArgumentException e) {
-            throw new WorkflowOperationException(elem + " is not a valid flavor!");
-          }
-          targetFlavorList.add(flavor);
-        }
+        targetFlavorList = getFlavors(operation, TARGET_FLAVORS, TARGET_FLAVOR);
         break;
       default:
         throw new WorkflowOperationException("Couldn't process targetFlavors configuration option!");
@@ -569,6 +609,34 @@ public abstract class AbstractWorkflowOperationHandler implements WorkflowOperat
     }
 
     return element;
+  }
+
+  private List<String> getTags(WorkflowOperationInstance operation, String multipleTagsKey, String singleTagKey) {
+    List<String> tagList = asList(StringUtils.trimToNull(operation.getConfiguration(multipleTagsKey)));
+    String singleTag = StringUtils.trimToNull(operation.getConfiguration(singleTagKey));
+    if (tagList.isEmpty() && singleTag != null) {
+      tagList.add(singleTag);
+    }
+    return tagList;
+  }
+
+  private List<MediaPackageElementFlavor> getFlavors(WorkflowOperationInstance operation, String multipleFlavorsKey,
+      String singleFlavorKey) throws WorkflowOperationException {
+    List<MediaPackageElementFlavor> flavorList = new ArrayList<>();
+    List<String> singleFlavorString = asList(StringUtils.trimToNull(operation.getConfiguration(multipleFlavorsKey)));
+    String singleSourceFlavor = StringUtils.trimToNull(operation.getConfiguration(singleFlavorKey));
+    if (singleFlavorString.isEmpty() && singleSourceFlavor != null) {
+      singleFlavorString.add(singleSourceFlavor);
+    }
+    for (String elem : singleFlavorString) {
+      try {
+        MediaPackageElementFlavor flavor = MediaPackageElementFlavor.parseFlavor(elem);
+        flavorList.add(flavor);
+      } catch (IllegalArgumentException e) {
+        throw new WorkflowOperationException(elem + " is not a valid flavor!");
+      }
+    }
+    return flavorList;
   }
 
   /**


### PR DESCRIPTION
My suggestion on how to fix #3530.

Most workflow operation handlers use `.getTagsAndFlavors` to parse tags and flavors (and if they don't they probably should). The `Configuration` arguments determine whether there should be zero, exactly one or an arbitrary amount of e.g. source flavors.

This commit introduces a new `Configuration` option called "atLeastOne", so that there for example must be at least one source flavor or more, but not zero.

This commit also introduces a new parameter list for `.getTagsAndFlavors` where the `Configuration` for both source tags and source flavors can be specified together. This means that the configuration will be applied to the sum of source tags and source flavors. I imagine this will mostly be used in combination with "atLeastOne", for WOHs that want at least one source flavor or tag specified, but don't particularly care which one.

### How to test this patch

Modify the segmentpreviews operation in the fast workflow with different combinations of source flavors and source tags. (Be sure to choose a presentation video long enough for segment-video to generate segments).

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
