### PR TITLE
Fix changelog link in Github Release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -57,4 +57,4 @@ jobs:
             For further information, please take a look at:
 
             - [Release notes](https://docs.opencast.org/r/${{ steps.get_version.outputs.VERSION_MAIN }}.x/admin/#releasenotes/#opencast-${{ steps.get_version.outputs.VERSION_COMBINED }})
-            - [Changelog](https://docs.opencast.org/r/${{ steps.get_version.outputs.VERSION_MAIN }}.x/admin/#changelog/#opencast-${{ steps.get_version.outputs.VERSION_COMBINED }})
+            - [Changelog](https://docs.opencast.org/r/${{ steps.get_version.outputs.VERSION_MAIN }}.x/admin/#changelog/opencast-${{ steps.get_version.outputs.VERSION_MAIN }})


### PR DESCRIPTION
Fixes the changelog link in the Github release. However, addressing the correct section is harder now bc I included the date in the section headers - idk how I feel about that, of course one could include that in GH actions, or I move the date somewhere else, or... and I don't know ow much work to put in that if we plan to move to Github's own changelog soon(TM).