### PR TITLE
Add filters to series list query for admin ui

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/SeriesListQuery.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/SeriesListQuery.java
@@ -87,6 +87,8 @@ public class SeriesListQuery extends ResourceListQueryImpl {
   public SeriesListQuery() {
     super();
     this.availableFilters.add(createCreationDateFilter(Option.<Tuple<Date, Date>> none()));
+    this.availableFilters.add(createOrganizersFilter(Option.none()));
+    this.availableFilters.add(createContributorsFilter(Option.none()));
   }
 
   /**


### PR DESCRIPTION
For frontend PR https://github.com/opencast/opencast-admin-interface/pull/1300. Will not break the frontend if merged without said PR.

Adds filters to the series list query, so that the frontend can use them to filter the series table. No idea why these were not available in the first place, to me this seems entirely reasonable.

EDIT: I found why these were removed, see https://github.com/opencast/opencast/pull/3172/commits/60ccd912fb42d0dd272d67442a45febd867e214d.
I still believe that the organizer and contributor filters are reasonable to have though, the index should be able to handle those easily.

### How to test this patch

Install this and test if you can use the new filters in the series table in the admin ui. 

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
