### PR TITLE
Disable icla check for opencastproject user

### DIFF
--- a/.github/workflows/check-icla.yml
+++ b/.github/workflows/check-icla.yml
@@ -6,7 +6,8 @@ on:
 
 jobs:
   main:
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    if: github.event.pull_request.user.login != 'dependabot[bot]' && 
+        github.event.pull_request.user.login != 'opencastproject'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/setup-python@v5


### PR DESCRIPTION

This PR disables the ICLA check for PRs originating from the @opencastproject user.  This user is a bot, being used to file PRs updating the admin and editor components as they update.
