### PR TITLE
Update r/17.x Admin UI to 17.x-2025-06-27

### DIFF
--- a/modules/admin-ui-interface/pom.xml
+++ b/modules/admin-ui-interface/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <interface.url>https://github.com/opencast/opencast-admin-interface/releases/download/17.x-2025-05-24/oc-admin-ui-17.x-2025-05-24.tar.gz</interface.url>
-    <interface.sha256>9d0438d8d2d158c295c07c9454b80b19127748fb19059988e8cb2d4eb8ce11a7</interface.sha256>
+    <interface.url>https://github.com/opencast/opencast-admin-interface/releases/download/17.x-2025-06-27/oc-admin-ui-17.x-2025-06-27.tar.gz</interface.url>
+    <interface.sha256>019b7c6cf54af579b264007f2418919a004f8954e3943261939fa8cea9d2036b</interface.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
Updating Opencast r/17.x Admin UI module to [17.x-2025-06-27](https://github.com/opencast/opencast-admin-interface/releases/tag/17.x-2025-06-27)