### PR TITLE
Fix minor markdown doc warnings

### DIFF
--- a/docs/guides/admin/docs/configuration/index.md
+++ b/docs/guides/admin/docs/configuration/index.md
@@ -39,7 +39,6 @@ Everything related to protecting your installation and data.
     - [Authentication and Authorization Infrastructure (AAI)](security.aai.md)
     - [JWT-based Authentication and Authorization (e.g. for OIDC)](security.jwt.md)
     - [Access Control Lists](acl.md)
-    - [Stream Security](stream-security.md)
     - [Role Based Event Access](episode-id-roles.md)
 - [Serving Static Files](serving-static-files.md)
 - [Stream Security Overview](stream-security/stream-security-overview.md)

--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -51,7 +51,7 @@ configure asset upload options in more detail [[#6362](https://github.com/openca
   no longer necessary to include a separate encode operation for this in the workflow.
   [[#6248](https://github.com/opencast/opencast/pull/6248)]
 - You can now provide terms of use to be presented to new users in the Admin UI. For configuration see
-  [the respective docs](../configuration/admin-ui/terms.md). [[#6010](https://github.com/opencast/opencast/pull/6010)]
+  [the respective docs](configuration/admin-ui/terms.md). [[#6010](https://github.com/opencast/opencast/pull/6010)]
 - There is a new UI for the documentation of our REST endpoints but since it currently has some issues, it's not turned
   on by default. You can however already try it out. [[#5668](https://github.com/opencast/opencast/pull/5668)]
 - There is a new GraphQL API as an alternative to the existing REST API. Please be aware that this is not yet production

--- a/docs/guides/developer/docs/develop/debugging.md
+++ b/docs/guides/developer/docs/develop/debugging.md
@@ -142,6 +142,6 @@ For security reasons, remember to disable the web console in production systems 
 
 ## Automatic Module Reloading
 
-See [Build Single Modules](development-environment.md#build-single-modules)
+See [Build Single Modules](setup-opencast-for-develop.md#build-single-modules)
 
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/SeriesListQuery.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/SeriesListQuery.java
@@ -87,6 +87,8 @@ public class SeriesListQuery extends ResourceListQueryImpl {
   public SeriesListQuery() {
     super();
     this.availableFilters.add(createCreationDateFilter(Option.<Tuple<Date, Date>> none()));
+    this.availableFilters.add(createOrganizersFilter(Option.none()));
+    this.availableFilters.add(createContributorsFilter(Option.none()));
   }
 
   /**


### PR DESCRIPTION
In reviewing a PR, I noticed a couple of very minor WARNINGs during the markdown docs.  This fixes them.
