### PR TITLE
Remove fast workflow prior to release

### DIFF
--- a/.github/make-release
+++ b/.github/make-release
@@ -49,6 +49,7 @@ test "$(jq .consistent < version.json)" = "true"
 
 # commit changes
 git add pom.xml modules/*/pom.xml assemblies/pom.xml assemblies/*/pom.xml
+git rm -f etc/workflows/fast.xml
 git commit -m "Opencast ${VERSION}"
 git tag "${VERSION}" -m "Opencast ${VERSION}"
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -30,7 +30,6 @@ jobs:
 
       - name: build opencast
         run: |
-          rm -f etc/workflows/fast*
           mvn clean install \
             --batch-mode \
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -30,6 +30,7 @@ jobs:
 
       - name: build opencast
         run: |
+          rm -f etc/workflows/fast*
           mvn clean install \
             --batch-mode \
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \


### PR DESCRIPTION
This PR removes the fast workflow as part of the release process.  This makes the removal transparent to development since it happens just before the final build in GHA.

Targetting r/18.x since we don't have an 18.0, happy to backport to wherever if we want to apply this more broadly.
