### PR TITLE
Tobira URLs improvement

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/tobira/TobiraService.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/tobira/TobiraService.java
@@ -66,6 +66,7 @@ public final class TobiraService {
     return (JSONObject) request(
             "query AdminUIHostPages($seriesId: String!) {"
                     + "  series: seriesByOpencastId(id: $seriesId) {"
+                    + "    id"
                     + "    hostPages: hostRealms {"
                     + "      ... RealmData"
                     + "      blocks { id }"
@@ -89,6 +90,7 @@ public final class TobiraService {
             "query AdminUIEventHostPages($eventId: String!) {"
                     + "  event: eventByOpencastId(id: $eventId) {"
                     + "    ...on AuthorizedEvent {"
+                    + "      id"
                     + "      hostPages: hostRealms {"
                     + "        title: name"
                     + "        path"


### PR DESCRIPTION
If you've configured Tobira correctly, a Tobira tab will appear in the event/series details dialog of the Admin UI. This provides a direct link to the resource in Tobira and lists all Tobira realms that contain it. The URLs are based on the Opencast resource ID. Since Tobira uses its own IDs (a hash-like format), we should preferably use these. However, the Tobira resource ID should also be requested.

This is a backend part of the Admin UI improvement.

Event Opencast ID: `18e4c988-e944-4aed-8376-3b25db6a6eb8`
Event URL without this patch: https://tobira.opencast.org/!v/:18e4c988-e944-4aed-8376-3b25db6a6eb8

Event Tobira ID: `evL52r4riq-hr` (the `ev` prefix used for events in general)
Event URL after: https://tobira.opencast.org/!v/L52r4riq-hr