### PR TITLE
Accept AAI attribute values as list

### DIFF
--- a/modules/security-aai/src/main/java/org/opencastproject/security/aai/api/AttributeMapper.java
+++ b/modules/security-aai/src/main/java/org/opencastproject/security/aai/api/AttributeMapper.java
@@ -90,10 +90,19 @@ public class AttributeMapper implements InitializingBean {
       Expression exp = null;
       try {
         exp = parser.parseExpression(expression);
-        String res = (String) exp.getValue(sourceAttributes);
+        Object res = exp.getValue(sourceAttributes);
         logger.debug("Mapping {} to {}", exp.getExpressionString(), res);
-        if (res != null) {
-          mappedAttributes.add(res);
+        if (res == null) {
+          continue;
+        }
+        if (res instanceof String) {
+          mappedAttributes.add((String) res);
+        } else if (res instanceof List<?>) {
+          for (Object resListItem : (List<?>) res) {
+            if (resListItem instanceof String) {
+              mappedAttributes.add((String) resListItem);
+            }
+          }
         }
       } catch (Exception e) {
         logger.warn("Mapping for '{}' with expression {} exp.getExpressionString() failed: {}",


### PR DESCRIPTION
The Opencast AAI DynamicLoginHandler uses a number of attributes. Some attributes can have multiple values, such as roles. These values ​​must be strings. SpEL's dynamic template engine allows for the transformation of lists, which can be useful in some cases. The results of transformed lists are, in turn, lists. The Opencast AttributeMapper should also accept lists as values.

Real-worl-example:

The AAI role mapping with dynamic values for user affiliations may look like:

```xml
<util:list id="roleMapping" value-type="java.lang.String">
  <value>'ROLE_AAI_USER'</value>
  <value>'ROLE_AAI_USER_' + ['uniqueID']</value>
  <!-- homeOrganization is always a single value, if set -->
  <value>['homeOrganization'] != null ? 'ROLE_AAI_ORG_' + ['homeOrganization'] + '_MEMBER' : null</value>
  <!-- user may have multiple affiliations -->
  <value>['homeOrganization'] != null AND ['affiliation'] != null ? ['affiliation'].!['ROLE_AAI_ORG_' + #root['homeOrganization'] + '_AFFILIATION_' + #this] : null</value>
</util:list>
```

Resulting roles may look like:

- ROLE_AAI_USER
- ROLE_AAI_USER_jane@edu.org
- ROLE_AAI_ORG_edu.org_MEMBER
- ROLE_AAI_ORG_edu.org_AFFILIATION_member
- ROLE_AAI_ORG_edu.org_AFFILIATION_student
