### PR TITLE
Remove series load in paella player

### DIFF
--- a/modules/engage-paella-player-7/package-lock.json
+++ b/modules/engage-paella-player-7/package-lock.json
@@ -19,7 +19,7 @@
         "@babel/core": "^7.25.7",
         "@babel/eslint-parser": "^7.25.9",
         "@babel/preset-env": "^7.26.0",
-        "@playwright/test": "^1.48.2",
+        "@playwright/test": "^1.53.1",
         "babel-loader": "^9.2.1",
         "copy-webpack-plugin": "^12.0.2",
         "css-loader": "^7.1.2",
@@ -1916,12 +1916,12 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.48.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.2.tgz",
-      "integrity": "sha512-54w1xCWfXuax7dz4W2M9uw0gDyh+ti/0K/MxcCUxChFh37kkdxPdfZDw5QBbuPUJHr1CiHJ1hXgSs+GgeQc5Zw==",
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.1.tgz",
+      "integrity": "sha512-Z4c23LHV0muZ8hfv4jw6HngPJkbbtZxTkxPNIg7cJcTc9C28N/p2q7g3JZS2SiKBBHJ3uM1dgDye66bB7LEk5w==",
       "dev": true,
       "dependencies": {
-        "playwright": "1.48.2"
+        "playwright": "1.53.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5806,12 +5806,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.48.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.2.tgz",
-      "integrity": "sha512-NjYvYgp4BPmiwfe31j4gHLa3J7bD2WiBz8Lk2RoSsmX38SVIARZ18VYjxLjAcDsAhA+F4iSEXTSGgjua0rrlgQ==",
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.1.tgz",
+      "integrity": "sha512-LJ13YLr/ocweuwxyGf1XNFWIU4M2zUSo149Qbp+A4cpwDjsxRPj7k6H25LBrEHiEwxvRbD8HdwvQmRMSvquhYw==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.48.2"
+        "playwright-core": "1.53.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5824,9 +5824,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.48.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.2.tgz",
-      "integrity": "sha512-sjjw+qrLFlriJo64du+EK0kJgZzoQPsabGF4lBvsid+3CNIZIYLgnMj9V6JY5VhM2Peh20DJWIVpVljLLnlawA==",
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.1.tgz",
+      "integrity": "sha512-Z46Oq7tLAyT0lGoFx4DOuB1IA9D1TPj0QkYxpPVUnGDqHHvDpCftu1J2hM2PiWsNMoZh8+LQaarAWcDfPBc6zg==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"

--- a/modules/engage-paella-player-7/package.json
+++ b/modules/engage-paella-player-7/package.json
@@ -17,7 +17,7 @@
     "@babel/core": "^7.25.7",
     "@babel/eslint-parser": "^7.25.9",
     "@babel/preset-env": "^7.26.0",
-    "@playwright/test": "^1.48.2",
+    "@playwright/test": "^1.53.1",
     "babel-loader": "^9.2.1",
     "copy-webpack-plugin": "^12.0.2",
     "css-loader": "^7.1.2",

--- a/modules/engage-paella-player-7/src/js/EpisodeConversor.js
+++ b/modules/engage-paella-player-7/src/js/EpisodeConversor.js
@@ -157,6 +157,7 @@ function getMetadata(episode, config) {
     rights: ensureArray(dc?.rightsHolder),
     license: ensureSingle(dc?.license),
     series: ensureSingle(dc?.isPartOf),
+    seriestitle: ensureSingle(episode?.mediapackage?.seriestitle),
     presenters: ensureArray(dc?.creator),
     contributors: ensureArray(dc?.contributor),
     startDate: new Date(dc?.created),

--- a/modules/engage-paella-player-7/src/js/PaellaOpencast.js
+++ b/modules/engage-paella-player-7/src/js/PaellaOpencast.js
@@ -170,22 +170,6 @@ const initParams = {
       }
     }
 
-    // Load the series, if appropriate
-    const loadSeries = async (sid) => {
-      const response = await fetch(getUrlFromOpencastServer('/search/series.json?id=' + sid));
-
-      if (response.ok) {
-        const sdata = await response.json();
-        return sdata['result'][0]['dc']['title'][0];
-      }
-      else {
-        throw Error('Series data missing');
-      }
-    };
-    const series = data?.metadata?.series !== undefined ? await loadSeries(data?.metadata?.series) : undefined;
-
-    data.metadata.seriestitle = series;
-
     // Add event title to browser tab
     const videoTitle = data?.metadata?.title ?? 'Unknown video title';
     const seriesTitle = data?.metadata?.seriestitle ?? 'No series';


### PR DESCRIPTION
I see no reason why this series fetch from Opencast is needed because the fetched episode data contains the series title. This series fetch was introduced in https://github.com/opencast/opencast/commit/4aaca26a0f9ebcb84ed440bdd23cbfbe5d59298.

This patch fixes #6812.