### PR TITLE
Remove entwine from Import-/ExportWorkflowPropertiesWOH.java

### DIFF
--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ExportWorkflowPropertiesWOH.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ExportWorkflowPropertiesWOH.java
@@ -20,7 +20,6 @@
  */
 package org.opencastproject.workflow.handler.workflow;
 
-import static com.entwinemedia.fn.Stream.$;
 import static org.opencastproject.workflow.handler.workflow.ImportWorkflowPropertiesWOH.loadPropertiesFromXml;
 
 import org.opencastproject.job.api.JobContext;
@@ -41,8 +40,6 @@ import org.opencastproject.workflow.api.WorkflowOperationResult;
 import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
 import org.opencastproject.workspace.api.Workspace;
 
-import com.entwinemedia.fn.fns.Strings;
-
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -54,12 +51,15 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * Workflow operation handler for exporting workflow properties.
@@ -97,7 +97,10 @@ public class ExportWorkflowPropertiesWOH extends AbstractWorkflowOperationHandle
           throws WorkflowOperationException {
     logger.info("Start exporting workflow properties for workflow {}", workflowInstance);
     final MediaPackage mediaPackage = workflowInstance.getMediaPackage();
-    final Set<String> keys = $(getOptConfig(workflowInstance, KEYS_PROPERTY)).bind(Strings.splitCsv).toSet();
+    // Parse CSV
+    final Set<String> keys = Optional.ofNullable(getOptConfig(workflowInstance, KEYS_PROPERTY).orNull())
+        .map(s -> Arrays.stream(s.split("\\s*,\\s*")).collect(Collectors.toSet()))
+        .orElse(Collections.emptySet());
     ConfiguredTagsAndFlavors tagsAndFlavors = getTagsAndFlavors(workflowInstance,
         Configuration.none, Configuration.none, Configuration.many, Configuration.many);
     List<MediaPackageElementFlavor> targetFlavorList = tagsAndFlavors.getTargetFlavors();

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ImportWorkflowPropertiesWOH.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ImportWorkflowPropertiesWOH.java
@@ -21,7 +21,6 @@
 
 package org.opencastproject.workflow.handler.workflow;
 
-import static com.entwinemedia.fn.Stream.$;
 import static org.opencastproject.workflow.api.WorkflowOperationResult.Action.CONTINUE;
 import static org.opencastproject.workflow.api.WorkflowOperationResult.Action.SKIP;
 
@@ -39,8 +38,6 @@ import org.opencastproject.workflow.api.WorkflowOperationHandler;
 import org.opencastproject.workflow.api.WorkflowOperationResult;
 import org.opencastproject.workspace.api.Workspace;
 
-import com.entwinemedia.fn.fns.Strings;
-
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
@@ -51,11 +48,15 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Workflow operation handler for importing workflow properties.
@@ -99,7 +100,10 @@ public class ImportWorkflowPropertiesWOH extends AbstractWorkflowOperationHandle
     if (attachments.size() == 1) {
       Attachment propertiesElem = attachments.iterator().next();
       Properties properties = loadPropertiesFromXml(workspace, propertiesElem.getURI());
-      final Set<String> keys = $(getOptConfig(wi, KEYS_PROPERTY)).bind(Strings.splitCsv).toSet();
+      // Parse CSV
+      final Set<String> keys = Optional.ofNullable(getOptConfig(wi, KEYS_PROPERTY).orNull())
+          .map(s -> Arrays.stream(s.split("\\s*,\\s*")).collect(Collectors.toSet()))
+          .orElse(Collections.emptySet());
       return createResult(mp, convertToWorkflowProperties(properties, keys), CONTINUE, 0);
     } else {
       logger.info("No attachment with workflow properties found, skipping...");


### PR DESCRIPTION
Replace entwine code with Java. Should result in no functional changes.

### How to test this patch
Run a workflow with the import-wf-properties and export-wf-properties workflow operation.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
