### PR TITLE
Document Search index rebuild when enabling episode id roles

### DIFF
--- a/docs/guides/admin/docs/configuration/episode-id-roles.md
+++ b/docs/guides/admin/docs/configuration/episode-id-roles.md
@@ -15,9 +15,9 @@ Setup
 Enable `episode.id.role.access` in `etc/custom.properties`.
 
 To make this work for the Admin UI and External API, the Elasticsearch Index needs to be updated with modified
-ACLs. You can achieve this by calling the `/index/rebuild/AssetManager/ACL` endpoint **after** enabling this feature
-in the aforementioned configuration files.
-The endpoint will reindex only event ACLs.
+ACLs. You can achieve this by calling the `/index/rebuild/AssetManager/ACL` and `/index/rebuild/Search` endpoints 
+**after** enabling this feature in the aforementioned configuration files.
+These endpoints will reindex the event ACLs in both the AssetManager index and the Search index.
 
 In case you have custom actions configured, this will only work for the actions that were configured during the
 reindex of the Elasticsearch index. If you later add custom actions, you will have to reindex again.


### PR DESCRIPTION
We have noticed that users have no access to view videos in the player. The problem was caused by missing episode id based ACLs in the search index, since the role check is handled in the search index. We were able to solve this problem with a search index rebuild.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
