### PR TITLE
Add event access control update mode configuration options back!

### DIFF
--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -1,5 +1,20 @@
 # Opencast 17: Release Notes
 
+## Opencast 17.4
+
+This release contains a few bug fixes and enhancements of existing features. Among others, it enables the use of
+Elasticsearch even if the setup is in yellow state ([#6681](https://github.com/opencast/opencast/pull/6681)).
+It also adds an endpoint to trigger the update of a single event in search
+([#6653](https://github.com/opencast/opencast/pull/6653)).
+
+Most importantly, this contains a new version of both the Editor
+([17.x-2025-05-23](https://github.com/opencast/opencast-editor/releases/tag/17.x-2025-05-23)) and the Admin UI
+([17.x-2025-05-24](https://github.com/opencast/opencast-admin-interface/releases/tag/17.x-2025-05-24)).
+
+Additionally it contains a new version of Opencast Studio
+([2025-04-30](https://github.com/elan-ev/opencast-studio/releases/tag/2025-04-30))
+with a bugfix regarding incorrect error messages when uploading.
+
 ## Opencast 17.3
 
 This release contains a few bug fixes, among them performance improvements for the metrics endpoint

--- a/etc/org.opencastproject.organization-mh_default_org.cfg
+++ b/etc/org.opencastproject.organization-mh_default_org.cfg
@@ -188,3 +188,15 @@ prop.org.opencastproject.admin.mediamodule.url=${prop.org.opencastproject.engage
 # Format: boolean
 # Default: false
 #prop.admin.statistics.enabled=false
+
+# Event access control update mode when modifying series permissions.
+# Possible modes are:
+# - always:   When modifying series permissions, automatically remove all permission rules specific to single episodes
+#             belonging to the series. This enforces every episode has the rules of the series in effect as soon as they
+#             are changed.
+# - never:    Only update the series permissions but never replace permissions set on event level. This can mean that
+#             updated rules have no effect on already existing events.
+# - optional: Like `never` but present users with a button in the series permission dialog which allows them to
+#             replace the event specific permissions if they want to.Add commentMore actions
+# Default: optional
+#prop.admin.series.acl.event.update.mode=optional


### PR DESCRIPTION
This PR fixes #6779.
It reintroduces the option `prop.admin.series.acl.event.update.mode` so that it can be used within the Admin-UI.

### How to test this patch

1. Apply this patch in your Opencast instance.
2. Enable the new configuration option and verify that it is correctly read by Opencast and reflected in the Organization endpoint.
3. Use the corresponding Admin-UI patch ([[opencast-admin-interface#1295](https://github.com/opencast/opencast-admin-interface/pull/1295)](https://github.com/opencast/opencast-admin-interface/pull/1295)) to test the functionality by toggling between `optional` and `never`.
 **Note:** The above-mentioned Admin-UI PR is still a work in progress.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
