### PR TITLE
Add event access control update mode configuration options: r/17.x

### DIFF
--- a/etc/org.opencastproject.organization-mh_default_org.cfg
+++ b/etc/org.opencastproject.organization-mh_default_org.cfg
@@ -188,3 +188,15 @@ prop.org.opencastproject.admin.mediamodule.url=${prop.org.opencastproject.engage
 # Format: boolean
 # Default: false
 #prop.admin.statistics.enabled=false
+
+# Event access control update mode when modifying series permissions.
+# Possible modes are:
+# - always:   When modifying series permissions, automatically remove all permission rules specific to single episodes
+#             belonging to the series. This enforces every episode has the rules of the series in effect as soon as they
+#             are changed.
+# - never:    Only update the series permissions but never replace permissions set on event level. This can mean that
+#             updated rules have no effect on already existing events.
+# - optional: Like `never` but present users with a button in the series permission dialog which allows them to
+#             replace the event specific permissions if they want to.Add commentMore actions
+# Default: optional
+#prop.admin.series.acl.event.update.mode=optional


### PR DESCRIPTION
This PR fixes #6779.
It reintroduces the option `prop.admin.series.acl.event.update.mode` so that it can be used within the Admin-UI.
rebase r/17.x!
### How to test this patch

1. Apply this patch in your Opencast instance.
2. Enable the new configuration option and verify that it is correctly read by Opencast and reflected in the Organization endpoint.
3. Use the corresponding Admin-UI patch ([[opencast-admin-interface#1295](https://github.com/opencast/opencast-admin-interface/pull/1295)](https://github.com/opencast/opencast-admin-interface/pull/1295)) to test the functionality by toggling between `optional` and `never`.
 **Note:** The above-mentioned Admin-UI PR is still a work in progress.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
