### PR TITLE
Update to Studio 2025-04-30 (important bug fix)

### DIFF
--- a/modules/studio/pom.xml
+++ b/modules/studio/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <opencast.studio.url>https://github.com/elan-ev/opencast-studio/releases/download/2025-04-02/oc-studio-2025-04-02-integrated.tar.gz</opencast.studio.url>
-    <opencast.studio.sha256>d758e13f2a51b62513be93e44adb763c35b849537f092f0ef88badb80ac1d8d9</opencast.studio.sha256>
+    <opencast.studio.url>https://github.com/elan-ev/opencast-studio/releases/download/2025-04-30/oc-studio-2025-04-30-integrated.tar.gz</opencast.studio.url>
+    <opencast.studio.sha256>d9ac678e753ee83ce2d02850ed1239e25c83170e2c127f50738bc75b96c6cc78</opencast.studio.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
This release only contains a bug fix for a bug introduced in the last release (which was merged into Opencast in #6615). Original bug report is https://github.com/elan-ev/opencast-studio/issues/1231, but in short: when uploading, an error message is shown after the upload successfully finished. This would understandably confuse users. There is also a potential other bug that would prevent users from uploading, but that is seemingly not triggered in the wild.

CC @KatrinIhler since you reviewed the Studio PR. I don't think this necessarily warrants an emergency release, since the uploads still work. And the next 17.x release is soonish already anyway?


### How to test this patch

Build Opencast and start it, then open Studio (`/studio`), record a video and upload it.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
