### PR TITLE
Update Whisper.cpp defaults to reflect new binary names

### DIFF
--- a/docs/guides/admin/docs/releasenotes/whisper-cpp.txt
+++ b/docs/guides/admin/docs/releasenotes/whisper-cpp.txt
@@ -1,0 +1,2 @@
+- We switched to using the new default binary names used by Whisper.cpp
+- The default model directory is now /usr/share/whisper.cpp/models

--- a/etc/org.opencastproject.speechtotext.impl.engine.WhisperCppEngine.cfg
+++ b/etc/org.opencastproject.speechtotext.impl.engine.WhisperCppEngine.cfg
@@ -1,12 +1,11 @@
 # Configuration for setting a custom path to the Whisper.cpp command line tool
 # Default: whisper.cpp
-#whispercpp.root.path=whisper.cpp
+#whispercpp.root.path=whisper-cli
 
 # Absolute path to language model
-# RPMs install models to /usr/share/ggml/ggml-<model>.bin
-# Available models: tiny, base, small, medium, large.
-# Default: /usr/share/ggml/ggml-base.bin
-#whispercpp.model=/usr/share/ggml/ggml-base.bin
+# Opencast's RPM and Debian packages install models to /usr/share/whisper.cpp/models/.
+# Default: /usr/share/whisper.cpp/models/ggml-base.bin
+#whispercpp.model=/usr/share/whisper.cpp/models/ggml-base.bin
 
 
 ## Optional settings to configure the underlying whispercpp engine

--- a/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/WhisperCppEngine.java
+++ b/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/WhisperCppEngine.java
@@ -73,7 +73,7 @@ public class WhisperCppEngine implements SpeechToTextEngine {
   private static final String WHISPERCPP_EXECUTABLE_PATH_CONFIG_KEY = "whispercpp.root.path";
 
   /** Default path to WhisperC++. */
-  public static final String WHISPERCPP_EXECUTABLE_DEFAULT_PATH = "whisper.cpp";
+  public static final String WHISPERCPP_EXECUTABLE_DEFAULT_PATH = "whisper-cli";
 
   /** Currently used path of the WhisperC++ installation. */
   private String whispercppExecutable = WHISPERCPP_EXECUTABLE_DEFAULT_PATH;
@@ -82,7 +82,7 @@ public class WhisperCppEngine implements SpeechToTextEngine {
   private static final String WHISPERCPP_MODEL_CONFIG_KEY = "whispercpp.model";
 
   /** Default whispercpp model */
-  public static final String WHISPERCPP_MODEL_DEFAULT = "/usr/share/ggml/ggml-base.bin";
+  public static final String WHISPERCPP_MODEL_DEFAULT = "/usr/share/whisper.cpp/models/ggml-base.bin";
 
   /** Currently used whispercpp model */
   private String whispercppModel = WHISPERCPP_MODEL_DEFAULT;


### PR DESCRIPTION
The default binary names of Whisper.cpp have changed. This patch adjusts the Opencast code to reflect the new binary names. For more details, see the deprecation warning at
https://github.com/ggml-org/whisper.cpp/tree/v1.7.5/examples/deprecation-warning

Starting with Opencast 18, this change will also be included in Opencast's package repository. The additional change to the default model folder is done to also match the packages.


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
