### PR TITLE
Paella security fix: Paella Player can load configuration files from arbitrary servers

### DIFF
--- a/modules/engage-paella-player-7/src/js/PaellaOpencast.js
+++ b/modules/engage-paella-player-7/src/js/PaellaOpencast.js
@@ -39,8 +39,15 @@ import dictionary from '../default-dictionaries.js';
 import OpencastAuth from './OpencastAuth.js';
 
 function getUrlFromBase(base, url) {
-  const a = base.endsWith('/') ? base.slice(0, -1) : base;
+  let a = base.endsWith('/') ? base.slice(0, -1) : base;
+  a = a.startsWith('/') ? a.slice(1) : a;
+  if (a.length > 0 ) {
+    a = a.startsWith(window.location.origin)
+      ? a
+      : `${window.location.origin}/${a}`;
+  }
   const b = url.startsWith('/') ? url.slice(1) : url;
+
   const fullURL = `${a}/${b}`;
   return fullURL;
 }


### PR DESCRIPTION
This PR fixes this report from @mtneug:

The Paella Player in Opencast checks whether there is a query parameter called „oc.config“. This parameter can be used to change what Paella Player configuration file is loaded. There is currently no limitation and any URL can be specified resulting in a GET request to that server by the users browser. For example, the following URL

https://stable.opencast.org/paella7/ui/watch.html?id=ID-about-opencast&oc.config=https://google.com

will happily make a request to

https://google.com/config.json

Opencast Studio has a similar query parameter called „settingsFile“, but this is limited to just filenames within the Opencast Studio configuration folder.

This feature is helpful in general. Especially in the context of embedding the Paella Player in various systems. However, there should be a similar limit as in Opencast Studio.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch