### PR TITLE
Fix episode id roles in series of search service index

### DIFF
--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
@@ -314,7 +314,56 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
       }).filter(Objects::nonNull).collect(Collectors.toList());
     }
 
-    // Add custom roles to the ACL
+    // Add custom roles if enabled
+    acl = addCustomAclRoles(mediaPackageId, acl);
+
+    SearchResult item = new SearchResult(SearchService.IndexEntryType.Episode, dc, acl, orgId, mediaPackage,
+        null != modDate ? modDate.toInstant() : Instant.now(),
+        null != delDate ? delDate.toInstant() : null);
+    Map<String, Object> metadata = item.dehydrateForIndex();
+    try {
+      var request = new IndexRequest(INDEX_NAME);
+      request.id(mediaPackageId);
+      request.source(metadata);
+      esIndex.getClient().index(request, RequestOptions.DEFAULT);
+      logger.debug("Indexed episode {}", mediaPackageId);
+    } catch (IOException e) {
+      throw new SearchException(e);
+    }
+
+    // Elasticsearch series
+    for (DublinCoreCatalog seriesDc : seriesList) {
+      String seriesId = seriesDc.getFirst(DublinCore.PROPERTY_IDENTIFIER);
+      AccessControlList seriesAcl = persistence.getAccessControlLists(seriesId, mediaPackageId).stream()
+          .map(aclPair -> addCustomAclRoles(aclPair.getKey(), aclPair.getValue()))
+          .reduce(new AccessControlList(acl.getEntries()), AccessControlList::mergeActions);
+      item = new SearchResult(SearchService.IndexEntryType.Series, seriesDc, seriesAcl, orgId,
+          null, Instant.now(), null);
+
+      Map<String, Object> seriesData = item.dehydrateForIndex();
+      try {
+        var request = new IndexRequest(INDEX_NAME);
+        request.id(seriesId);
+        request.source(seriesData);
+        esIndex.getClient().index(request, RequestOptions.DEFAULT);
+        logger.debug("Indexed series {} related to episode {}", seriesId, mediaPackageId);
+      } catch (IOException e) {
+        throw new SearchException(e);
+      }
+    }
+  }
+
+  /**
+   * Add custom roles of the media package to the passed ACL
+   *
+   * @param mediaPackageId
+   *          the media package
+   * @param acl
+   *          the existing access control list
+   * @return {@link AccessControlList} containing the passed and the custom roles merged together
+   *
+   */
+  private AccessControlList addCustomAclRoles(String mediaPackageId, AccessControlList acl) {
     // This allows users with a role of the form ROLE_EPISODE_<ID>_<ACTION> to access the event through the index
     if (episodeIdRole) {
       Set<AccessControlEntry> customEntries = new HashSet<>();
@@ -339,39 +388,7 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
       acl = customRoles.merge(acl);
     }
 
-    SearchResult item = new SearchResult(SearchService.IndexEntryType.Episode, dc, acl, orgId, mediaPackage,
-        null != modDate ? modDate.toInstant() : Instant.now(),
-        null != delDate ? delDate.toInstant() : null);
-    Map<String, Object> metadata = item.dehydrateForIndex();
-    try {
-      var request = new IndexRequest(INDEX_NAME);
-      request.id(mediaPackageId);
-      request.source(metadata);
-      esIndex.getClient().index(request, RequestOptions.DEFAULT);
-      logger.debug("Indexed episode {}", mediaPackageId);
-    } catch (IOException e) {
-      throw new SearchException(e);
-    }
-
-    // Elasticsearch series
-    for (DublinCoreCatalog seriesDc : seriesList) {
-      String seriesId = seriesDc.getFirst(DublinCore.PROPERTY_IDENTIFIER);
-      AccessControlList seriesAcl = persistence.getAccessControlLists(seriesId, mediaPackageId).stream()
-          .reduce(new AccessControlList(acl.getEntries()), AccessControlList::mergeActions);
-      item = new SearchResult(SearchService.IndexEntryType.Series, seriesDc, seriesAcl, orgId,
-          null, Instant.now(), null);
-
-      Map<String, Object> seriesData = item.dehydrateForIndex();
-      try {
-        var request = new IndexRequest(INDEX_NAME);
-        request.id(seriesId);
-        request.source(seriesData);
-        esIndex.getClient().index(request, RequestOptions.DEFAULT);
-        logger.debug("Indexed series {} related to episode {}", seriesId, mediaPackageId);
-      } catch (IOException e) {
-        throw new SearchException(e);
-      }
-    }
+    return acl;
   }
 
   private void checkSearchEntityWritePermission(final String mediaPackageId) throws SearchException {
@@ -452,6 +469,7 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
           if (!persistence.getSeries(seriesId).isEmpty()) {
             // Update series acl if there are still episodes in the series
             final AccessControlList seriesAcl = persistence.getAccessControlLists(seriesId).stream()
+                .map(aclPair -> addCustomAclRoles(aclPair.getKey(), aclPair.getValue()))
                 .reduce(new AccessControlList(), AccessControlList::mergeActions);
             JsonElement json = gson.toJsonTree(Map.of(
                 SearchResult.INDEX_ACL, SearchResult.dehydrateAclForIndex(seriesAcl),
@@ -538,10 +556,6 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
             AccessControlList acl = persistence.getAccessControlList(mediaPackageId);
             Date modificationDate = persistence.getModificationDate(mediaPackageId);
             Date deletionDate = persistence.getDeletionDate(mediaPackageId);
-
-            AccessControlList seriesAcl = persistence.getAccessControlLists(mediaPackage.getSeries(), mediaPackageId)
-                .stream().reduce(new AccessControlList(acl.getEntries()), AccessControlList::mergeActions);
-            logger.debug("Updating series ACL with merged access control list: {}", seriesAcl);
 
             current.getAndIncrement();
 

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabase.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabase.java
@@ -120,11 +120,11 @@ public interface SearchServiceDatabase {
    *          series identifier for which ACL will be retrieved
    * @param excludeIds
    *          list of media package identifier to exclude from the list
-   * @return Collection of {@link AccessControlList} of media packages from the series
+   * @return Collection of pairs of media package id and its {@link AccessControlList} of media packages from the series
    * @throws SearchServiceDatabaseException
    *           if exception occurred
    */
-  Collection<AccessControlList> getAccessControlLists(String seriesId, String ... excludeIds)
+  Collection<Pair<String, AccessControlList>> getAccessControlLists(String seriesId, String ... excludeIds)
           throws SearchServiceDatabaseException;
 
   /**

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
@@ -283,10 +283,10 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
    * @see org.opencastproject.search.impl.persistence.SearchServiceDatabase#getAccessControlLists(String, String...)
    */
   @Override
-  public Collection<AccessControlList> getAccessControlLists(final String seriesId, String ... excludeIds)
+  public Collection<Pair<String, AccessControlList>> getAccessControlLists(final String seriesId, String ... excludeIds)
           throws SearchServiceDatabaseException {
     List<String> excludes = Arrays.asList(excludeIds);
-    List<AccessControlList> accessControlLists = new ArrayList<>();
+    List<Pair<String,AccessControlList>> accessControlLists = new ArrayList<>();
     try {
       List<SearchEntity> result = db.exec(namedQuery.findAll(
           "Search.findBySeriesId",
@@ -295,7 +295,10 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
       ));
       for (SearchEntity entity: result) {
         if (entity.getAccessControl() != null && !excludes.contains(entity.getMediaPackageId())) {
-          accessControlLists.add(AccessControlParser.parseAcl(entity.getAccessControl()));
+          accessControlLists.add(Pair.of(
+              entity.getMediaPackageId(),
+              AccessControlParser.parseAcl(entity.getAccessControl()))
+          );
         }
       }
     } catch (IOException | AccessControlParsingException e) {


### PR DESCRIPTION
This patch adds the missing episode id roles to the series of the search service index.

## Note
To add missing ALCs to the series of the search service index, simply rebuild the search service index (`POST /index/rebuild/Search`).

Fix #6814
