### PR TITLE
Allow to select three or more tracks

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/select-streams-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/select-streams-woh.md
@@ -61,14 +61,16 @@ edited according to the selections in video editor’s “Tracks” panel. The r
 corresponding `target-flavor` and `target-tags` are applied.
 
 Note: If your editing results in a single video and single audio (track/stream) they will be muxed together even if
-this option is set to `none`.
+this option is set to `none`. If you have three or more video tracks and at least one video track is hidden, the resulting
+audio and video tracks will not be muxed.
 
 ### `force`
 
-The parameter value `force` only applies to media packages that have exactly one non-hidden audio stream. For media
-packages without an audio stream or with more than one audio stream, the behavior is the same as if the parameter were
-omitted. The same applies to media packages for which there is only one audio stream, and it already belongs to the
-track with flavor type given by `force-target` (or `presenter` if that parameter is omitted).
+The parameter value `force` only applies to media packages that have exactly one non-hidden audio stream and no
+hidden video streams. For media packages without an audio stream or with more than one audio stream, the behavior is the 
+same as if the parameter were omitted. The same applies to media packages for which there is only one audio 
+stream, and it already belongs to the track with flavor type given by `force-target` (or `presenter` if that 
+parameter is omitted).
 
 If, however, there is only one non-hidden audio stream and it does *not* belong to the track given by `force-target`,
 then the operation will “move” the audio stream to this target track. Specifically, it will mux the video stream of

--- a/etc/workflows/partial-theming.xml
+++ b/etc/workflows/partial-theming.xml
@@ -44,7 +44,7 @@
       if="NOT(${theme_active})"
       description="Tag elements as themed">
       <configurations>
-        <configuration key="source-flavors">presenter/trimmed,presentation/trimmed</configuration>
+        <configuration key="source-flavors">*/trimmed</configuration>
         <configuration key="target-flavor">*/themed</configuration>
         <configuration key="copy">false</configuration>
       </configurations>

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SelectStreamsWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SelectStreamsWorkflowOperationHandler.java
@@ -429,9 +429,14 @@ public class SelectStreamsWorkflowOperationHandler extends AbstractWorkflowOpera
     long queueTime = 0L;
     final List<Track> resultingTracks = new ArrayList<>(0);
     for (final AugmentedTrack t : augmentedTracks) {
-      // If track has non-hidden video and non-hidden audio, clone this track and re-add it to the MP (since it will
+      // If track has non-hidden video and non-hidden audio, or only one non-hidden video/audio,
+      // clone this track and re-add it to the MP (since it will
       // be a new track with a different flavor)
-      if (t.hasVideo() && !t.hideVideo && t.hasAudio() && !t.hideAudio) {
+      if (
+        t.hasVideo() && !t.hideVideo && t.hasAudio() && !t.hideAudio  // non-hidden video and non-hidden audio
+        || t.hasVideo() && !t.hideVideo && !t.hasAudio()  // non-hidden video without audio
+        || !t.hasVideo() && t.hasAudio() && !t.hideAudio  // non-hidden audio without video
+      ) {
         logger.debug("Add clone of track {} to mediapackage {}", t.track.getIdentifier(),
             mediaPackage.getIdentifier());
         final Track clonedTrack = (Track) t.track.clone();

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SelectStreamsWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SelectStreamsWorkflowOperationHandler.java
@@ -273,8 +273,6 @@ public class SelectStreamsWorkflowOperationHandler extends AbstractWorkflowOpera
       }
     }
 
-    // Note that the logic below currently supports at most two input tracks
-
     if (allNonHidden(augmentedTracks, SubTrack.VIDEO)) {
       // Case 1: We have only tracks with non-hidden video streams. So we keep them all and possibly cut away audio.
 
@@ -359,12 +357,17 @@ public class SelectStreamsWorkflowOperationHandler extends AbstractWorkflowOpera
            }
          }
        }
-    } else {
-      /* Case 3: We have one or more tracks where exactly one track has a non-hidden video stream (implied as this
+    } else if (augmentedTracks.size() == 2) {
+      /* Case 3: We have two tracks where exactly one track has a non-hidden video stream (implied as this
          logic assumes at most two input tracks).
          Considering the audio stream, the track with the non-hidden video stream might also contain an audio stream
          or we have to mux the audio stream from another track into that track */
       final MuxResult muxResult = muxSingleVideoTrack(mediaPackage, augmentedTracks);
+      result.add(muxResult);
+    } else {
+      /* Case 4: We have three or more tracks where at least one track has a hidden video stream.
+         Simply remove video or audio streams where requested, or copy the track otherwise*/
+      final MuxResult muxResult = muxMultipleVideoTracks(mediaPackage, augmentedTracks);
       result.add(muxResult);
     }
 
@@ -426,21 +429,30 @@ public class SelectStreamsWorkflowOperationHandler extends AbstractWorkflowOpera
     long queueTime = 0L;
     final List<Track> resultingTracks = new ArrayList<>(0);
     for (final AugmentedTrack t : augmentedTracks) {
-      if (t.hasAudio() && t.hideAudio) {
+      // If track has non-hidden video and non-hidden audio, clone this track and re-add it to the MP (since it will
+      // be a new track with a different flavor)
+      if (t.hasVideo() && !t.hideVideo && t.hasAudio() && !t.hideAudio) {
+        logger.debug("Add clone of track {} to mediapackage {}", t.track.getIdentifier(),
+            mediaPackage.getIdentifier());
+        final Track clonedTrack = (Track) t.track.clone();
+        clonedTrack.setIdentifier(null);
+        resultingTracks.add(clonedTrack);
+      } else if (t.hasVideo() && !t.hideVideo && t.hasAudio() && t.hideAudio) {
+        // If track has non-hidden video and hidden audio, hide audio and add it to the MP
         // The flavor gets "nulled" in the process. Reverse that so we can treat all tracks equally.
         final MediaPackageElementFlavor previousFlavor = t.track.getFlavor();
         final TrackJobResult trackJobResult = hideAudio(t.track, mediaPackage);
         trackJobResult.track.setFlavor(previousFlavor);
         resultingTracks.add(trackJobResult.track);
         queueTime += trackJobResult.waitTime;
-      } else {
-        // Even if we don't modify the track, we clone and re-add it to the MP (since it will be a new track with a
-        // different flavor)
-        logger.debug("Add clone of track {} to mediapackage {}", t.track.getIdentifier(),
-            mediaPackage.getIdentifier());
-        final Track clonedTrack = (Track) t.track.clone();
-        clonedTrack.setIdentifier(null);
-        resultingTracks.add(clonedTrack);
+      } else if (t.hasVideo() && t.hideVideo && t.hasAudio() && !t.hideAudio) {
+        // If track has hidden video and non-hidden audio, hide video and add the audio track to the MP
+        // The flavor gets "nulled" in the process. Reverse that so we can treat all tracks equally.
+        final MediaPackageElementFlavor previousFlavor = t.track.getFlavor();
+        final TrackJobResult trackJobResult = hideVideo(t.track, mediaPackage);
+        trackJobResult.track.setFlavor(previousFlavor);
+        resultingTracks.add(trackJobResult.track);
+        queueTime += trackJobResult.waitTime;
       }
     }
     return new MuxResult(queueTime, resultingTracks);


### PR DESCRIPTION
Currently, the `select-tracks` workflow operation only supports up to two input tracks. This patch removes this limit by adding a simple support for these mediapackages.

The new case in the code simply adds the tracks to the mediapackage while recognising the hide configurations. This new case doesn't mux any video or audio.

### How to test this patch

1. Ingest a mediapackage with three videos, e.g. `curl -u admin http://localhost:8080/ingest/addMediaPackage/schedule-and-upload -F 'flavor=presenter/source' -F BODY=@presenter.mp4 -F 'flavor=presentation/source' -F BODY=@presentation.mp4 -F 'flavor=presentation-2/source' -F BODY=@presentation-2.mp4 -F title=triple-video-test`
2. Open OC editor and remove one track in the selector
3. Save and process event
4. Check if event displays two video tracks in the player

### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
