### PR TITLE
Partially remove entwine from dublincore

### DIFF
--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreCatalog.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreCatalog.java
@@ -20,21 +20,13 @@
  */
 package org.opencastproject.metadata.dublincore;
 
-import static com.entwinemedia.fn.Stream.$;
-import static org.opencastproject.util.EqualsUtil.eq;
-import static org.opencastproject.util.data.Monadics.mlist;
-
 import org.opencastproject.mediapackage.EName;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.mediapackage.XMLCatalogImpl;
 import org.opencastproject.metadata.api.MetadataCatalog;
 import org.opencastproject.util.RequireUtil;
 import org.opencastproject.util.XmlNamespaceContext;
-import org.opencastproject.util.data.Function;
-import org.opencastproject.util.data.Function2;
 
-import com.entwinemedia.fn.Fns;
-import com.entwinemedia.fn.data.ImmutableSetWrapper;
 import com.google.gson.annotations.JsonAdapter;
 
 import org.apache.commons.collections4.Closure;
@@ -46,11 +38,14 @@ import org.xml.sax.Attributes;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
@@ -152,23 +147,26 @@ public class DublinCoreCatalog extends XMLCatalogImpl implements DublinCore, Met
 
   @Override
   public Map<EName, List<DublinCoreValue>> getValues() {
-    return mlist(data.values().iterator())
-            .foldl(new HashMap<EName, List<DublinCoreValue>>(),
-                    new Function2<HashMap<EName, List<DublinCoreValue>>, List<CatalogEntry>, HashMap<EName, List<DublinCoreValue>>>() {
-                      @Override
-                      public HashMap<EName, List<DublinCoreValue>> apply(HashMap<EName, List<DublinCoreValue>> map,
-                              List<CatalogEntry> entries) {
-                        if (entries.size() > 0) {
-                          final EName property = entries.get(0).getEName();
-                          map.put(property, mlist(entries).map(toDublinCoreValue).value());
-                        }
-                        return map;
-                      }
-                    });
+    Map<EName, List<DublinCoreValue>> result = new HashMap<>();
+
+    for (List<CatalogEntry> entries : data.values()) {
+      if (!entries.isEmpty()) {
+        EName property = entries.get(0).getEName();
+        List<DublinCoreValue> values = entries.stream()
+            .map(toDublinCoreValue)
+            .collect(Collectors.toList());
+        result.put(property, values);
+      }
+    }
+
+    return result;
   }
 
   @Override public List<DublinCoreValue> getValuesFlat() {
-    return $(data.values()).bind(Fns.<List<CatalogEntry>>id()).map(toDublinCoreValue.toFn()).toList();
+    return data.values().stream()
+        .flatMap(List::stream)
+        .map(toDublinCoreValue)
+        .collect(Collectors.toList());
   }
 
   @Override
@@ -233,7 +231,11 @@ public class DublinCoreCatalog extends XMLCatalogImpl implements DublinCore, Met
         values = getLocalizedValuesAsList(property, language);
         break;
     }
-    return values.size() > 0 ? $(values).mkString(delimiter) : null;
+    return (values != null && !values.isEmpty())
+        ? values.stream()
+          .map(CatalogEntry::toString)
+          .collect(Collectors.joining(delimiter))
+        : null;
   }
 
   @Override
@@ -322,7 +324,7 @@ public class DublinCoreCatalog extends XMLCatalogImpl implements DublinCore, Met
   public void set(EName property, @Nullable DublinCoreValue value) {
     RequireUtil.notNull(property, "property");
     if (value != null) {
-      setValue(property, value.getValue(), value.getLanguage(), value.getEncodingScheme().orNull());
+      setValue(property, value.getValue(), value.getLanguage(), value.getEncodingScheme().orElse(null));
     } else {
       removeValue(property, LANGUAGE_ANY);
     }
@@ -372,7 +374,7 @@ public class DublinCoreCatalog extends XMLCatalogImpl implements DublinCore, Met
     RequireUtil.notNull(property, "property");
     RequireUtil.notNull(value, "value");
 
-    add(property, value.getValue(), value.getLanguage(), value.getEncodingScheme().orNull());
+    add(property, value.getValue(), value.getLanguage(), value.getEncodingScheme().orElse(null));
   }
 
   void add(EName property, String value, String language, @Nullable EName encodingScheme) {
@@ -448,12 +450,15 @@ public class DublinCoreCatalog extends XMLCatalogImpl implements DublinCore, Met
 
   @Override
   public Set<EName> getProperties() {
-    return new ImmutableSetWrapper<>(data.keySet());
+    return Collections.unmodifiableSet(data.keySet());
   }
 
   boolean equalLanguage(String a, String b) {
-    return (a == null && eq(b, LANGUAGE_UNDEFINED)) || (b == null && eq(a, LANGUAGE_UNDEFINED)) || eq(a, LANGUAGE_ANY)
-            || eq(b, LANGUAGE_ANY) || (a != null && eq(a, b));
+    return (a == null && Objects.equals(b, LANGUAGE_UNDEFINED))
+        || (b == null && Objects.equals(a, LANGUAGE_UNDEFINED))
+        || Objects.equals(a, LANGUAGE_ANY)
+        || Objects.equals(b, LANGUAGE_ANY)
+        || (a != null && Objects.equals(a, b));
   }
 
   // make public

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreCatalogService.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreCatalogService.java
@@ -32,8 +32,6 @@ import org.opencastproject.metadata.api.MediaPackageMetadataService;
 import org.opencastproject.metadata.api.MediapackageMetadataImpl;
 import org.opencastproject.workspace.api.Workspace;
 
-import com.entwinemedia.fn.Stream;
-
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -45,6 +43,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -103,7 +102,9 @@ public class DublinCoreCatalogService implements CatalogService<DublinCoreCatalo
   @Override
   public MediaPackageMetadata getMetadata(MediaPackage mp) {
     MediapackageMetadataImpl metadata = new MediapackageMetadataImpl();
-    for (Catalog catalog : Stream.$(mp.getCatalogs(DublinCoreCatalog.ANY_DUBLINCORE)).sort(COMPARE_BY_FLAVOR)) {
+    Catalog[] catalogs = mp.getCatalogs(DublinCoreCatalog.ANY_DUBLINCORE);
+    Arrays.sort(catalogs, COMPARE_BY_FLAVOR);
+    for (Catalog catalog : catalogs) {
       DublinCoreCatalog dc = DublinCoreUtil.loadDublinCore(workspace, catalog);
       if (MediaPackageElements.EPISODE.equals(catalog.getFlavor())) {
         // Title

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreJsonFormat.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreJsonFormat.java
@@ -21,12 +21,9 @@
 
 package org.opencastproject.metadata.dublincore;
 
-import static com.entwinemedia.fn.Equality.ne;
 import static org.opencastproject.metadata.dublincore.DublinCore.LANGUAGE_UNDEFINED;
 
 import org.opencastproject.mediapackage.EName;
-
-import com.entwinemedia.fn.data.Opt;
 
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -35,6 +32,7 @@ import org.json.simple.parser.ParseException;
 
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -145,14 +143,14 @@ public final class DublinCoreJsonFormat {
       }
       for (DublinCoreValue value : entry.getValue()) {
         final String lang = value.getLanguage();
-        final Opt<EName> encScheme = value.getEncodingScheme();
+        final Optional<EName> encScheme = value.getEncodingScheme();
         final JSONObject v = new JSONObject();
         v.put("value", value.getValue());
-        if (ne(DublinCore.LANGUAGE_UNDEFINED, lang)) {
+        if (!DublinCore.LANGUAGE_UNDEFINED.equals(lang)) {
           v.put("lang", lang);
         }
-        for (EName e : encScheme) {
-          v.put("type", dc.toQName(e));
+        if (encScheme.isPresent()) {
+          v.put("type", dc.toQName(encScheme.get()));
         }
         localNameArray.add(v);
       }

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreUtil.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreUtil.java
@@ -21,8 +21,6 @@
 
 package org.opencastproject.metadata.dublincore;
 
-import static com.entwinemedia.fn.Prelude.chuck;
-
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElement;
 import org.opencastproject.mediapackage.MediaPackageElements;
@@ -77,7 +75,7 @@ public final class DublinCoreUtil {
       return DublinCores.read(in);
     } catch (Exception e) {
       logger.error("Unable to load metadata from catalog '{}'", mpe, e);
-      return chuck(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -127,7 +125,7 @@ public final class DublinCoreUtil {
       }
       return Checksum.create("md5", Checksum.convertToHex(digest.digest()));
     } catch (NoSuchAlgorithmException e) {
-      return chuck(e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreValue.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreValue.java
@@ -28,9 +28,8 @@ import org.opencastproject.mediapackage.EName;
 import org.opencastproject.util.EqualsUtil;
 import org.opencastproject.util.RequireUtil;
 
-import com.entwinemedia.fn.data.Opt;
-
 import java.io.Serializable;
+import java.util.Optional;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 import javax.annotation.concurrent.Immutable;
@@ -49,7 +48,7 @@ public final class DublinCoreValue implements Serializable {
 
   private final String value;
   private final String language;
-  private final Opt<EName> encodingScheme;
+  private final Optional<EName> encodingScheme;
 
   /**
    * Create a new Dublin Core value.
@@ -61,7 +60,7 @@ public final class DublinCoreValue implements Serializable {
    * @param encodingScheme
    *          the encoding scheme used to encode the value
    */
-  public DublinCoreValue(String value, String language, Opt<EName> encodingScheme) {
+  public DublinCoreValue(String value, String language, Optional<EName> encodingScheme) {
     this.value = RequireUtil.notNull(value, "value");
     this.language = RequireUtil.notNull(language, "language");
     this.encodingScheme = RequireUtil.notNull(encodingScheme, "encodingScheme");
@@ -77,7 +76,7 @@ public final class DublinCoreValue implements Serializable {
    * @param encodingScheme
    *         the encoding scheme used to encode the value
    */
-  public static DublinCoreValue mk(String value, String language, Opt<EName> encodingScheme) {
+  public static DublinCoreValue mk(String value, String language, Optional<EName> encodingScheme) {
     return new DublinCoreValue(value, language, encodingScheme);
   }
 
@@ -92,7 +91,7 @@ public final class DublinCoreValue implements Serializable {
    *         the encoding scheme used to encode the value
    */
   public static DublinCoreValue mk(String value, String language, EName encodingScheme) {
-    return new DublinCoreValue(value, language, Opt.some(encodingScheme));
+    return new DublinCoreValue(value, language, Optional.of(encodingScheme));
   }
 
   /**
@@ -104,7 +103,7 @@ public final class DublinCoreValue implements Serializable {
    *          the language (two letter ISO 639)
    */
   public static DublinCoreValue mk(String value, String language) {
-    return new DublinCoreValue(value, language, Opt.<EName>none());
+    return new DublinCoreValue(value, language, Optional.empty());
   }
 
   /**
@@ -115,7 +114,7 @@ public final class DublinCoreValue implements Serializable {
    * @see org.opencastproject.metadata.dublincore.DublinCore#LANGUAGE_UNDEFINED
    */
   public static DublinCoreValue mk(String value) {
-    return new DublinCoreValue(value, DublinCore.LANGUAGE_UNDEFINED, Opt.<EName>none());
+    return new DublinCoreValue(value, DublinCore.LANGUAGE_UNDEFINED, Optional.empty());
   }
 
   /**
@@ -135,12 +134,12 @@ public final class DublinCoreValue implements Serializable {
   /**
    * Return the encoding scheme.
    */
-  public Opt<EName> getEncodingScheme() {
+  public Optional<EName> getEncodingScheme() {
     return encodingScheme;
   }
 
   public boolean hasEncodingScheme() {
-    return encodingScheme.isSome();
+    return encodingScheme.isPresent();
   }
 
   @Override

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreXmlFormat.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreXmlFormat.java
@@ -27,8 +27,6 @@ import org.opencastproject.mediapackage.XMLCatalogImpl.CatalogEntry;
 import org.opencastproject.util.XmlNamespaceContext;
 import org.opencastproject.util.XmlSafeParser;
 
-import com.entwinemedia.fn.data.Opt;
-
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,6 +46,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Optional;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -146,11 +145,11 @@ public final class DublinCoreXmlFormat extends DefaultHandler {
         new InputSource(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))));
   }
 
-  public static Opt<DublinCoreCatalog> readOpt(String xml) {
+  public static Optional<DublinCoreCatalog> readOpt(String xml) {
     try {
-      return Opt.some(read(xml));
+      return Optional.of(read(xml));
     } catch (Exception e) {
-      return Opt.none();
+      return Optional.empty();
     }
   }
 

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/EncodingSchemeUtils.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/EncodingSchemeUtils.java
@@ -22,8 +22,6 @@
 
 package org.opencastproject.metadata.dublincore;
 
-import com.entwinemedia.fn.data.Opt;
-
 import org.joda.time.Duration;
 import org.joda.time.format.ISODateTimeFormat;
 import org.joda.time.format.ISOPeriodFormat;
@@ -32,6 +30,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -78,7 +77,7 @@ public final class EncodingSchemeUtils {
     if (precision == null)
       throw new IllegalArgumentException("The precision must not be null");
 
-    return DublinCoreValue.mk(formatDate(date, precision), DublinCore.LANGUAGE_UNDEFINED, Opt.some(DublinCore.ENC_SCHEME_W3CDTF));
+    return DublinCoreValue.mk(formatDate(date, precision), DublinCore.LANGUAGE_UNDEFINED, Optional.of(DublinCore.ENC_SCHEME_W3CDTF));
   }
 
   public static String formatDate(Date date, Precision precision) {
@@ -123,7 +122,7 @@ public final class EncodingSchemeUtils {
       b.append(" ").append("name=").append(period.getName().replace(";", "")).append(";");
     }
     b.append(" ").append("scheme=W3C-DTF;");
-    return DublinCoreValue.mk(b.toString(), DublinCore.LANGUAGE_UNDEFINED, Opt.some(DublinCore.ENC_SCHEME_PERIOD));
+    return DublinCoreValue.mk(b.toString(), DublinCore.LANGUAGE_UNDEFINED, Optional.of(DublinCore.ENC_SCHEME_PERIOD));
   }
 
   /**
@@ -139,7 +138,7 @@ public final class EncodingSchemeUtils {
    */
   public static DublinCoreValue encodeDuration(long duration) {
     return DublinCoreValue.mk(ISOPeriodFormat.standard().print(new Duration(duration).toPeriod()),
-            DublinCore.LANGUAGE_UNDEFINED, Opt.some(DublinCore.ENC_SCHEME_ISO8601));
+            DublinCore.LANGUAGE_UNDEFINED, Optional.of(DublinCore.ENC_SCHEME_ISO8601));
   }
 
   /**

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/OpencastDctermsDublinCore.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/OpencastDctermsDublinCore.java
@@ -251,7 +251,7 @@ public abstract class OpencastDctermsDublinCore {
     // only allow to set a created date, if no start date is set. Otherwise DC created will be changed by changing the
     // start date with setTemporal. Synchronization is not vice versa, as setting DC created to arbitraty dates might
     // have unwanted side effects, like setting the wrong recording time, on imported data, or third-party REST calls.
-    if (!getTemporal().isPresent()) {
+    if (getTemporal().isEmpty()) {
       t.fold(new Temporal.Match<Void>() {
         @Override
         public Void period(DCMIPeriod period) {

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/OpencastDctermsDublinCore.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/OpencastDctermsDublinCore.java
@@ -20,7 +20,6 @@
  */
 package org.opencastproject.metadata.dublincore;
 
-import static com.entwinemedia.fn.Stream.$;
 import static org.opencastproject.metadata.dublincore.DublinCore.LANGUAGE_ANY;
 import static org.opencastproject.metadata.dublincore.DublinCore.PROPERTY_AUDIENCE;
 import static org.opencastproject.metadata.dublincore.DublinCore.PROPERTY_CONTRIBUTOR;
@@ -42,13 +41,6 @@ import static org.opencastproject.metadata.dublincore.DublinCore.PROPERTY_TITLE;
 import static org.opencastproject.metadata.dublincore.DublinCore.PROPERTY_TYPE;
 
 import org.opencastproject.mediapackage.EName;
-import org.opencastproject.metadata.dublincore.Temporal.Match;
-
-import com.entwinemedia.fn.Fn;
-import com.entwinemedia.fn.Stream;
-import com.entwinemedia.fn.Unit;
-import com.entwinemedia.fn.data.Opt;
-import com.entwinemedia.fn.fns.Strings;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -56,6 +48,9 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.MissingResourceException;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -124,7 +119,7 @@ public abstract class OpencastDctermsDublinCore {
 
   /* ------------------------------------------------------------------------------------------------------------------ */
 
-  @Nonnull public Opt<String> getLicense() {
+  @Nonnull public Optional<String> getLicense() {
     return getFirst(PROPERTY_LICENSE);
   }
 
@@ -139,7 +134,7 @@ public abstract class OpencastDctermsDublinCore {
   /* ------------------------------------------------------------------------------------------------------------------ */
 
   /** Get the {@link DublinCore#PROPERTY_IDENTIFIER} property. */
-  @Nonnull public Opt<String> getDcIdentifier() {
+  @Nonnull public Optional<String> getDcIdentifier() {
     return getFirst(PROPERTY_IDENTIFIER);
   }
 
@@ -149,7 +144,7 @@ public abstract class OpencastDctermsDublinCore {
   }
 
   /** Update the {@link DublinCore#PROPERTY_IDENTIFIER} property. */
-  public void updateDcIdentifier(Opt<String> id) {
+  public void updateDcIdentifier(Optional<String> id) {
     update(PROPERTY_IDENTIFIER, id);
   }
 
@@ -161,7 +156,7 @@ public abstract class OpencastDctermsDublinCore {
   /* ------------------------------------------------------------------------------------------------------------------ */
 
   /** Get the {@link DublinCore#PROPERTY_TITLE} property. */
-  @Nonnull public Opt<String> getTitle() {
+  @Nonnull public Optional<String> getTitle() {
     return getFirst(PROPERTY_TITLE);
   }
 
@@ -171,7 +166,7 @@ public abstract class OpencastDctermsDublinCore {
   }
 
   /** Update the {@link DublinCore#PROPERTY_TITLE} property. */
-  public void updateTitle(Opt<String> title) {
+  public void updateTitle(Optional<String> title) {
     update(PROPERTY_TITLE, title);
   }
 
@@ -183,7 +178,7 @@ public abstract class OpencastDctermsDublinCore {
   /* ------------------------------------------------------------------------------------------------------------------ */
 
   /** Get the {@link DublinCore#PROPERTY_DESCRIPTION} property. */
-  @Nonnull public Opt<String> getDescription() {
+  @Nonnull public Optional<String> getDescription() {
     return getFirst(PROPERTY_DESCRIPTION);
   }
 
@@ -193,7 +188,7 @@ public abstract class OpencastDctermsDublinCore {
   }
 
   /** Update the {@link DublinCore#PROPERTY_DESCRIPTION} property. */
-  public void updateDescription(Opt<String> description) {
+  public void updateDescription(Optional<String> description) {
     update(PROPERTY_DESCRIPTION, description);
   }
 
@@ -225,7 +220,7 @@ public abstract class OpencastDctermsDublinCore {
   }
 
   /** Update the {@link DublinCore#PROPERTY_AUDIENCE} property. */
-  public void updateAudience(Opt<String> audience) {
+  public void updateAudience(Optional<String> audience) {
     update(PROPERTY_AUDIENCE, audience);
   }
 
@@ -237,7 +232,7 @@ public abstract class OpencastDctermsDublinCore {
   /* ------------------------------------------------------------------------------------------------------------------ */
 
   /** Get the {@link DublinCore#PROPERTY_CREATED} property. */
-  @Nonnull public Opt<Temporal> getCreated() {
+  @Nonnull public Optional<Temporal> getCreated() {
     return getFirstVal(PROPERTY_CREATED).map(OpencastMetadataCodec.decodeTemporal);
   }
 
@@ -246,34 +241,62 @@ public abstract class OpencastDctermsDublinCore {
     // only allow to set a created date, if no start date is set. Otherwise DC created will be changed by changing the
     // start date with setTemporal. Synchronization is not vice versa, as setting DC created to arbitraty dates might
     // have unwanted side effects, like setting the wrong recording time, on imported data, or third-party REST calls.
-    if (getTemporal().isNone()) {
+    if (getTemporal().isEmpty()) {
       setDate(PROPERTY_CREATED, date, Precision.Day);
     }
   }
 
   /** Set the {@link DublinCore#PROPERTY_CREATED} property. The date is encoded with a precision of {@link Precision#Day}. */
+//  public void setCreated(Temporal t) {
+//    // only allow to set a created date, if no start date is set. Otherwise DC created will be changed by changing the
+//    // start date with setTemporal. Synchronization is not vice versa, as setting DC created to arbitraty dates might
+//    // have unwanted side effects, like setting the wrong recording time, on imported data, or third-party REST calls.
+//    if (getTemporal().isEmpty()) {
+//      t.fold(new Match<Unit>() {
+//        @Override public Unit period(DCMIPeriod period) {
+//          setCreated(period.getStart());
+//          return Unit.unit;
+//        }
+//
+//        @Override public Unit instant(Date instant) {
+//          setCreated(instant);
+//          return Unit.unit;
+//        }
+//
+//        @Override public Unit duration(long duration) {
+//          return Unit.unit;
+//        }
+//      });
+//    }
+//  }
+
   public void setCreated(Temporal t) {
     // only allow to set a created date, if no start date is set. Otherwise DC created will be changed by changing the
     // start date with setTemporal. Synchronization is not vice versa, as setting DC created to arbitraty dates might
     // have unwanted side effects, like setting the wrong recording time, on imported data, or third-party REST calls.
-    if (getTemporal().isNone()) {
-      t.fold(new Match<Unit>() {
-        @Override public Unit period(DCMIPeriod period) {
+    if (!getTemporal().isPresent()) {
+      t.fold(new Temporal.Match<Void>() {
+        @Override
+        public Void period(DCMIPeriod period) {
           setCreated(period.getStart());
-          return Unit.unit;
+          return null;
         }
 
-        @Override public Unit instant(Date instant) {
+        @Override
+        public Void instant(Date instant) {
           setCreated(instant);
-          return Unit.unit;
+          return null;
         }
 
-        @Override public Unit duration(long duration) {
-          return Unit.unit;
+        @Override
+        public Void duration(long duration) {
+          // No action needed for duration
+          return null;
         }
       });
     }
   }
+
 
   /** Remove the {@link DublinCore#PROPERTY_CREATED} property. */
   public void removeCreated() {
@@ -303,7 +326,7 @@ public abstract class OpencastDctermsDublinCore {
   }
 
   /** Update the {@link DublinCore#PROPERTY_CREATOR} property. */
-  public void updateCreator(Opt<String> name) {
+  public void updateCreator(Optional<String> name) {
     update(PROPERTY_CREATOR, name);
   }
 
@@ -315,7 +338,7 @@ public abstract class OpencastDctermsDublinCore {
   /* ------------------------------------------------------------------------------------------------------------------ */
 
   /** Get the {@link DublinCore#PROPERTY_EXTENT} property. */
-  @Nonnull public Opt<Long> getExtent() {
+  @Nonnull public Optional<Long> getExtent() {
     return getFirst(PROPERTY_EXTENT).map(OpencastMetadataCodec.decodeDuration);
   }
 
@@ -332,7 +355,7 @@ public abstract class OpencastDctermsDublinCore {
   /* ------------------------------------------------------------------------------------------------------------------ */
 
   /** Get the {@link DublinCore#PROPERTY_ISSUED} property. */
-  @Nonnull public Opt<Date> getIssued() {
+  @Nonnull public Optional<Date> getIssued() {
     return getFirst(PROPERTY_ISSUED).map(OpencastMetadataCodec.decodeDate);
   }
 
@@ -342,7 +365,7 @@ public abstract class OpencastDctermsDublinCore {
   }
 
   /** Update the {@link DublinCore#PROPERTY_ISSUED} property. */
-  public void updateIssued(Opt<Date> date) {
+  public void updateIssued(Optional<Date> date) {
     updateDate(PROPERTY_ISSUED, date, Precision.Day);
   }
 
@@ -354,7 +377,7 @@ public abstract class OpencastDctermsDublinCore {
   /* ------------------------------------------------------------------------------------------------------------------ */
 
   /** Get the {@link DublinCore#PROPERTY_LANGUAGE} property. */
-  @Nonnull public Opt<String> getLanguage() {
+  @Nonnull public Optional<String> getLanguage() {
     return getFirst(PROPERTY_LANGUAGE);
   }
 
@@ -384,7 +407,7 @@ public abstract class OpencastDctermsDublinCore {
   /* ------------------------------------------------------------------------------------------------------------------ */
 
   /** Get the {@link DublinCore#PROPERTY_SPATIAL} property. */
-  @Nonnull public Opt<String> getSpatial() {
+  @Nonnull public Optional<String> getSpatial() {
     return getFirst(PROPERTY_SPATIAL);
   }
 
@@ -394,7 +417,7 @@ public abstract class OpencastDctermsDublinCore {
   }
 
   /** Update the {@link DublinCore#PROPERTY_SPATIAL} property. */
-  public void updateSpatial(Opt<String> spatial) {
+  public void updateSpatial(Optional<String> spatial) {
     update(PROPERTY_SPATIAL, spatial);
   }
 
@@ -406,7 +429,7 @@ public abstract class OpencastDctermsDublinCore {
   /* ------------------------------------------------------------------------------------------------------------------ */
 
   /** Get the {@link DublinCore#PROPERTY_SOURCE} property. */
-  @Nonnull public Opt<String> getSource() {
+  @Nonnull public Optional<String> getSource() {
     return getFirst(PROPERTY_SOURCE);
   }
 
@@ -443,7 +466,7 @@ public abstract class OpencastDctermsDublinCore {
   }
 
   /** Update the {@link DublinCore#PROPERTY_CONTRIBUTOR} property. */
-  public void updateContributor(Opt<String> contributor) {
+  public void updateContributor(Optional<String> contributor) {
     update(PROPERTY_CONTRIBUTOR, contributor);
   }
 
@@ -455,7 +478,7 @@ public abstract class OpencastDctermsDublinCore {
   /* ------------------------------------------------------------------------------------------------------------------ */
 
   /** Get the {@link DublinCore#PROPERTY_TEMPORAL} property. */
-  @Nonnull public Opt<Temporal> getTemporal() {
+  @Nonnull public Optional<Temporal> getTemporal() {
     return getFirstVal(PROPERTY_TEMPORAL).map(OpencastMetadataCodec.decodeTemporal);
   }
 
@@ -478,12 +501,12 @@ public abstract class OpencastDctermsDublinCore {
   /* ------------------------------------------------------------------------------------------------------------------ */
 
   /** Get the {@link DublinCore#PROPERTY_TYPE} property split into its components. Components are separated by "/". */
-  @Nonnull public Opt<Stream<String>> getType() {
-    return getFirst(PROPERTY_TYPE).map(Strings.split("/"));
+  @Nonnull public Optional<Stream<String>> getType() {
+    return getFirst(PROPERTY_TYPE).map(s -> Stream.of(s.split("/")));
   }
 
   /** Get the {@link DublinCore#PROPERTY_TYPE} property as a single string. */
-  @Nonnull public Opt<String> getTypeCombined() {
+  @Nonnull public Optional<String> getTypeCombined() {
     return getFirst(PROPERTY_TYPE);
   }
 
@@ -514,7 +537,7 @@ public abstract class OpencastDctermsDublinCore {
     }
 
     /** Get the {@link DublinCore#PROPERTY_IS_PART_OF} property. */
-    @Nonnull public Opt<String> getIsPartOf() {
+    @Nonnull public Optional<String> getIsPartOf() {
       return getFirst(PROPERTY_IS_PART_OF);
     }
 
@@ -524,7 +547,7 @@ public abstract class OpencastDctermsDublinCore {
     }
 
     /** Update the {@link DublinCore#PROPERTY_IS_PART_OF} property. */
-    public void updateIsPartOf(Opt<String> seriesID) {
+    public void updateIsPartOf(Optional<String> seriesID) {
       update(PROPERTY_IS_PART_OF, seriesID);
     }
 
@@ -549,9 +572,9 @@ public abstract class OpencastDctermsDublinCore {
     dc.set(property, OpencastMetadataCodec.encodeDate(date, p));
   }
 
-  protected void updateDate(EName property, Opt<Date> date, Precision p) {
-    for (Date d : date) {
-      setDate(property, d, p);
+  protected void updateDate(EName property, Optional<Date> date, Precision p) {
+    if (date.isPresent()) {
+      setDate(property, date.get(), p);
     }
   }
 
@@ -565,13 +588,13 @@ public abstract class OpencastDctermsDublinCore {
   }
 
   /** Like {@link DublinCore#getFirst(EName)} but with the result wrapped in an Opt. */
-  protected Opt<String> getFirst(EName property) {
-    return Opt.nul(dc.getFirst(property));
+  protected Optional<String> getFirst(EName property) {
+    return Optional.ofNullable(dc.getFirst(property));
   }
 
   /** Like {@link DublinCore#getFirstVal(EName)} but with the result wrapped in an Opt. */
-  protected Opt<DublinCoreValue> getFirstVal(EName property) {
-    return Opt.nul(dc.getFirstVal(property));
+  protected Optional<DublinCoreValue> getFirstVal(EName property) {
+    return Optional.ofNullable(dc.getFirstVal(property));
   }
 
   public void set(EName property, String value) {
@@ -581,7 +604,10 @@ public abstract class OpencastDctermsDublinCore {
   }
 
   public void set(EName property, List<String> values) {
-    final List<DublinCoreValue> valuesFiltered = $(values).filter(Strings.isNotBlank).map(mkValue).toList();
+    List<DublinCoreValue> valuesFiltered = values.stream()
+        .filter(s -> s != null && !s.trim().isEmpty())
+        .map(DublinCoreValue::mk) // assuming mkValue is DublinCoreValue::mk
+        .collect(Collectors.toList());
     if (!valuesFiltered.isEmpty()) {
       dc.remove(property);
       dc.set(property, valuesFiltered);
@@ -594,15 +620,9 @@ public abstract class OpencastDctermsDublinCore {
     }
   }
 
-  protected void update(EName property, Opt<String> value) {
-    for (String v : value) {
-      set(property, v);
+  protected void update(EName property, Optional<String> value) {
+    if (value.isPresent()) {
+      set(property, value.get());
     }
   }
-
-  private final Fn<String, DublinCoreValue> mkValue = new Fn<String, DublinCoreValue>() {
-    @Override public DublinCoreValue apply(String v) {
-      return DublinCoreValue.mk(v);
-    }
-  };
 }

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/OpencastDctermsDublinCore.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/OpencastDctermsDublinCore.java
@@ -247,29 +247,6 @@ public abstract class OpencastDctermsDublinCore {
   }
 
   /** Set the {@link DublinCore#PROPERTY_CREATED} property. The date is encoded with a precision of {@link Precision#Day}. */
-//  public void setCreated(Temporal t) {
-//    // only allow to set a created date, if no start date is set. Otherwise DC created will be changed by changing the
-//    // start date with setTemporal. Synchronization is not vice versa, as setting DC created to arbitraty dates might
-//    // have unwanted side effects, like setting the wrong recording time, on imported data, or third-party REST calls.
-//    if (getTemporal().isEmpty()) {
-//      t.fold(new Match<Unit>() {
-//        @Override public Unit period(DCMIPeriod period) {
-//          setCreated(period.getStart());
-//          return Unit.unit;
-//        }
-//
-//        @Override public Unit instant(Date instant) {
-//          setCreated(instant);
-//          return Unit.unit;
-//        }
-//
-//        @Override public Unit duration(long duration) {
-//          return Unit.unit;
-//        }
-//      });
-//    }
-//  }
-
   public void setCreated(Temporal t) {
     // only allow to set a created date, if no start date is set. Otherwise DC created will be changed by changing the
     // start date with setTemporal. Synchronization is not vice versa, as setting DC created to arbitraty dates might

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/OpencastMetadataCodec.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/OpencastMetadataCodec.java
@@ -20,9 +20,8 @@
  */
 package org.opencastproject.metadata.dublincore;
 
-import com.entwinemedia.fn.Fn;
-
 import java.util.Date;
+import java.util.function.Function;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -46,7 +45,7 @@ public final class OpencastMetadataCodec {
   }
 
   /** {@link OpencastMetadataCodec#decodeDate(java.lang.String)} as a function. */
-  public static final Fn<String, Date> decodeDate = new Fn<String, Date>() {
+  public static final Function<String, Date> decodeDate = new Function<String, Date>() {
     @Override public Date apply(String a) {
       return decodeDate(a);
     }
@@ -63,7 +62,7 @@ public final class OpencastMetadataCodec {
   }
 
   /** {@link OpencastMetadataCodec#decodeDuration(String)} as a function. */
-  public static final Fn<String, Long> decodeDuration = new Fn<String, Long>() {
+  public static final Function<String, Long> decodeDuration = new Function<String, Long>() {
     @Override public Long apply(String a) {
       return decodeDuration(a);
     }
@@ -80,7 +79,7 @@ public final class OpencastMetadataCodec {
   }
 
   /** {@link OpencastMetadataCodec#decodeTemporal(DublinCoreValue)} as a function. */
-  @Nonnull public static final Fn<DublinCoreValue, Temporal> decodeTemporal = new Fn<DublinCoreValue, Temporal>() {
+  @Nonnull public static final Function<DublinCoreValue, Temporal> decodeTemporal = new Function<DublinCoreValue, Temporal>() {
     @Override public Temporal apply(DublinCoreValue a) {
       return decodeTemporal(a);
     }

--- a/modules/dublincore/src/test/java/org/opencastproject/metadata/dublincore/DublinCoreCatalogTest.java
+++ b/modules/dublincore/src/test/java/org/opencastproject/metadata/dublincore/DublinCoreCatalogTest.java
@@ -21,7 +21,6 @@
 
 package org.opencastproject.metadata.dublincore;
 
-import static com.entwinemedia.fn.Stream.$;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -35,11 +34,6 @@ import org.opencastproject.mediapackage.EName;
 import org.opencastproject.mediapackage.XMLCatalogImpl.CatalogEntry;
 import org.opencastproject.util.IoSupport;
 
-import com.entwinemedia.fn.Fn;
-import com.entwinemedia.fn.FnX;
-import com.entwinemedia.fn.Unit;
-import com.entwinemedia.fn.data.Opt;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -51,9 +45,11 @@ import java.io.FileOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CyclicBarrier;
+import java.util.stream.Collectors;
 
 import javax.xml.XMLConstants;
 
@@ -70,7 +66,7 @@ public class DublinCoreCatalogTest {
   public void testLoadFromFile() throws Exception {
     final DublinCoreCatalog dc = read("/dublincore-extended.xml");
     assertEquals(asList("2007-12-05"), dc.get(DublinCore.PROPERTY_MODIFIED, DublinCore.LANGUAGE_UNDEFINED));
-    assertEquals(Opt.<EName>none(), dc.get(DublinCore.PROPERTY_TYPE).get(0).getEncodingScheme());
+    assertEquals(Optional.<EName>empty(), dc.get(DublinCore.PROPERTY_TYPE).get(0).getEncodingScheme());
     assertEquals(2, dc.get(DublinCore.PROPERTY_TITLE).size());
     assertEquals(1, dc.get(DublinCore.PROPERTY_TITLE, DublinCore.LANGUAGE_UNDEFINED).size());
     assertEquals(2, dc.get(DublinCore.PROPERTY_TITLE, DublinCore.LANGUAGE_ANY).size());
@@ -79,9 +75,9 @@ public class DublinCoreCatalogTest {
             dc.get(DublinCore.PROPERTY_CONTRIBUTOR, DublinCore.LANGUAGE_UNDEFINED));
     assertEquals(
             "The modified property should be of type W3CDTF.",
-            Opt.some(DublinCore.ENC_SCHEME_W3CDTF), dc.get(DublinCore.PROPERTY_MODIFIED).get(0).getEncodingScheme());
+            Optional.of(DublinCore.ENC_SCHEME_W3CDTF), dc.get(DublinCore.PROPERTY_MODIFIED).get(0).getEncodingScheme());
     assertEquals(1, dc.get(PROPERTY_FOO_ID).size());
-    assertEquals(Opt.<EName>none(), dc.get(PROPERTY_FOO_ID).get(0).getEncodingScheme());
+    assertEquals(Optional.<EName>empty(), dc.get(PROPERTY_FOO_ID).get(0).getEncodingScheme());
     assertTrue(
             "Property foo:id should be in the list of known properties.",
             dc.getProperties().contains(PROPERTY_FOO_ID));
@@ -97,7 +93,7 @@ public class DublinCoreCatalogTest {
     assertEquals(9, dc.getValuesFlat().size());
     assertEquals(2, dc.get(DublinCore.PROPERTY_TITLE).size());
     assertEquals(
-            Opt.some(EName.mk("http://lib.org/metadata-enc", "PlainTitle")),
+            Optional.of(EName.mk("http://lib.org/metadata-enc", "PlainTitle")),
             dc.get(DublinCore.PROPERTY_TITLE).get(0).getEncodingScheme());
     for (CatalogEntry entry : dc.getEntriesSorted()) {
       logger.debug(entry.getEName().toString() + " " + entry.getValue());
@@ -123,7 +119,7 @@ public class DublinCoreCatalogTest {
     assertEquals(10, dc.getValuesFlat().size());
     assertEquals(2, dc.get(DublinCore.PROPERTY_TITLE).size());
     assertEquals(
-            Opt.some(EName.mk("http://lib.org/metadata-enc", "PlainTitle")),
+            Optional.of(EName.mk("http://lib.org/metadata-enc", "PlainTitle")),
             dc.get(DublinCore.PROPERTY_TITLE).get(0).getEncodingScheme());
     for (CatalogEntry entry : dc.getEntriesSorted()) {
       logger.debug(entry.getEName().toString() + " " + entry.getValue());
@@ -172,12 +168,9 @@ public class DublinCoreCatalogTest {
   public void testLoadAndSave() throws Exception {
     final DublinCoreCatalog dc = read("/dublincore-extended.xml");
     final File out = testFolder.newFile("dublincore.xml");
-    IoSupport.withResource(new FileOutputStream(out), new FnX<FileOutputStream, Unit>() {
-      @Override public Unit applyX(FileOutputStream out) throws Exception {
-        dc.toXml(out, false);
-        return Unit.unit;
-      }
-    });
+    try (FileOutputStream fos = new FileOutputStream(out)) {
+      dc.toXml(fos, false);
+    }
     final DublinCoreCatalog reloaded = DublinCoreXmlFormat.read(out);
     assertEquals(
             "The reloaded catalog should have the same amount of properties than the original one.",
@@ -199,13 +192,9 @@ public class DublinCoreCatalogTest {
     final DublinCoreCatalog dc2 = read("/sorting/dublincore1-2.xml");
     assertEquals(dc1.getEntriesSorted(), dc2.getEntriesSorted());
     // make sure attributes are sorted in the correct order
-    List<Map<EName, String>> attributes = $(dc1.getEntriesSorted())
-        .map(new Fn<CatalogEntry, Map<EName, String>>() {
-          @Override public Map<EName, String> apply(CatalogEntry entry) {
-            return entry.getAttributes();
-          }
-        })
-        .toList();
+    List<Map<EName, String>> attributes = dc1.getEntriesSorted().stream()
+        .map(CatalogEntry::getAttributes)
+        .collect(Collectors.toList());
     assertEquals("Attribute order", attributes, list(
         map(),
         map(tuple(EName.mk(XMLConstants.XML_NS_URI, "lang"), "de")),

--- a/modules/dublincore/src/test/java/org/opencastproject/metadata/dublincore/DublinCoreMetadataCollectionTest.java
+++ b/modules/dublincore/src/test/java/org/opencastproject/metadata/dublincore/DublinCoreMetadataCollectionTest.java
@@ -24,13 +24,12 @@ package org.opencastproject.metadata.dublincore;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.entwinemedia.fn.data.Opt;
-
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Optional;
 
 public class DublinCoreMetadataCollectionTest {
   private static final String FIRST_ID = "first";
@@ -191,19 +190,19 @@ public class DublinCoreMetadataCollectionTest {
       .asList(unorderedOne, unorderedTwo, unorderedThree, first, third, seventh, newFirst));
 
     int numberOfFirsts = 0;
-    Opt<String> valueFound = Opt.none();
+    Optional<String> valueFound = Optional.empty();
 
     for (final MetadataField field : collection.getFields()) {
       if (field.getInputID().equals(FIRST_ID)) {
         numberOfFirsts++;
         if (field.getValue() != null && field.getValue() instanceof String) {
-          valueFound = Opt.some((String) field.getValue());
+          valueFound = Optional.of((String) field.getValue());
         }
       }
     }
 
     assertEquals("There should only be one field called first in the collection.", 1, numberOfFirsts);
-    assertTrue("The value has been set so it should be in the collection.", valueFound.isSome());
+    assertTrue("The value has been set so it should be in the collection.", valueFound.isPresent());
     assertEquals("There should only be one field called first in the collection.", value, valueFound.get());
   }
 }

--- a/modules/dublincore/src/test/java/org/opencastproject/metadata/dublincore/EncodingSchemeUtilsTest.java
+++ b/modules/dublincore/src/test/java/org/opencastproject/metadata/dublincore/EncodingSchemeUtilsTest.java
@@ -37,14 +37,13 @@ import static org.opencastproject.metadata.dublincore.TestUtil.createDate;
 import static org.opencastproject.metadata.dublincore.TestUtil.precisionDay;
 import static org.opencastproject.metadata.dublincore.TestUtil.precisionSecond;
 
-import com.entwinemedia.fn.data.Opt;
-
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Optional;
 import java.util.TimeZone;
 
 /**
@@ -66,7 +65,7 @@ public class EncodingSchemeUtilsTest {
     assertEquals(4, encodeDate(now, Precision.Year).getValue().length());
     assertEquals(3, encodeDate(now, Precision.Day).getValue().split("-").length);
     assertEquals("2009-01-01T00:00:00Z".length(), encodeDate(now, Precision.Second).getValue().length());
-    assertEquals(Opt.some(DublinCore.ENC_SCHEME_W3CDTF), encodeDate(now, Precision.Year).getEncodingScheme());
+    assertEquals(Optional.of(DublinCore.ENC_SCHEME_W3CDTF), encodeDate(now, Precision.Year).getEncodingScheme());
     // Test symmetry
     assertEquals(decodeDate(encodeDate(now, Precision.Second)), precisionSecond(now));
     assertEquals(decodeDate(encodeDate(createDate(1999, 3, 21, 14, 0, 0), Precision.Day)), precisionDay(createDate(
@@ -99,7 +98,7 @@ public class EncodingSchemeUtilsTest {
     DublinCoreValue a = encodePeriod(new DCMIPeriod(createDate(2007, 2, 10, 12, 0, 0), createDate(2009, 12, 24, 10, 0,
             0), "long time"), Precision.Day);
     assertEquals("start=2007-02-10; end=2009-12-24; name=long time; scheme=W3C-DTF;", a.getValue());
-    assertEquals(Opt.some(DublinCore.ENC_SCHEME_PERIOD), a.getEncodingScheme());
+    assertEquals(Optional.of(DublinCore.ENC_SCHEME_PERIOD), a.getEncodingScheme());
     DublinCoreValue b = encodePeriod(new DCMIPeriod(createDate(2007, 2, 10, 12, 0, 0), null), Precision.Day);
     assertEquals("start=2007-02-10; scheme=W3C-DTF;", b.getValue());
   }
@@ -193,7 +192,7 @@ public class EncodingSchemeUtilsTest {
     assertEquals(d3, decodeDuration(encodeDuration(d3).getValue()));
     assertEquals(new Long(1 * 1000 * 60 * 60 + 10 * 1000 * 60 + 5 * 1000), decodeDuration("01:10:05"));
 
-    assertEquals(Opt.some(DublinCore.ENC_SCHEME_ISO8601), encodeDuration(d3).getEncodingScheme());
+    assertEquals(Optional.of(DublinCore.ENC_SCHEME_ISO8601), encodeDuration(d3).getEncodingScheme());
 
     assertNull(decodeDuration(DublinCoreValue.mk("bla")));
     assertNull(decodeDuration(DublinCoreValue.mk(encodeDuration(d1).getValue(), DublinCore.LANGUAGE_UNDEFINED,

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
@@ -757,7 +757,7 @@ public class SeriesEndpoint {
       }
     }
 
-    if (optCollection.isNone()) {
+    if (optCollection.isEmpty()) {
       return ApiResponseBuilder.notFound("Cannot find a catalog with type '%s' for series with id '%s'.", type, id);
     }
 

--- a/modules/message-broker-api/src/main/java/org/opencastproject/message/broker/api/scheduler/SchedulerItem.java
+++ b/modules/message-broker-api/src/main/java/org/opencastproject/message/broker/api/scheduler/SchedulerItem.java
@@ -289,7 +289,7 @@ public class SchedulerItem implements Serializable {
       return null;
     }
 
-    return DublinCoreXmlFormat.readOpt(event).orNull();
+    return DublinCoreXmlFormat.readOpt(event).orElse(null);
   }
 
   public Map<String, String> getProperties() {

--- a/modules/message-broker-api/src/main/java/org/opencastproject/message/broker/api/series/SeriesItem.java
+++ b/modules/message-broker-api/src/main/java/org/opencastproject/message/broker/api/series/SeriesItem.java
@@ -168,7 +168,7 @@ public final class SeriesItem implements MessageItem, Serializable {
   }
 
   public DublinCoreCatalog getMetadata() {
-    return DublinCoreXmlFormat.readOpt(series).orNull();
+    return DublinCoreXmlFormat.readOpt(series).orElse(null);
   }
 
   public DublinCoreCatalog getExtendedMetadata() {

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerUtil.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerUtil.java
@@ -226,16 +226,16 @@ public final class SchedulerUtil {
 
           boolean hasLanguageDefined = !DublinCore.LANGUAGE_UNDEFINED.equals(value.getLanguage());
 
-          if (hasLanguageDefined || value.getEncodingScheme().isSome()) {
+          if (hasLanguageDefined || value.getEncodingScheme().isPresent()) {
             sb.append(" (");
             if (hasLanguageDefined) {
               sb.append("lang:").append(value.getLanguage());
-              if (value.getEncodingScheme().isSome())
+              if (value.getEncodingScheme().isPresent())
                 sb.append("/");
             }
 
-            for (EName schema : value.getEncodingScheme()) {
-              sb.append(schema.getLocalName());
+            if (value.getEncodingScheme().isPresent()) {
+              sb.append(value.getEncodingScheme().get().getLocalName());
             }
             sb.append(")");
           }


### PR DESCRIPTION
Replace entwine code with plain Java in the dublincore module. Leaves some entwine that would otherwise require large changes in the index or external-api modules.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
