### PR TITLE
Update r/17.x Editor to 17.x-2025-06-19

### DIFF
--- a/modules/editor/pom.xml
+++ b/modules/editor/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <editor.url>https://github.com/opencast/opencast-editor/releases/download/17.x-2025-05-23/oc-editor-17.x-2025-05-23.tar.gz</editor.url>
-    <editor.sha256></editor.sha256>
+    <editor.url>https://github.com/opencast/opencast-editor/releases/download/17.x-2025-06-19/oc-editor-17.x-2025-06-19.tar.gz</editor.url>
+    <editor.sha256>38926f4d89b7f4ecab2d5568a37f7939689f2e9682265106da9fbed661a76f3e</editor.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
Updating Opencast r/17.x Editor module to [17.x-2025-06-19](https://github.com/opencast/opencast-editor/releases/tag/17.x-2025-06-19)