### PR TITLE
Allow Opensearch to be in yellow state

### DIFF
--- a/modules/elasticsearch-impl/src/main/java/org/opencastproject/elasticsearch/impl/AbstractElasticsearchIndex.java
+++ b/modules/elasticsearch-impl/src/main/java/org/opencastproject/elasticsearch/impl/AbstractElasticsearchIndex.java
@@ -472,10 +472,13 @@ public abstract class AbstractElasticsearchIndex implements SearchIndex {
     try {
       // test connection
       ClusterHealthRequest request = new ClusterHealthRequest();
-      request.waitForGreenStatus();
+      request.waitForYellowStatus();
       ClusterHealthResponse resp = client.cluster().health(request, RequestOptions.DEFAULT);
       if (resp.getStatus().equals(ClusterHealthStatus.GREEN)) {
         logger.debug("Connected to OpenSearch, cluster health is {}", resp.getStatus());
+        return true;
+      } else if (resp.getStatus().equals(ClusterHealthStatus.YELLOW)) {
+        logger.warn("Connected to OpenSearch, cluster health is {}", resp.getStatus());
         return true;
       }
       logger.debug("Connected to OpenSearch, but cluster health is {}", resp.getStatus());


### PR DESCRIPTION
This is a backport of #6491, which allows the cluster to be in yellow status.  This is common for some of our adopters, and is not necessarily a sign of things being broken.  Originally fixed in 17, a bunch of adopters with 16 are also experiencing issues related to this.

Fixes: #6680 

### How to test this patch

Start Opencast with an Opensearch cluster in Yellow state, and in Green state

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
