### PR TITLE
Fix jwt validation failures when using ECDSA algorithms

### DIFF
--- a/modules/security-jwt/pom.xml
+++ b/modules/security-jwt/pom.xml
@@ -14,7 +14,7 @@
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
     <java-jwt.version>3.18.1</java-jwt.version>
-    <jwks-rsa.version>0.19.0</jwks-rsa.version>
+    <jwks-rsa.version>0.22.1</jwks-rsa.version>
   </properties>
   <dependencies>
     <!-- Internal -->


### PR DESCRIPTION
This patch simply updates the package `com.auth0.jwks-rsa` version to the latest version 0.22.1. This update includes a [fix for invalid public keys](https://github.com/auth0/jwks-rsa-java/pull/153) and should fix the jwts validation fails in #6092.

Todo:
- [x] This patch needs to be tested