### PR TITLE
Fix whispercpp operation when using the language from metadata

### DIFF
--- a/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/WhisperCppEngine.java
+++ b/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/WhisperCppEngine.java
@@ -184,9 +184,6 @@ public class WhisperCppEngine implements SpeechToTextEngine {
   /** Path to the executable */
   protected String ffmpegBinary = DEFAULT_FFMPEG_BINARY;
 
-  /** The LangCodeUtil instance, contains language code mappings */
-  private LangCodeUtil langCodeUtil;
-
   @Override
   public String getEngineName() {
     return engineName;
@@ -279,9 +276,6 @@ public class WhisperCppEngine implements SpeechToTextEngine {
 
     ffmpegBinary = Objects.toString(cc.getBundleContext().getProperty(FFMPEG_BINARY_CONFIG_KEY), DEFAULT_FFMPEG_BINARY);
     logger.debug("ffmpeg binary set to {}", ffmpegBinary);
-
-    langCodeUtil = LangCodeUtil.getInstance();
-    logger.debug("LangCodeUtil initialized");
 
     logger.debug("Finished activating/updating speech-to-text service");
   }
@@ -383,7 +377,7 @@ public class WhisperCppEngine implements SpeechToTextEngine {
       // Convert ISO3 language code to ISO2 if possible, as WhisperC++ expects ISO2 codes.
       // If the conversion is not possible, retain the original language code.
       logger.info("Found language '{}'", language);
-      language = langCodeUtil.iso3ToIso2(language, language);
+      language = LangCodeUtil.iso3ToIso2(language, language);
       logger.info("Using language code '{}' for transcription process", language);
       command.add("--language");
       command.add(language);
@@ -430,7 +424,7 @@ public class WhisperCppEngine implements SpeechToTextEngine {
         JSONObject result = (JSONObject) jsonObject.get("result");
         subtitleLanguage = (String) result.get("language");
         // convert language name to iso3 if necessary or take default
-        subtitleLanguage = langCodeUtil.getIso2FromLang(subtitleLanguage, subtitleLanguage);
+        subtitleLanguage = LangCodeUtil.getIso2FromLang(subtitleLanguage, subtitleLanguage);
         logger.info("Language detected by WhisperC++: {}", subtitleLanguage);
       } catch (Exception e) {
         logger.info("Error reading WhisperC++ JSON file for: {}", mediaFile);

--- a/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/WhisperCppEngine.java
+++ b/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/WhisperCppEngine.java
@@ -23,6 +23,7 @@ package org.opencastproject.speechtotext.impl.engine;
 
 import org.opencastproject.speechtotext.api.SpeechToTextEngine;
 import org.opencastproject.speechtotext.api.SpeechToTextEngineException;
+import org.opencastproject.speechtotext.util.LangCodeUtil;
 import org.opencastproject.util.IoSupport;
 import org.opencastproject.util.OsgiUtil;
 import org.opencastproject.util.data.Option;
@@ -183,6 +184,9 @@ public class WhisperCppEngine implements SpeechToTextEngine {
   /** Path to the executable */
   protected String ffmpegBinary = DEFAULT_FFMPEG_BINARY;
 
+  /** The LangCodeUtil instance, contains language code mappings */
+  private LangCodeUtil langCodeUtil;
+
   @Override
   public String getEngineName() {
     return engineName;
@@ -275,6 +279,9 @@ public class WhisperCppEngine implements SpeechToTextEngine {
 
     ffmpegBinary = Objects.toString(cc.getBundleContext().getProperty(FFMPEG_BINARY_CONFIG_KEY), DEFAULT_FFMPEG_BINARY);
     logger.debug("ffmpeg binary set to {}", ffmpegBinary);
+
+    langCodeUtil = LangCodeUtil.getInstance();
+    logger.debug("LangCodeUtil initialized");
 
     logger.debug("Finished activating/updating speech-to-text service");
   }
@@ -373,7 +380,11 @@ public class WhisperCppEngine implements SpeechToTextEngine {
 
     // set language of the source audio if known
     if (!language.isBlank()) {
-      logger.info("Using language {} from workflows", language);
+      // Convert ISO3 language code to ISO2 if possible, as WhisperC++ expects ISO2 codes.
+      // If the conversion is not possible, retain the original language code.
+      logger.info("Found language '{}'", language);
+      language = langCodeUtil.iso3ToIso2(language, language);
+      logger.info("Using language code '{}' for transcription process", language);
       command.add("--language");
       command.add(language);
     } else {
@@ -418,6 +429,8 @@ public class WhisperCppEngine implements SpeechToTextEngine {
         JSONObject jsonObject = (JSONObject) obj;
         JSONObject result = (JSONObject) jsonObject.get("result");
         subtitleLanguage = (String) result.get("language");
+        // convert language name to iso3 if necessary or take default
+        subtitleLanguage = langCodeUtil.getIso2FromLang(subtitleLanguage, subtitleLanguage);
         logger.info("Language detected by WhisperC++: {}", subtitleLanguage);
       } catch (Exception e) {
         logger.info("Error reading WhisperC++ JSON file for: {}", mediaFile);

--- a/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/WhisperEngine.java
+++ b/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/WhisperEngine.java
@@ -101,9 +101,6 @@ public class WhisperEngine implements SpeechToTextEngine {
   /** Currently used Whisper args */
   private String[] whisperArgs;
 
-  /** Holds some utility methods to handle locale names and codes **/
-  private LangCodeUtil langCodeUtil;
-
   @Override
   public String getEngineName() {
     return engineName;
@@ -128,9 +125,6 @@ public class WhisperEngine implements SpeechToTextEngine {
 
     whisperArgs = StringUtils.split(Objects.toString(prop.get(WHISPER_ARGS_CONFIG_KEY), ""));
     logger.debug("Additional args for Whisper: {}", (Object) whisperArgs);
-
-    langCodeUtil = LangCodeUtil.getInstance();
-    logger.debug("LangCodeUtil initialized");
 
     logger.debug("Finished activating/updating speech-to-text service");
   }
@@ -164,7 +158,7 @@ public class WhisperEngine implements SpeechToTextEngine {
 
     if (!language.isBlank() && !translate) {
       // get 2-letter language code
-      language = langCodeUtil.iso3ToIso2(language, "");
+      language = LangCodeUtil.iso3ToIso2(language, "");
       if (language.isBlank()) {
         logger.warn("No 2-letter language code found, using language auto detection");
       } else {
@@ -248,7 +242,7 @@ public class WhisperEngine implements SpeechToTextEngine {
         JSONObject jsonObject = (JSONObject) obj;
         language = (String) jsonObject.get("language");
         // convert language name to iso3 if necessary or take default
-        language = langCodeUtil.getIso2FromLang(language, language);
+        language = LangCodeUtil.getIso2FromLang(language, language);
         logger.debug("Language detected by Whisper: {}", language);
       } catch (Exception e) {
         logger.debug("Error reading Whisper JSON file for: {}", mediaFile);

--- a/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/WhisperEngine.java
+++ b/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/WhisperEngine.java
@@ -23,6 +23,7 @@ package org.opencastproject.speechtotext.impl.engine;
 
 import org.opencastproject.speechtotext.api.SpeechToTextEngine;
 import org.opencastproject.speechtotext.api.SpeechToTextEngineException;
+import org.opencastproject.speechtotext.util.LangCodeUtil;
 import org.opencastproject.util.OsgiUtil;
 import org.opencastproject.util.data.Option;
 
@@ -43,10 +44,7 @@ import java.io.FileReader;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
@@ -103,11 +101,8 @@ public class WhisperEngine implements SpeechToTextEngine {
   /** Currently used Whisper args */
   private String[] whisperArgs;
 
-  /** Map to get ISO 639 language code for language name in English */
-  private Map<String, String> languageMap = new HashMap<>();
-
-  /** Map to get ISO 639 language code for 3-letter language code */
-  private Map<String, String> languageISO3to2Map = new HashMap<>();
+  /** Holds some utility methods to handle locale names and codes **/
+  private LangCodeUtil langCodeUtil;
 
   @Override
   public String getEngineName() {
@@ -134,15 +129,8 @@ public class WhisperEngine implements SpeechToTextEngine {
     whisperArgs = StringUtils.split(Objects.toString(prop.get(WHISPER_ARGS_CONFIG_KEY), ""));
     logger.debug("Additional args for Whisper: {}", (Object) whisperArgs);
 
-    String[] languageCodes = Locale.getISOLanguages();
-    for (String languageCode: languageCodes) {
-      Locale locale = new Locale(languageCode);
-      String languageName = locale.getDisplayLanguage(new Locale("en"));
-      languageMap.put(languageName, languageCode);
-      String languageISO3 = locale.getISO3Language();
-      languageISO3to2Map.put(languageISO3, languageCode);
-    }
-    logger.debug("Filled language map.");
+    langCodeUtil = LangCodeUtil.getInstance();
+    logger.debug("LangCodeUtil initialized");
 
     logger.debug("Finished activating/updating speech-to-text service");
   }
@@ -176,7 +164,7 @@ public class WhisperEngine implements SpeechToTextEngine {
 
     if (!language.isBlank() && !translate) {
       // get 2-letter language code
-      language = languageISO3to2Map.getOrDefault(language,"");
+      language = langCodeUtil.iso3ToIso2(language, "");
       if (language.isBlank()) {
         logger.warn("No 2-letter language code found, using language auto detection");
       } else {
@@ -259,7 +247,8 @@ public class WhisperEngine implements SpeechToTextEngine {
         Object obj = jsonParser.parse(reader);
         JSONObject jsonObject = (JSONObject) obj;
         language = (String) jsonObject.get("language");
-        language = languageMap.getOrDefault(language, language);
+        // convert language name to iso3 if necessary or take default
+        language = langCodeUtil.getIso2FromLang(language, language);
         logger.debug("Language detected by Whisper: {}", language);
       } catch (Exception e) {
         logger.debug("Error reading Whisper JSON file for: {}", mediaFile);

--- a/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/util/LangCodeUtil.java
+++ b/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/util/LangCodeUtil.java
@@ -26,9 +26,14 @@ import java.util.Locale;
 import java.util.Map;
 
 /**
- * Utility class for language codes, singleton.
+ * Utility class for language codes
  */
 public final class LangCodeUtil {
+
+  // Prevent instantiation because of Checkstyle: "HideUtilityClassConstructor"
+  private LangCodeUtil() {
+    throw new UnsupportedOperationException("Utility class should not have a public or default constructor");
+  }
 
   /** Map to get ISO 639 language code for language name in English */
   private static final Map<String, String> iso3ToIso2Map = new HashMap<>();

--- a/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/util/LangCodeUtil.java
+++ b/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/util/LangCodeUtil.java
@@ -30,31 +30,20 @@ import java.util.Map;
  */
 public final class LangCodeUtil {
 
-  private static LangCodeUtil instance;
-
   /** Map to get ISO 639 language code for language name in English */
   private static final Map<String, String> iso3ToIso2Map = new HashMap<>();
 
   /** Map to get ISO 639 language code for 3-letter language code */
   private static final Map<String, String> langNameToIso2Map = new HashMap<>();
 
-  private LangCodeUtil() {
-    // Private constructor to prevent instantiation (singleton pattern)
-  }
-
-  public static synchronized LangCodeUtil getInstance() {
-    if (instance == null) {
-      instance = new LangCodeUtil();
-      for (String languageCode : Locale.getISOLanguages()) {
-        Locale locale = new Locale(languageCode);
-        String languageName = locale.getDisplayLanguage(new Locale("en"));
-        langNameToIso2Map.put(languageName, languageCode);
-        String languageISO3 = locale.getISO3Language();
-        iso3ToIso2Map.put(languageISO3, languageCode);
-      }
-
+  static {
+    for (String languageCode : Locale.getISOLanguages()) {
+      Locale locale = new Locale(languageCode);
+      String languageName = locale.getDisplayLanguage(new Locale("en"));
+      langNameToIso2Map.put(languageName, languageCode);
+      String languageISO3 = locale.getISO3Language();
+      iso3ToIso2Map.put(languageISO3, languageCode);
     }
-    return instance;
   }
 
   /**
@@ -64,7 +53,7 @@ public final class LangCodeUtil {
    * @param defaultValue The default value to return if the conversion fails.
    * @return The ISO 639-2 language code, or the default value if the conversion fails.
    */
-  public String iso3ToIso2(String langIso3Code, String defaultValue) {
+  public static String iso3ToIso2(String langIso3Code, String defaultValue) {
     return iso3ToIso2Map.getOrDefault(langIso3Code, defaultValue);
   }
 
@@ -75,7 +64,7 @@ public final class LangCodeUtil {
    * @param defaultValue      The default value to return if the conversion fails.
    * @return The ISO 639-2 language code, or the default value if the conversion fails.
    */
-  public String getIso2FromLang(String langNameInEnglish, String defaultValue) {
+  public static String getIso2FromLang(String langNameInEnglish, String defaultValue) {
     return langNameToIso2Map.getOrDefault(langNameInEnglish, defaultValue);
   }
 

--- a/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/util/LangCodeUtil.java
+++ b/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/util/LangCodeUtil.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.speechtotext.util;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Utility class for language codes, singleton.
+ */
+public final class LangCodeUtil {
+
+  private static LangCodeUtil instance;
+
+  /** Map to get ISO 639 language code for language name in English */
+  private static final Map<String, String> iso3ToIso2Map = new HashMap<>();
+
+  /** Map to get ISO 639 language code for 3-letter language code */
+  private static final Map<String, String> langNameToIso2Map = new HashMap<>();
+
+  private LangCodeUtil() {
+    // Private constructor to prevent instantiation (singleton pattern)
+  }
+
+  public static synchronized LangCodeUtil getInstance() {
+    if (instance == null) {
+      instance = new LangCodeUtil();
+      for (String languageCode : Locale.getISOLanguages()) {
+        Locale locale = new Locale(languageCode);
+        String languageName = locale.getDisplayLanguage(new Locale("en"));
+        langNameToIso2Map.put(languageName, languageCode);
+        String languageISO3 = locale.getISO3Language();
+        iso3ToIso2Map.put(languageISO3, languageCode);
+      }
+
+    }
+    return instance;
+  }
+
+  /**
+   * Convert ISO 639-3 language code to ISO 639-2 language code.
+   *
+   * @param langIso3Code The ISO 639-3 language code to convert.
+   * @param defaultValue The default value to return if the conversion fails.
+   * @return The ISO 639-2 language code, or the default value if the conversion fails.
+   */
+  public String iso3ToIso2(String langIso3Code, String defaultValue) {
+    return iso3ToIso2Map.getOrDefault(langIso3Code, defaultValue);
+  }
+
+  /**
+   * Get the ISO 639-2 language code for a given language name in English.
+   *
+   * @param langNameInEnglish The language name in English.
+   * @param defaultValue      The default value to return if the conversion fails.
+   * @return The ISO 639-2 language code, or the default value if the conversion fails.
+   */
+  public String getIso2FromLang(String langNameInEnglish, String defaultValue) {
+    return langNameToIso2Map.getOrDefault(langNameInEnglish, defaultValue);
+  }
+
+}


### PR DESCRIPTION
Fixes #6293 

When using the language string from the event metadata, the speechtotext operation using the whisperc++ engine won't work. Now it should be fixed. I used the same logic that already works in the whisper engine version.

### Why in 17.x
It's a Bugfix and it shouldn't alter any other logic.

### How to test

1. Install whisperc++. I've done it with the quick start instructions from the github repository (it's nice and fast).
https://github.com/ggml-org/whisper.cpp?tab=readme-ov-file#quick-start

2. Edit Opencasts whispercpp config: `org.opencastproject.speechtotext.impl.engine.WhisperCppEngine.cfg`
The configuration depends on the installation path of your whisperc++.
Configure the root path and the model path to something like this:
``` 
whispercpp.root.path=/path/to/cloned/github/project/directory/whisper.cpp/build/bin/whisper-cli
whispercpp.model=/path/to/cloned/github/project/directory/whisper.cpp/models/ggml-base.en.bin
```

3. Add the speechtotext operation somewhere in your workflows. I've put the following two operations in the default schedule-and-upload Workflow right before the "partial-publish" Operation. (Please notice that I only run the speechtotext operation on the presenter track. Don't forget this when uploading a video. You also can change the source-flavors configuration here)
```
    <operation
        id="speechtotext"
        description="Create subtitles with WhisperCPP">
      <configurations>
        <configuration key="source-flavor">presenter/source</configuration>
        <configuration key="target-flavor">captions/source</configuration>
        <configuration key="limit-to-one">true</configuration>
      </configurations>
    </operation>

    <operation id="tag">
      <configurations>
        <configuration key="source-flavors">captions/source</configuration>
        <configuration key="target-tags">+archive</configuration>
      </configurations>
    </operation>
```

4. Upload an event and set a language in the metadata.
5. The Workflow should run without errors and you should find a subtitle file in the Assets/Archive. You also should see your selected language in the tags.
![image](https://github.com/user-attachments/assets/d9d2ba87-b280-41ca-a757-a8bc0e3d4d9b)
