### PR TITLE
Enable feature "Episode ID Roles" by default

### DIFF
--- a/docs/guides/admin/docs/configuration/episode-id-roles.md
+++ b/docs/guides/admin/docs/configuration/episode-id-roles.md
@@ -12,11 +12,11 @@ The `<ACTION>` will be capitalized, but special characters may not be converted 
 Setup
 --------------------
 
-Enable `episode.id.role.access` in `etc/custom.properties`.
+`episode.id.role.access` in `etc/custom.properties` is enabled by default.
 
 To make this work for the Admin UI and External API, the Elasticsearch Index needs to be updated with modified
 ACLs. You can achieve this by calling the `/index/rebuild/AssetManager/ACL` and `/index/rebuild/Search` endpoints 
-**after** enabling this feature in the aforementioned configuration files.
+**after** enabling this feature.
 These endpoints will reindex the event ACLs in both the AssetManager index and the Search index.
 
 In case you have custom actions configured, this will only work for the actions that were configured during the

--- a/docs/guides/admin/docs/configuration/episode-id-roles.md
+++ b/docs/guides/admin/docs/configuration/episode-id-roles.md
@@ -1,7 +1,7 @@
 Episode ID roles
 =================================
 
-If activated, users with a role like `ROLE_EPISODE_<ID>_<ACTION>` will have access to the episode with the given
+Users with a role like `ROLE_EPISODE_<ID>_<ACTION>` will have access to the episode with the given
 identifier, without this having to be explicitly stated in the ACL attached to the episode.
 
 For example, `ROLE_EPISODE_872dc4ec-ca8a-4e12-8dac-ce99784d6d29_READ` will allow the user to get read access to
@@ -12,11 +12,9 @@ The `<ACTION>` will be capitalized, but special characters may not be converted 
 Setup
 --------------------
 
-`episode.id.role.access` in `etc/custom.properties` is enabled by default.
-
-To make this work for the Admin UI and External API, the Elasticsearch Index needs to be updated with modified
-ACLs. You can achieve this by calling the `/index/rebuild/AssetManager/ACL` and `/index/rebuild/Search` endpoints 
-**after** enabling this feature.
+When updating from an Opencast that did not have this feature, to make this work for the Admin UI and External API,
+the Elasticsearch Index needs to be updated with modified ACLs.
+You can achieve this by calling the `/index/rebuild/AssetManager/ACL` and `/index/rebuild/Search` endpoints.
 These endpoints will reindex the event ACLs in both the AssetManager index and the Search index.
 
 In case you have custom actions configured, this will only work for the actions that were configured during the

--- a/docs/guides/admin/docs/releasenotes/magic-roles-default-on.txt
+++ b/docs/guides/admin/docs/releasenotes/magic-roles-default-on.txt
@@ -1,3 +1,3 @@
-The feature "Episode ID Roles" is now enabled by default.
-If you haven't done that before, you need to rebuild parts of the index.
-For more information, see guides/admin/docs/configuration/episode-id-roles.md`.
+The feature "Episode ID Roles" is now a core feature: enabled by default with no to disable.
+If you haven't enabled the feature before, you need to rebuild parts of the index.
+For more information, see guides/admin/docs/configuration/episode-id-roles.md.

--- a/docs/guides/admin/docs/releasenotes/magic-roles-default-on.txt
+++ b/docs/guides/admin/docs/releasenotes/magic-roles-default-on.txt
@@ -1,0 +1,3 @@
+The feature "Episode ID Roles" is now enabled by default.
+If you haven't done that before, you need to rebuild parts of the index.
+For more information, see guides/admin/docs/configuration/episode-id-roles.md`.

--- a/docs/guides/admin/docs/releasenotes/magic-roles-default-on.txt
+++ b/docs/guides/admin/docs/releasenotes/magic-roles-default-on.txt
@@ -1,3 +1,3 @@
 The feature "Episode ID Roles" is now a core feature: enabled by default with no to disable.
-If you haven't enabled the feature before, you need to rebuild parts of the index.
+If you haven't enabled the feature before, you need to rebuild parts of the index (which can be done after the update, while your Opencast is already running).
 For more information, see guides/admin/docs/configuration/episode-id-roles.md.

--- a/etc/custom.properties
+++ b/etc/custom.properties
@@ -344,5 +344,5 @@ karaf.pid.file=${karaf.data}/pid
 # ACLs. You can achieve this by calling the /index/rebuild/AssetManager/ACL endpoint AFTER activating this feature.
 # The endpoint will reindex only event ACLs.
 #
-# Default: false
-#org.opencastproject.episode.id.role.access = false
+# Default: true
+#org.opencastproject.episode.id.role.access = true

--- a/etc/custom.properties
+++ b/etc/custom.properties
@@ -332,17 +332,3 @@ karaf.pid.file=${karaf.data}/pid
 # a system where url signing is not configured. For more information please see:
 # https://docs.opencast.org/develop/admin/#configuration/stream-security/stream-security-config/#configuration-of-url-signing-timeout-values
 #org.opencastproject.security.internal.url.signing.duration=60
-
-# Allow episode ID based access control via roles.
-# If activated, users with a role like ROLE_EPISODE_<ID>_<ACTION> will have access to the episode with the given
-# identifier, without this having to be explicitly stated in the ACL attached to the episode.
-#
-# For example, ROLE_EPISODE_872dc4ec-ca8a-4e12-8dac-ce99784d6d29_READ will allow the user to get read access to episode
-# 872dc4ec-ca8a-4e12-8dac-ce99784d6d29.
-#
-# To make this work for the Admin UI and External API, the Elasticsearch index needs to be updated with modified
-# ACLs. You can achieve this by calling the /index/rebuild/AssetManager/ACL endpoint AFTER activating this feature.
-# The endpoint will reindex only event ACLs.
-#
-# Default: true
-#org.opencastproject.episode.id.role.access = true

--- a/modules/asset-manager-impl/pom.xml
+++ b/modules/asset-manager-impl/pom.xml
@@ -120,10 +120,6 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>osgi.core</artifactId>
-    </dependency>
     <!-- Querydsl -->
     <dependency>
       <groupId>com.mysema.querydsl</groupId>

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
@@ -33,6 +33,7 @@ import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_RO
 import static org.opencastproject.security.api.SecurityConstants.GLOBAL_CAPTURE_AGENT_ROLE;
 import static org.opencastproject.security.util.SecurityUtil.getEpisodeRoleId;
 import static org.opencastproject.systems.OpencastConstants.EPISODE_ID_ROLE_ACCESS_PROPERTY;
+import static org.opencastproject.systems.OpencastConstants.EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT;
 
 import org.opencastproject.assetmanager.api.Asset;
 import org.opencastproject.assetmanager.api.AssetId;
@@ -178,7 +179,7 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
 
   private static final String MANIFEST_DEFAULT_NAME = "manifest";
 
-  private static boolean episodeIdRole = false;
+  private static boolean episodeIdRole = EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT;
 
   private CopyOnWriteArrayList<AssetManagerUpdateHandler> handlers = new CopyOnWriteArrayList<>();
 
@@ -223,8 +224,9 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
     includeCARoles = BooleanUtils.toBoolean(Objects.toString(cc.getProperties().get("includeCARoles"), null));
     includeUIRoles = BooleanUtils.toBoolean(Objects.toString(cc.getProperties().get("includeUIRoles"), null));
 
-    episodeIdRole = BooleanUtils.toBoolean(Objects.toString(
-        cc.getBundleContext().getProperty(EPISODE_ID_ROLE_ACCESS_PROPERTY), "false"));
+    episodeIdRole = Optional.ofNullable(cc.getBundleContext().getProperty(EPISODE_ID_ROLE_ACCESS_PROPERTY))
+        .map(BooleanUtils::toBoolean)
+        .orElse(EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT);
     logger.debug("Usage of episode ID roles is set to {}", episodeIdRole);
   }
 

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
@@ -32,8 +32,6 @@ import static org.opencastproject.security.api.SecurityConstants.EPISODE_ROLE_ID
 import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
 import static org.opencastproject.security.api.SecurityConstants.GLOBAL_CAPTURE_AGENT_ROLE;
 import static org.opencastproject.security.util.SecurityUtil.getEpisodeRoleId;
-import static org.opencastproject.systems.OpencastConstants.EPISODE_ID_ROLE_ACCESS_PROPERTY;
-import static org.opencastproject.systems.OpencastConstants.EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT;
 
 import org.opencastproject.assetmanager.api.Asset;
 import org.opencastproject.assetmanager.api.AssetId;
@@ -179,8 +177,6 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
 
   private static final String MANIFEST_DEFAULT_NAME = "manifest";
 
-  private static boolean episodeIdRole = EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT;
-
   private CopyOnWriteArrayList<AssetManagerUpdateHandler> handlers = new CopyOnWriteArrayList<>();
 
   private SecurityService securityService;
@@ -223,11 +219,6 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
     includeAPIRoles = BooleanUtils.toBoolean(Objects.toString(cc.getProperties().get("includeAPIRoles"), null));
     includeCARoles = BooleanUtils.toBoolean(Objects.toString(cc.getProperties().get("includeCARoles"), null));
     includeUIRoles = BooleanUtils.toBoolean(Objects.toString(cc.getProperties().get("includeUIRoles"), null));
-
-    episodeIdRole = Optional.ofNullable(cc.getBundleContext().getProperty(EPISODE_ID_ROLE_ACCESS_PROPERTY))
-        .map(BooleanUtils::toBoolean)
-        .orElse(EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT);
-    logger.debug("Usage of episode ID roles is set to {}", episodeIdRole);
   }
 
   /**
@@ -1082,7 +1073,7 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
     return securityService.getUser().getRoles().stream()
             .filter(roleFilter)
             .map((role) -> {
-              if (episodeIdRole && role.getName().startsWith(EPISODE_ROLE_ID_PREFIX)) {
+              if (role.getName().startsWith(EPISODE_ROLE_ID_PREFIX)) {
                 return q.mediapackageId().eq(StringUtils.substringBetween(
                     role.getName(), EPISODE_ROLE_ID_PREFIX + "_", "_"));
               } else {
@@ -1119,7 +1110,7 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
         }
         // check episode role id
         User user = securityService.getUser();
-        if (episodeIdRole && user.hasRole(getEpisodeRoleId(mediaPackageId, action))) {
+        if (user.hasRole(getEpisodeRoleId(mediaPackageId, action))) {
           return true;
         }
         // check acl rules

--- a/modules/authorization-xacml/pom.xml
+++ b/modules/authorization-xacml/pom.xml
@@ -51,10 +51,6 @@
       <artifactId>jakarta.xml.bind-api</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>osgi.core</artifactId>
-    </dependency>
     <!-- Logging -->
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
+++ b/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
@@ -24,8 +24,6 @@ package org.opencastproject.authorization.xacml;
 import static org.opencastproject.mediapackage.MediaPackageElements.XACML_POLICY_EPISODE;
 import static org.opencastproject.mediapackage.MediaPackageElements.XACML_POLICY_SERIES;
 import static org.opencastproject.security.util.SecurityUtil.getEpisodeRoleId;
-import static org.opencastproject.systems.OpencastConstants.EPISODE_ID_ROLE_ACCESS_PROPERTY;
-import static org.opencastproject.systems.OpencastConstants.EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT;
 import static org.opencastproject.util.data.Tuple.tuple;
 
 import org.opencastproject.mediapackage.Attachment;
@@ -47,7 +45,6 @@ import org.opencastproject.util.data.Tuple;
 import org.opencastproject.workspace.api.Workspace;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
@@ -98,7 +95,6 @@ public class XACMLAuthorizationService implements AuthorizationService {
 
   /** Definition of how merging of series and episode ACLs work */
   private static MergeMode mergeMode = MergeMode.OVERRIDE;
-  private static boolean episodeIdRole = EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT;
 
   enum MergeMode {
     OVERRIDE, ROLES, ACTIONS
@@ -112,7 +108,6 @@ public class XACMLAuthorizationService implements AuthorizationService {
     if (properties == null) {
       mergeMode = MergeMode.OVERRIDE;
       logger.debug("Merge mode set to {}", mergeMode);
-      episodeIdRole = EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT;
       logger.debug("Using episode ID roles is deactivated");
       return;
     }
@@ -125,11 +120,6 @@ public class XACMLAuthorizationService implements AuthorizationService {
       mergeMode = MergeMode.OVERRIDE;
     }
     logger.debug("Merge mode set to {}", mergeMode);
-
-    episodeIdRole = Optional.ofNullable(cc.getBundleContext().getProperty(EPISODE_ID_ROLE_ACCESS_PROPERTY))
-        .map(BooleanUtils::toBoolean)
-        .orElse(EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT);
-    logger.debug("Usage of episode ID roles is set to {}", episodeIdRole);
   }
 
   @Reference(
@@ -322,13 +312,9 @@ public class XACMLAuthorizationService implements AuthorizationService {
 
     // Check special ROLE_EPISODE_<ID>_<ACTION> permissions
     final User user = securityService.getUser();
-    var allowed = false;
-    logger.debug("episodeIdRole set to: {}", episodeIdRole);
-    if (episodeIdRole) {
-      var episodeRole = getEpisodeRoleId(mp.getIdentifier().toString(), action);
-      logger.debug("Checking for role: {}", episodeRole);
-      allowed = user.getRoles().stream().map(Role::getName).anyMatch(r -> r.equals(episodeRole));
-    }
+    var episodeRole = getEpisodeRoleId(mp.getIdentifier().toString(), action);
+    logger.debug("Checking for role: {}", episodeRole);
+    var allowed = user.getRoles().stream().map(Role::getName).anyMatch(r -> r.equals(episodeRole));
 
     return allowed || hasPermission(acl, action);
   }

--- a/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
+++ b/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
@@ -25,6 +25,7 @@ import static org.opencastproject.mediapackage.MediaPackageElements.XACML_POLICY
 import static org.opencastproject.mediapackage.MediaPackageElements.XACML_POLICY_SERIES;
 import static org.opencastproject.security.util.SecurityUtil.getEpisodeRoleId;
 import static org.opencastproject.systems.OpencastConstants.EPISODE_ID_ROLE_ACCESS_PROPERTY;
+import static org.opencastproject.systems.OpencastConstants.EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT;
 import static org.opencastproject.util.data.Tuple.tuple;
 
 import org.opencastproject.mediapackage.Attachment;
@@ -63,7 +64,6 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
-import java.util.Objects;
 import java.util.Optional;
 
 import javax.xml.bind.JAXBException;
@@ -98,7 +98,7 @@ public class XACMLAuthorizationService implements AuthorizationService {
 
   /** Definition of how merging of series and episode ACLs work */
   private static MergeMode mergeMode = MergeMode.OVERRIDE;
-  private static boolean episodeIdRole = false;
+  private static boolean episodeIdRole = EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT;
 
   enum MergeMode {
     OVERRIDE, ROLES, ACTIONS
@@ -112,7 +112,7 @@ public class XACMLAuthorizationService implements AuthorizationService {
     if (properties == null) {
       mergeMode = MergeMode.OVERRIDE;
       logger.debug("Merge mode set to {}", mergeMode);
-      episodeIdRole = false;
+      episodeIdRole = EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT;
       logger.debug("Using episode ID roles is deactivated");
       return;
     }
@@ -126,8 +126,9 @@ public class XACMLAuthorizationService implements AuthorizationService {
     }
     logger.debug("Merge mode set to {}", mergeMode);
 
-    episodeIdRole = BooleanUtils.toBoolean(Objects.toString(
-        cc.getBundleContext().getProperty(EPISODE_ID_ROLE_ACCESS_PROPERTY), "false"));
+    episodeIdRole = Optional.ofNullable(cc.getBundleContext().getProperty(EPISODE_ID_ROLE_ACCESS_PROPERTY))
+        .map(BooleanUtils::toBoolean)
+        .orElse(EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT);
     logger.debug("Usage of episode ID roles is set to {}", episodeIdRole);
   }
 

--- a/modules/common/src/main/java/org/opencastproject/systems/OpencastConstants.java
+++ b/modules/common/src/main/java/org/opencastproject/systems/OpencastConstants.java
@@ -61,7 +61,4 @@ public interface OpencastConstants {
   /** The property key for the environment defined in the custom.properties */
   String ENVIRONMENT_NAME_PROPERTY = "org.opencastproject.environment.name";
 
-  String EPISODE_ID_ROLE_ACCESS_PROPERTY = "org.opencastproject.episode.id.role.access";
-
-  boolean EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT = true;
 }

--- a/modules/common/src/main/java/org/opencastproject/systems/OpencastConstants.java
+++ b/modules/common/src/main/java/org/opencastproject/systems/OpencastConstants.java
@@ -62,4 +62,6 @@ public interface OpencastConstants {
   String ENVIRONMENT_NAME_PROPERTY = "org.opencastproject.environment.name";
 
   String EPISODE_ID_ROLE_ACCESS_PROPERTY = "org.opencastproject.episode.id.role.access";
+
+  boolean EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT = true;
 }

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/ElasticsearchIndex.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/ElasticsearchIndex.java
@@ -21,8 +21,6 @@
 
 package org.opencastproject.elasticsearch.index;
 
-import static org.opencastproject.systems.OpencastConstants.EPISODE_ID_ROLE_ACCESS_PROPERTY;
-import static org.opencastproject.systems.OpencastConstants.EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT;
 import static org.opencastproject.util.data.functions.Misc.chuck;
 
 import org.opencastproject.elasticsearch.api.SearchIndexException;
@@ -47,7 +45,6 @@ import org.opencastproject.security.api.User;
 
 import com.google.common.util.concurrent.Striped;
 
-import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.delete.DeleteResponse;
@@ -123,8 +120,6 @@ public class ElasticsearchIndex extends AbstractElasticsearchIndex {
 
   private ListProvidersService listProvidersService;
 
-  private boolean episodeIdRole = EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT;
-
   @Reference(
       cardinality = ReferenceCardinality.OPTIONAL,
       policy = ReferencePolicy.DYNAMIC,
@@ -158,11 +153,6 @@ public class ElasticsearchIndex extends AbstractElasticsearchIndex {
     } catch (Throwable t) {
       throw new ComponentException("Error initializing elastic search index", t);
     }
-
-    episodeIdRole = Optional.ofNullable(bundleContext.getProperty(EPISODE_ID_ROLE_ACCESS_PROPERTY))
-        .map(BooleanUtils::toBoolean)
-        .orElse(EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT);
-    logger.debug("Usage of episode ID roles is set to {}", episodeIdRole);
   }
 
   /**
@@ -434,8 +424,7 @@ public class ElasticsearchIndex extends AbstractElasticsearchIndex {
     logger.debug("Adding event {} to search index", event.getIdentifier());
 
     // Add the resource to the index
-    SearchMetadataCollection inputDocument = EventIndexUtils.toSearchMetadata(event, listProvidersService,
-        episodeIdRole);
+    SearchMetadataCollection inputDocument = EventIndexUtils.toSearchMetadata(event, listProvidersService);
     List<SearchMetadata<?>> resourceMetadata = inputDocument.getMetadata();
     ElasticsearchDocument doc = new ElasticsearchDocument(inputDocument.getIdentifier(),
             inputDocument.getDocumentType(), resourceMetadata);
@@ -461,8 +450,7 @@ public class ElasticsearchIndex extends AbstractElasticsearchIndex {
     for (Event event: eventList) {
       logger.debug("Adding event {} to search index", event.getIdentifier());
       // Add the resource to the index
-      SearchMetadataCollection inputDocument = EventIndexUtils.toSearchMetadata(event, listProvidersService,
-          episodeIdRole);
+      SearchMetadataCollection inputDocument = EventIndexUtils.toSearchMetadata(event, listProvidersService);
       List<SearchMetadata<?>> resourceMetadata = inputDocument.getMetadata();
       docs.add(new ElasticsearchDocument(inputDocument.getIdentifier(),
               inputDocument.getDocumentType(), resourceMetadata));

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/ElasticsearchIndex.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/ElasticsearchIndex.java
@@ -22,6 +22,7 @@
 package org.opencastproject.elasticsearch.index;
 
 import static org.opencastproject.systems.OpencastConstants.EPISODE_ID_ROLE_ACCESS_PROPERTY;
+import static org.opencastproject.systems.OpencastConstants.EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT;
 import static org.opencastproject.util.data.functions.Misc.chuck;
 
 import org.opencastproject.elasticsearch.api.SearchIndexException;
@@ -68,7 +69,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.locks.Lock;
 import java.util.function.Function;
@@ -123,7 +123,7 @@ public class ElasticsearchIndex extends AbstractElasticsearchIndex {
 
   private ListProvidersService listProvidersService;
 
-  private boolean episodeIdRole = false;
+  private boolean episodeIdRole = EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT;
 
   @Reference(
       cardinality = ReferenceCardinality.OPTIONAL,
@@ -159,8 +159,9 @@ public class ElasticsearchIndex extends AbstractElasticsearchIndex {
       throw new ComponentException("Error initializing elastic search index", t);
     }
 
-    episodeIdRole = BooleanUtils.toBoolean(Objects.toString(
-        bundleContext.getProperty(EPISODE_ID_ROLE_ACCESS_PROPERTY), "false"));
+    episodeIdRole = Optional.ofNullable(bundleContext.getProperty(EPISODE_ID_ROLE_ACCESS_PROPERTY))
+        .map(BooleanUtils::toBoolean)
+        .orElse(EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT);
     logger.debug("Usage of episode ID roles is set to {}", episodeIdRole);
   }
 

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/event/EventIndexUtils.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/event/EventIndexUtils.java
@@ -115,8 +115,7 @@ public final class EventIndexUtils {
    *          the recording event
    * @return the set of metadata
    */
-  public static SearchMetadataCollection toSearchMetadata(Event event, ListProvidersService listProviderService,
-      boolean episodeIdRole) {
+  public static SearchMetadataCollection toSearchMetadata(Event event, ListProvidersService listProviderService) {
     SearchMetadataCollection metadata = new SearchMetadataCollection(
             event.getIdentifier().concat(event.getOrganization()), Event.DOCUMENT_TYPE);
     metadata.addField(EventIndexSchema.UID, event.getIdentifier(), false);
@@ -247,7 +246,7 @@ public final class EventIndexUtils {
 
     if (StringUtils.isNotBlank(event.getAccessPolicy())) {
       metadata.addField(EventIndexSchema.ACCESS_POLICY, event.getAccessPolicy(), false);
-      addAuthorization(metadata, event.getAccessPolicy(), event.getIdentifier(), listProviderService, episodeIdRole);
+      addAuthorization(metadata, event.getAccessPolicy(), event.getIdentifier(), listProviderService);
     }
 
     if (StringUtils.isNotBlank(event.getAgentId())) {
@@ -373,7 +372,7 @@ public final class EventIndexUtils {
    *          the access control list string
    */
   private static void addAuthorization(SearchMetadataCollection doc, String aclString,
-      String eventId, ListProvidersService listProvidersService, boolean episodeIdRole) {
+      String eventId, ListProvidersService listProvidersService) {
     Map<String, List<String>> permissions = new HashMap<>();
 
     // Define containers for common permissions
@@ -386,26 +385,24 @@ public final class EventIndexUtils {
     List<AccessControlEntry> entries = acl.getEntries();
 
     // Add special action roles for episode id roles
-    if (episodeIdRole) {
-      Set<AccessControlEntry> customEntries = new HashSet<>();
-      customEntries.add(new AccessControlEntry(getEpisodeRoleId(eventId, "READ"), "read", true));
-      customEntries.add(new AccessControlEntry(getEpisodeRoleId(eventId, "WRITE"), "write", true));
+    Set<AccessControlEntry> customEntries = new HashSet<>();
+    customEntries.add(new AccessControlEntry(getEpisodeRoleId(eventId, "READ"), "read", true));
+    customEntries.add(new AccessControlEntry(getEpisodeRoleId(eventId, "WRITE"), "write", true));
 
-      ResourceListQuery query = new ResourceListQueryImpl();
-      if (listProvidersService.hasProvider("ACL.ACTIONS")) {
-        Map<String, String> actions = new HashMap<>();
-        try {
-          actions = listProvidersService.getList("ACL.ACTIONS", query, true);
-        } catch (ListProviderException e) {
-          logger.error("Listproviders not loaded. " + e);
-        }
-        for (String action : actions.keySet()) {
-          customEntries.add(new AccessControlEntry(getEpisodeRoleId(eventId, action), action, true));
-        }
+    ResourceListQuery query = new ResourceListQueryImpl();
+    if (listProvidersService.hasProvider("ACL.ACTIONS")) {
+      Map<String, String> actions = new HashMap<>();
+      try {
+        actions = listProvidersService.getList("ACL.ACTIONS", query, true);
+      } catch (ListProviderException e) {
+        logger.error("Listproviders not loaded. " + e);
       }
-
-      entries.addAll(customEntries);
+      for (String action : actions.keySet()) {
+        customEntries.add(new AccessControlEntry(getEpisodeRoleId(eventId, action), action, true));
+      }
     }
+
+    entries.addAll(customEntries);
 
     // Convert roles to permission blocks
     for (AccessControlEntry entry : entries) {

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
@@ -22,8 +22,6 @@
 package org.opencastproject.search.impl;
 
 import static org.opencastproject.security.util.SecurityUtil.getEpisodeRoleId;
-import static org.opencastproject.systems.OpencastConstants.EPISODE_ID_ROLE_ACCESS_PROPERTY;
-import static org.opencastproject.systems.OpencastConstants.EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT;
 
 import org.opencastproject.elasticsearch.index.ElasticsearchIndex;
 import org.opencastproject.elasticsearch.index.rebuild.AbstractIndexProducer;
@@ -67,7 +65,6 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.BooleanUtils;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.index.IndexRequest;
@@ -100,7 +97,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -151,8 +147,6 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
 
   private ListProvidersService listProvidersService;
 
-  private boolean episodeIdRole = EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT;
-
   private String systemUserName = null;
 
 
@@ -170,11 +164,6 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
    */
   @Activate
   public void activate(final ComponentContext cc) throws IllegalStateException {
-    episodeIdRole = Optional.ofNullable(cc.getBundleContext().getProperty(EPISODE_ID_ROLE_ACCESS_PROPERTY))
-        .map(BooleanUtils::toBoolean)
-        .orElse(EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT);
-    logger.debug("Usage of episode ID roles is set to {}", episodeIdRole);
-
     createIndex();
     systemUserName = SecurityUtil.getSystemUserName(cc);
   }
@@ -318,28 +307,26 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
 
     // Add custom roles to the ACL
     // This allows users with a role of the form ROLE_EPISODE_<ID>_<ACTION> to access the event through the index
-    if (episodeIdRole) {
-      Set<AccessControlEntry> customEntries = new HashSet<>();
-      customEntries.add(new AccessControlEntry(getEpisodeRoleId(mediaPackageId, "READ"), "read", true));
-      customEntries.add(new AccessControlEntry(getEpisodeRoleId(mediaPackageId, "WRITE"), "write", true));
+    Set<AccessControlEntry> customEntries = new HashSet<>();
+    customEntries.add(new AccessControlEntry(getEpisodeRoleId(mediaPackageId, "READ"), "read", true));
+    customEntries.add(new AccessControlEntry(getEpisodeRoleId(mediaPackageId, "WRITE"), "write", true));
 
-      ResourceListQuery query = new ResourceListQueryImpl();
-      if (listProvidersService.hasProvider("ACL.ACTIONS")) {
-        Map<String, String> actions = new HashMap<>();
-        try {
-          actions = listProvidersService.getList("ACL.ACTIONS", query, true);
-        } catch (ListProviderException e) {
-          throw new SearchException("Listproviders not loaded. " + e);
-        }
-        for (String action : actions.keySet()) {
-          customEntries.add(
-              new AccessControlEntry(getEpisodeRoleId(mediaPackageId, action), action, true));
-        }
+    ResourceListQuery query = new ResourceListQueryImpl();
+    if (listProvidersService.hasProvider("ACL.ACTIONS")) {
+      Map<String, String> actions = new HashMap<>();
+      try {
+        actions = listProvidersService.getList("ACL.ACTIONS", query, true);
+      } catch (ListProviderException e) {
+        throw new SearchException("Listproviders not loaded. " + e);
       }
-
-      AccessControlList customRoles = new AccessControlList(new ArrayList<>(customEntries));
-      acl = customRoles.merge(acl);
+      for (String action : actions.keySet()) {
+        customEntries.add(
+            new AccessControlEntry(getEpisodeRoleId(mediaPackageId, action), action, true));
+      }
     }
+
+    AccessControlList customRoles = new AccessControlList(new ArrayList<>(customEntries));
+    acl = customRoles.merge(acl);
 
     SearchResult item = new SearchResult(SearchService.IndexEntryType.Episode, dc, acl, orgId, mediaPackage,
         null != modDate ? modDate.toInstant() : Instant.now(),

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
@@ -23,6 +23,7 @@ package org.opencastproject.search.impl;
 
 import static org.opencastproject.security.util.SecurityUtil.getEpisodeRoleId;
 import static org.opencastproject.systems.OpencastConstants.EPISODE_ID_ROLE_ACCESS_PROPERTY;
+import static org.opencastproject.systems.OpencastConstants.EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT;
 
 import org.opencastproject.elasticsearch.index.ElasticsearchIndex;
 import org.opencastproject.elasticsearch.index.rebuild.AbstractIndexProducer;
@@ -99,6 +100,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -149,7 +151,7 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
 
   private ListProvidersService listProvidersService;
 
-  private boolean episodeIdRole = false;
+  private boolean episodeIdRole = EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT;
 
   private String systemUserName = null;
 
@@ -168,8 +170,9 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
    */
   @Activate
   public void activate(final ComponentContext cc) throws IllegalStateException {
-    episodeIdRole = BooleanUtils.toBoolean(Objects.toString(
-        cc.getBundleContext().getProperty(EPISODE_ID_ROLE_ACCESS_PROPERTY), "false"));
+    episodeIdRole = Optional.ofNullable(cc.getBundleContext().getProperty(EPISODE_ID_ROLE_ACCESS_PROPERTY))
+        .map(BooleanUtils::toBoolean)
+        .orElse(EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT);
     logger.debug("Usage of episode ID roles is set to {}", episodeIdRole);
 
     createIndex();

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
@@ -26,8 +26,6 @@ import static org.opencastproject.security.api.Permissions.Action.CONTRIBUTE;
 import static org.opencastproject.security.api.Permissions.Action.READ;
 import static org.opencastproject.security.api.Permissions.Action.WRITE;
 import static org.opencastproject.security.api.SecurityConstants.GLOBAL_CAPTURE_AGENT_ROLE;
-import static org.opencastproject.systems.OpencastConstants.EPISODE_ID_ROLE_ACCESS_PROPERTY;
-import static org.opencastproject.systems.OpencastConstants.EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT;
 
 import org.opencastproject.db.DBSession;
 import org.opencastproject.db.DBSessionFactory;
@@ -45,7 +43,6 @@ import org.opencastproject.security.api.User;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.data.Tuple;
 
-import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.osgi.service.component.ComponentContext;
@@ -87,8 +84,6 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
   /** Logging utilities */
   private static final Logger logger = LoggerFactory.getLogger(SearchServiceDatabaseImpl.class);
 
-  private boolean episodeRoleId = EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT;
-
   /** Factory used to create {@link EntityManager}s for transactions */
   protected EntityManagerFactory emf;
 
@@ -121,11 +116,6 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
     logger.info("Activating persistence manager for search service");
     db = dbSessionFactory.createSession(emf);
     this.populateSeriesData();
-
-    episodeRoleId = Optional.ofNullable(cc.getBundleContext().getProperty(EPISODE_ID_ROLE_ACCESS_PROPERTY))
-        .map(BooleanUtils::toBoolean)
-        .orElse(EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT);
-    logger.debug("Usage of episode ID roles is set to {}", episodeRoleId);
   }
 
   /**

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
@@ -27,6 +27,7 @@ import static org.opencastproject.security.api.Permissions.Action.READ;
 import static org.opencastproject.security.api.Permissions.Action.WRITE;
 import static org.opencastproject.security.api.SecurityConstants.GLOBAL_CAPTURE_AGENT_ROLE;
 import static org.opencastproject.systems.OpencastConstants.EPISODE_ID_ROLE_ACCESS_PROPERTY;
+import static org.opencastproject.systems.OpencastConstants.EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT;
 
 import org.opencastproject.db.DBSession;
 import org.opencastproject.db.DBSessionFactory;
@@ -60,7 +61,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -87,7 +87,7 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
   /** Logging utilities */
   private static final Logger logger = LoggerFactory.getLogger(SearchServiceDatabaseImpl.class);
 
-  private boolean episodeRoleId = false;
+  private boolean episodeRoleId = EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT;
 
   /** Factory used to create {@link EntityManager}s for transactions */
   protected EntityManagerFactory emf;
@@ -122,8 +122,9 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
     db = dbSessionFactory.createSession(emf);
     this.populateSeriesData();
 
-    episodeRoleId = BooleanUtils.toBoolean(Objects.toString(
-        cc.getBundleContext().getProperty(EPISODE_ID_ROLE_ACCESS_PROPERTY), "false"));
+    episodeRoleId = Optional.ofNullable(cc.getBundleContext().getProperty(EPISODE_ID_ROLE_ACCESS_PROPERTY))
+        .map(BooleanUtils::toBoolean)
+        .orElse(EPISODE_ID_ROLE_ACCESS_PROPERTY_DEFAULT);
     logger.debug("Usage of episode ID roles is set to {}", episodeRoleId);
   }
 


### PR DESCRIPTION
This is a very useful feature to have, especially for external systems. Especially especially so with JWT, which depends on this to make the `oc` claim work. For external apps, it's extremely useful to be able to rely on the presence of this feature and it will be annoying to tell everyone to enable it manually. For example, Tobira is already making use of this.

CC @lkiesow @Arnei  (since you implemented this in #5056)


### How to test this patch

Build & start Opencast, then somehow create a user with a magic role (permanent or just a JWT session) and see that the user has access to the event.


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
