### PR TITLE
Deselecting a series may result in loss of access to the event

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -1683,10 +1683,25 @@ public class IndexServiceImpl implements IndexService {
           mp.remove(mpe);
           seriesDcTags.addAll(Arrays.asList(mpe.getTags()));
         }
-        // remove series ACL from the media package
-        for (MediaPackageElement mpe : mp.getElementsByFlavor(MediaPackageElements.XACML_POLICY_SERIES)) {
-          mp.remove(mpe);
-          seriesAclTags.addAll(Arrays.asList(mpe.getTags()));
+        if (mp.getSeries() != null || mp.getElementsByFlavor(MediaPackageElements.XACML_POLICY_EPISODE).length > 0) {
+          // a new series was set or the series was unset and episode ACL exists
+          // remove series ACL from the media package
+          for (MediaPackageElement mpe : mp.getElementsByFlavor(MediaPackageElements.XACML_POLICY_SERIES)) {
+            mp.remove(mpe);
+            seriesAclTags.addAll(Arrays.asList(mpe.getTags()));
+          }
+        } else {
+          // series was unset but episode don't have an episode ACL
+          // in this case user may lose access to the episode if we delete the series ACL
+          // but, we also shouldn't keep the series ACL because the series was unset
+          // let's keep the series ACL as episode ACL and provide same access rights as before
+          Tuple<AccessControlList, AclScope> activeAcl = authorizationService.getActiveAcl(mp);
+          try {
+            authorizationService.setAcl(mp, AclScope.Episode, activeAcl.getA());
+            authorizationService.removeAcl(mp, AclScope.Series);
+          } catch (MediaPackageException e) {
+            throw new IllegalStateException("Unable to set episode ACL on media package", e);
+          }
         }
         // remove series extended metadata from the media package
         try {


### PR DESCRIPTION
If the event has no episode ACL but only a series ACL, deselecting a series may result in the event no longer having any ACL. The non admin user will then lose access to the event. This occurs because the series ACL will be applied or (in this case) removed during the metadata update. To prevent this, we can keep the currently active ACL as the episode ACL before deleting the series ACL.

### How to test this patch

- Create and use an unprivileged Opencast user
  - Grant access to the admin UI and creating events
- Create an event
- Change series of the event
- Series metadata and ACLs should be attached to the event
- Delete event ACL
  - within the Admin UI you can't delete an event ACL, but a workflow will do the job
  - Series ACL should be still applied
- Unset series

### Expected behavior

- User should still have access to the event

### Current behavior

- Event don't have any ACLs
- User can's access the event