### PR TITLE
HttpClient Timeouts in Stud.IP User Directory

### DIFF
--- a/modules/userdirectory-studip/src/main/java/org/opencastproject/userdirectory/studip/StudipUserProviderInstance.java
+++ b/modules/userdirectory-studip/src/main/java/org/opencastproject/userdirectory/studip/StudipUserProviderInstance.java
@@ -38,11 +38,12 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.ExecutionError;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -278,7 +279,7 @@ public class StudipUserProviderInstance implements UserProvider, RoleProvider, C
       logger.error("Exception while parsing response from provider for user {}", userName, e);
       return null;
     } catch (IOException e) {
-      logger.error(e.getMessage());
+      logger.error("Error requesting user data for user `{}`: {}", userName, e.getMessage());
       return null;
     } catch (URISyntaxException e) {
       logger.error("Misspelled URI", e);
@@ -306,7 +307,12 @@ public class StudipUserProviderInstance implements UserProvider, RoleProvider, C
     HttpGet get = new HttpGet(url);
     get.setHeader("User-Agent", OC_USERAGENT);
 
-    try (CloseableHttpClient client = HttpClients.createDefault()) {
+    // Don't wait for responses indefinitely
+    RequestConfig config = RequestConfig.custom()
+        .setConnectTimeout(5000)
+        .setSocketTimeout(10000).build();
+
+    try (CloseableHttpClient client = HttpClientBuilder.create().setDefaultRequestConfig(config).build();) {
       try (CloseableHttpResponse resp = client.execute(get)) {
         var statusCode = resp.getStatusLine().getStatusCode();
         if (statusCode == 404) {


### PR DESCRIPTION
If the Stud.IP user directory is configured, but the LMS doesn't answer HTTP requests, the HTTP client will just hang, blocking all kind of internal Opencast functionality.

This patch adds a simple timeout configuration as a mitigation. Opencast will still be slowed down at several places, but it will at least continue to function.

### How to test this patch

Enable the Stud.IP user directory plugin and configure the provider by creating `etc/org.opencastproject.userdirectory.studip-default.cfg` containing:

```properties
org.opencastproject.userdirectory.studip.org=mh_default_org
org.opencastproject.userdirectory.studip.url=http://localhost:8000
org.opencastproject.userdirectory.studip.token=sometoken
```

Run a non-answering fake LMS:
```
while true; do nc -l 8000; done
```

Create a user not called `admin` and log-in. The login will take ~10s since you run into the timeout.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
