### PR TITLE
Wait for Opensearch on Opencast boot

### DIFF
--- a/modules/elasticsearch-impl/src/main/java/org/opencastproject/elasticsearch/impl/AbstractElasticsearchIndex.java
+++ b/modules/elasticsearch-impl/src/main/java/org/opencastproject/elasticsearch/impl/AbstractElasticsearchIndex.java
@@ -499,6 +499,11 @@ public abstract class AbstractElasticsearchIndex implements SearchIndex {
       // something different triggered an ioexception, so we fail
       throw new RuntimeException("Couldn't connect to opensearch due to IOExceptionError", ioException);
     } catch (ElasticsearchException elasticsearchException) {
+      if (elasticsearchException.status().getStatus() >= 500) {
+        logger.debug("OpenSearch health request ended with HTTP status code {}. Is OpenSearch service running?",
+            elasticsearchException.status().getStatus());
+        return false;
+      }
       // An ElasticsearchException is usually thrown in case where the server returns a 4xx or 5xx error code.
       // So for example for an HTTP 401 Unauthorized: In this case we want the startup to fail, so
       // we get an error and have the chance to change the configuration


### PR DESCRIPTION
If Opensearch is behind a reverse proxy and the service is not running, all HTTP requests end up with 502. We have to handle this case on Opencast boot.

### How to reproduce:
1. Stop Opencast and opensearch
2. Start Opencast

### Expected behavior:
Opencast wait for Opensearch and continue the startup process.

### Actual behavior:
Opencast throws Exception


<details><summary>Exception</summary>

<div>

```
2025-03-17T02:04:32,509 | INFO  | (AbstractElasticsearchIndex:450) - Testing connection to OpenSearch at https://unixy:9243
2025-03-17T02:04:33,035 | ERROR | (AbstractElasticsearchIndex:502) - Error while testing OpenSearch connection
org.elasticsearch.ElasticsearchStatusException: Unable to parse response body
	…
	at org.opencastproject.elasticsearch.impl.AbstractElasticsearchIndex.isOpensearchReachable(AbstractElasticsearchIndex.java:476) [!/:?]
	at org.opencastproject.elasticsearch.impl.AbstractElasticsearchIndex.waitUntilOpensearchIsAvailable(AbstractElasticsearchIndex.java:451) [!/:?]
	at org.opencastproject.elasticsearch.impl.AbstractElasticsearchIndex.init(AbstractElasticsearchIndex.java:437) [!/:?]
	at org.opencastproject.elasticsearch.index.ElasticsearchIndex.activate(ElasticsearchIndex.java:133) [!/:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	…
	at java.lang.Thread.run(Thread.java:840) [?:?]
	Suppressed: java.lang.IllegalStateException: Unsupported Content-Type: text/html
		…
		at org.opencastproject.elasticsearch.index.ElasticsearchIndex.activate(ElasticsearchIndex.java:133) [!/:?]
		at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
		at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
		at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
		at java.lang.reflect.Method.invoke(Method.java:569) ~[?:?]
		…
		at org.apache.felix.framework.FrameworkStartLevelImpl.run(FrameworkStartLevelImpl.java:297) [org.apache.felix.framework-7.0.5.jar:?]
		at java.lang.Thread.run(Thread.java:840) [?:?]
Caused by: org.elasticsearch.client.ResponseException: method [GET], host [https://unixy:9243], URI [/_cluster/health?master_timeout=30s&level=cluster&timeout=30s&wait_for_status=green], status line [HTTP/1.1 502 Bad Gateway]
<html>
<head><title>502 Bad Gateway</title></head>
<body>
<center><h1>502 Bad Gateway</h1></center>
<hr><center>nginx</center>
</body>
</html>

2025-03-17T02:04:33,037 | ERROR | (ScrLogManager$ScrLoggerFacade:206) - bundle opencast-elasticsearch-index:16.9.0 (103)[org.opencastproject.elasticsearch.index.ElasticsearchIndex(106)] : The activate method has thrown an exception
org.osgi.service.component.ComponentException: Error initializing elastic search index
	at org.opencastproject.elasticsearch.index.ElasticsearchIndex.activate(ElasticsearchIndex.java:135) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	…
	at java.lang.Thread.run(Thread.java:840) [?:?]
Caused by: org.elasticsearch.ElasticsearchStatusException: Unable to parse response body
	…
	at org.elasticsearch.client.ClusterClient.health(ClusterClient.java:130) ~[?:?]
	at org.opencastproject.elasticsearch.impl.AbstractElasticsearchIndex.isOpensearchReachable(AbstractElasticsearchIndex.java:476) ~[?:?]
	at org.opencastproject.elasticsearch.impl.AbstractElasticsearchIndex.waitUntilOpensearchIsAvailable(AbstractElasticsearchIndex.java:451) ~[?:?]
	at org.opencastproject.elasticsearch.impl.AbstractElasticsearchIndex.init(AbstractElasticsearchIndex.java:437) ~[?:?]
	at org.opencastproject.elasticsearch.index.ElasticsearchIndex.activate(ElasticsearchIndex.java:133) ~[?:?]
	... 37 more
	Suppressed: java.lang.IllegalStateException: Unsupported Content-Type: text/html
		at org.elasticsearch.client.RestHighLevelClient.parseEntity(RestHighLevelClient.java:1908) ~[?:?]
		at org.elasticsearch.client.RestHighLevelClient.parseResponseException(RestHighLevelClient.java:1888) ~[?:?]
		at org.elasticsearch.client.RestHighLevelClient.internalPerformRequest(RestHighLevelClient.java:1645) ~[?:?]
		at org.elasticsearch.client.RestHighLevelClient.performRequest(RestHighLevelClient.java:1602) ~[?:?]
		at org.elasticsearch.client.RestHighLevelClient.performRequestAndParseEntity(RestHighLevelClient.java:1572) ~[?:?]
		at org.elasticsearch.client.ClusterClient.health(ClusterClient.java:130) ~[?:?]
		at org.opencastproject.elasticsearch.impl.AbstractElasticsearchIndex.isOpensearchReachable(AbstractElasticsearchIndex.java:476) ~[?:?]
		at org.opencastproject.elasticsearch.impl.AbstractElasticsearchIndex.waitUntilOpensearchIsAvailable(AbstractElasticsearchIndex.java:451) ~[?:?]
		at org.opencastproject.elasticsearch.impl.AbstractElasticsearchIndex.init(AbstractElasticsearchIndex.java:437) ~[?:?]
		at org.opencastproject.elasticsearch.index.ElasticsearchIndex.activate(ElasticsearchIndex.java:133) ~[?:?]
		…
		at java.lang.Thread.run(Thread.java:840) [?:?]
Caused by: org.elasticsearch.client.ResponseException: method [GET], host [https://unixy:9243], URI [/_cluster/health?master_timeout=30s&level=cluster&timeout=30s&wait_for_status=green], status line [HTTP/1.1 502 Bad Gateway]
<html>
<head><title>502 Bad Gateway</title></head>
<body>
<center><h1>502 Bad Gateway</h1></center>
<hr><center>nginx</center>
```

</div>

</details>



I would like to see this bugfix in 16.x.