### PR TITLE
Explain that WhisperC++ autoencode is an Opencast feature

### DIFF
--- a/etc/org.opencastproject.speechtotext.impl.engine.WhisperCppEngine.cfg
+++ b/etc/org.opencastproject.speechtotext.impl.engine.WhisperCppEngine.cfg
@@ -51,5 +51,6 @@
 #whispercpp.no-fallback=false
 
 # Automatically convert media files to wav
+# This is done by Opencast itself before handing over the audio track.
 # Default: true
 #whispercpp.auto-encode=true


### PR DESCRIPTION
WhisperC++ now supports converting audio internally if built with FFmpeg support:
https://github.com/ggml-org/whisper.cpp/blob/2679bec6e09231c6fd59715fcba3eebc9e2f6076/README.md#ffmpeg-support-linux-only

That may make the auto encode option a bit confusing and we should explain that Opencast does the encoding and then passes the encoded file to WhisperC++.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
