### PR TITLE
Fix documentation regarding dummy capture agent configuration

### DIFF
--- a/docs/guides/developer/docs/develop/debugging.md
+++ b/docs/guides/developer/docs/develop/debugging.md
@@ -101,10 +101,20 @@ To add a dummy CA, go to the API Docs page in Opencast and enter a new capture a
 
   **Configuration:**
 
+General Structure:
+
     {
-    "key": "capture.device.names",
-    "value": "presentation,presenter"
+        "key": "value",
+        "another_key": "value",
+        ...
     }
+
+And here is a concrete example how you can add two channels:
+
+    {
+        "capture.device.names": "presentation,presenter"
+    }
+
 
 Click on `submit` and is ready to go.
 


### PR DESCRIPTION
I tried to add a dummy CA with the config provided in the docs. But the channels didn't appear in the frontend. After some tests, I noticed that the config was simply wrong.

Instead of 
```
{
  "key": "foo", 
  "value":" bar"
}
```
It should be
```
{
  "foo": "bar"
}
```

I changed the documentation accordingly.