### PR TITLE
Replace video.ethz.ch links with OC explore & adjust docs dashboard

### DIFF
--- a/docs/guides/.infrastructure/index.html.j2
+++ b/docs/guides/.infrastructure/index.html.j2
@@ -91,9 +91,15 @@
           <h4>Webinars</h4>
           <p>Our webinars range from how to use basic tools to highly technical topics.
             Upcoming webinars are announced on the mailing list and on the website.
-            Take a look at <a href="https://video.ethz.ch/events/opencast/miscellaneous/webinars.html">
+            Take a look at <a href="https://explore.opencast.org/webinars">
             the list of previously recorded webinars</a>.
           </p>
+        </div>
+
+        <div class="col-md-6">
+          <h4>Conference Recordings & Opencast Explore</h4>
+          <p>Many of our conference talks are very suitable to learn more about Opencast and everything related to it.
+          You can find all of these recordings, and more, on <a href="https://explore.opencast.org">Opencast Explore</a>.
         </div>
       </div>
 

--- a/docs/guides/admin/docs/configuration/encoding.md
+++ b/docs/guides/admin/docs/configuration/encoding.md
@@ -10,7 +10,7 @@ build to work for everyone, meaning that in most cases optimization can be done 
 these profiles or building new ones often makes sense. This document will help you modify or augment Opencast's
 default encoding profiles for audio, video and still images.
 
-If you prefer a video introduction to the topic, check out [this talk on encoding profiles and ffmpeg](https://video.ethz.ch/events/opencast/2020/gent/63bccf44-3409-4434-9988-be4e8674f607.html) 
+If you prefer a video introduction to the topic, check out [this talk on encoding profiles and ffmpeg](https://explore.opencast.org/conferences/2020/summit/v/P0azdNWPoNj)
 
 Default Profiles and Possible Settings
 --------------------------------------

--- a/docs/guides/admin/docs/configuration/ltimodule.md
+++ b/docs/guides/admin/docs/configuration/ltimodule.md
@@ -15,7 +15,7 @@ Opencast videos without ever leaving their course.
 More information about the LTI specification is available at
 [IMS Learning Tools Interoperability](https://imsglobal.org/activity/learning-tools-interoperability).
 For a better  understanding of what LTI is and what it is not, consider this
-[introductory webinar](https://video.ethz.ch/events/opencast/miscellaneous/webinars/3bb13443-19d3-4147-8ff9-7106f5a959bb.html).
+[introductory webinar](https://explore.opencast.org/webinars/v/A_q9rVZ3Pzb).
 
 
 Configuration

--- a/docs/guides/admin/docs/configuration/workflow.md
+++ b/docs/guides/admin/docs/configuration/workflow.md
@@ -13,8 +13,8 @@ operations, see:
 
 > [List of Workflow Operation Handler](../workflowoperationhandlers/index.md)
 
-For a video introduction to workflow, take a look at this [workflow workshop](https://video.ethz.ch/events/opencast/2020/gent/7cb2164f-e060-4108-9b3f-770e9f361ec7.html).
-Or for longer session, check out this [in-depth webinar on workflows](https://video.ethz.ch/events/opencast/miscellaneous/webinars/445be642-685a-4575-9bbf-08db21bd8c94.html).
+For a video introduction to workflow, take a look at this [workflow workshop](https://explore.opencast.org/conferences/2020/summit/v/CQeYQie869O).
+Or for longer session, check out this [in-depth webinar on workflows](https://explore.opencast.org/webinars/v/CjqLfpgeTVW).
 
 ## Overview
 
@@ -332,8 +332,8 @@ As the formal description above explains, such boolean expressions may contain�
 - …strings, which must be surrounded by single-quotes. Escaping of single quotes is supported, just use two single
   quotes next to each other: `'foo''bar'`
 - …as well as references to the variables of the workflow instance that contain these data types. Variables
-  are enclosed in `${}`, as shown below. A default value may be specified for a variable, after the name, 
-  separated by a colon, as such: `${foo:1}`. The default value will be used in case the variable doesn’t exist. 
+  are enclosed in `${}`, as shown below. A default value may be specified for a variable, after the name,
+  separated by a colon, as such: `${foo:1}`. The default value will be used in case the variable doesn’t exist.
   If no default value is specified, `false` will be used. This, of course, only makes sense in boolean contexts. Be
   aware to specify a default value in relations such as `${foo} < ${bar}`.
 

--- a/docs/guides/admin/docs/installation/rpm-el.md
+++ b/docs/guides/admin/docs/installation/rpm-el.md
@@ -129,7 +129,7 @@ Upgrading
 ---------
 
 > 🎞️ If you want to see how upgrading Opencast works if you are using the RPM repository,
-> [we made a short recording to show you the process](https://video.ethz.ch/events/opencast/miscellaneous/webinars/6803b383-239e-4a37-b0c6-e1fc7af124b0.html).
+> [we made a short recording to show you the process](https://explore.opencast.org/webinars/v/N_HuDZx9rO0).
 
 Packages will automatically upgrade to the latest minor version in a release series when running `dnf update`.
 They do not automatically upgrade the latest major version.

--- a/docs/guides/developer/docs/architecture/filesystem.md
+++ b/docs/guides/developer/docs/architecture/filesystem.md
@@ -1,3 +1,3 @@
 # Under Construction
 
-While this page is being constructed, consider checking out [this webinar on Storage management and snapshots](https://video.ethz.ch/events/opencast/miscellaneous/webinars/ba506689-f6ff-4ebd-bfb7-b61d2f3fcaef.html).
+While this page is being constructed, consider checking out [this webinar on Storage management and snapshots](https://explore.opencast.org/webinars/v/K0McuVkZs2X).

--- a/docs/guides/developer/docs/architecture/job-dispatch.md
+++ b/docs/guides/developer/docs/architecture/job-dispatch.md
@@ -1,3 +1,3 @@
 # Under construction
 
-While this page is being constructed, consider checking out [this webinar on Job Dispatching and Job Loads](https://video.ethz.ch/events/opencast/miscellaneous/webinars/ac93170a-79ab-4981-b8c0-06bd224a07a8.html).
+While this page is being constructed, consider checking out [this webinar on Job Dispatching and Job Loads](https://explore.opencast.org/webinars/v/PGom1gu6yO4).

--- a/docs/guides/developer/docs/develop/integration.md
+++ b/docs/guides/developer/docs/develop/integration.md
@@ -2,6 +2,6 @@ Integrating with Opencast
 -------------------------
 
 ### Video guides
-[How to integrate? An overview of Opencast's APIs](https://video.ethz.ch/events/opencast/2023/berlin/41ccd52d-97cc-4cbc-bfdc-26dfa5271135.html),
+[How to integrate? An overview of Opencast's APIs](https://explore.opencast.org/conferences/2023/summit/v/PzNE_Ifjw_Z),
 a talk from the Opencast Summit 2023 which goes over the different APIs Opencast makes available and how they should or
 should not be used.

--- a/docs/guides/developer/docs/participate/development-process.md
+++ b/docs/guides/developer/docs/participate/development-process.md
@@ -161,7 +161,7 @@ Was a sensible description chosen?
 
 - Does the description detail the goal of the pull request? A pull request should have one clear goal. If there are
   multiple goals, it is usually best to split these among multiple pull requests.
-- Would the stated goal of the pull request improve the Opencast codebase, or should it be rejected outright? Fixing a 
+- Would the stated goal of the pull request improve the Opencast codebase, or should it be rejected outright? Fixing a
   bug usually improves the code, adding another video player might not.
 - Does the description explain how to test the pull request, e.g. is certain configuration necessary?
 
@@ -223,11 +223,11 @@ The GitHub web interface is ever-changing. If you are looking for help with navi
 
 If videos are more your style:
 
-- (English) [Talk from 2021 Opencast Summit](https://video.ethz.ch/events/opencast/2021/graz/0014efff-ff04-414c-876c-7a7eeb66122b.html),
+- (English) [Talk from 2021 Opencast Summit](https://explore.opencast.org/conferences/2021/summit/v/KFCy9-UiTQH),
   slide presentation by Greg on how he does things.
-- (German) [Talk from 2020 Opencast D/A/CH](https://video.ethz.ch/events/opencast/2020/innsbruck/58a02ce8-1bf6-4b2a-b220-faf65931efbc.html),
+- (German) [Talk from 2020 Opencast D/A/CH](https://explore.opencast.org/conferences/2020/dach/v/D_oVQk8WOMB),
   shows how to navigate the Opencast GitHub website for beginners. Starts at minute 30.
-- (English) [Talk from 2024 Opencast Summit](https://video.ethz.ch/events/opencast/2024/zaragoza/b12f4344-12db-4d1e-8997-c8dd3832a462.html),
+- (English) [Talk from 2024 Opencast Summit](https://explore.opencast.org/conferences/2024/summit/v/Bj1WJ_SPn_t),
   5 minutes of motivation for non-technical reviewers.
 
 
@@ -386,7 +386,7 @@ and that code patches do not break the existing functionality. These tests are a
 built. If building repeatedly fails due to test failures, then something is most likely wrong. Please report this as a
 severe bug.
 
-For a guide on how to write unit tests, see [Writing Unit Tests](https://video.ethz.ch/events/opencast/2023/berlin/b4861f53-738b-40fb-a1ab-ec4726eec6bd.html),
+For a guide on how to write unit tests, see [Writing Unit Tests](https://explore.opencast.org/conferences/2023/summit/v/EK9jXqbn78K),
 a talk how to write (good!) unit tests.
 
 ### User Tests

--- a/docs/guides/developer/docs/participate/proposal-log.md
+++ b/docs/guides/developer/docs/participate/proposal-log.md
@@ -218,30 +218,30 @@ Katrin
 ### External API deprecation policy
 Proposed by Maximiliano Lira Del Canto <mliradel@uni-koeln.de>, passed on 24 Feb 2021
 ```no-highlight
-As we talked in the draft thread and there are no more comments, this is the 
-final version of the proposal about the deprecation of the old 
+As we talked in the draft thread and there are no more comments, this is the
+final version of the proposal about the deprecation of the old
 versions in the external API.
 
 External API deprecation policy:
 
-- Any minor version should be supported at a maximum of 2 (Two) Opencast 
+- Any minor version should be supported at a maximum of 2 (Two) Opencast
 Releases since the release of the next minor version of the API.
- 
-    Example: If Opencast 10 has API v1.3.0 and Opencast 11 comes 
+
+    Example: If Opencast 10 has API v1.3.0 and Opencast 11 comes
     with API v1.4.0, the API v1.3.0 will be supported until Opencast 12)
- 
 
-- Deprecating a version does not require removing it from the code base, 
+
+- Deprecating a version does not require removing it from the code base,
 just removes the guarantee that it will be present in the next version.
- 
 
-- When an API version is set to be deprecated needs to notify the users 
-with a warning that they should start to use the newest version of the API. 
-A custom HTTP header when the flagged version is called plus a warning in 
+
+- When an API version is set to be deprecated needs to notify the users
+with a warning that they should start to use the newest version of the API.
+A custom HTTP header when the flagged version is called plus a warning in
 the website docs.
- 
 
-- In the case of a new major version, the immediate old version should 
+
+- In the case of a new major version, the immediate old version should
 be deprecated 4 (Four) next releases of Opencast.
 
 - Updating Opencast don't mean a new API version
@@ -462,7 +462,7 @@ OSGi component annotation example:
 If you want to know more about the service configuration and see
 annotations in action, watch the “Opencast OSGI Configuration“ webinar:
 
-  https://video.ethz.ch/events/opencast/webinars/7261ea70-ce36-4e17-8634-963966311028.html
+  https://explore.opencast.org/webinars/v/NJr9fCyXnqx
 
 This proposal passes on Wednesday evening if no one objects.
 


### PR DESCRIPTION
As we just discussed, OC Explore is now live, so we should replace all old links in the docs. Which this patch does. It also adds a small section to the docs dashboard, talking about conference recordings and OC Explore.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
