### PR TITLE
Faster Tests (Build JavaDocs only once)

### DIFF
--- a/.github/workflows/test-opencast-build.yml
+++ b/.github/workflows/test-opencast-build.yml
@@ -75,6 +75,7 @@ jobs:
 
         #This has to happen in a separate step or else various service classes aren't visible
       - name: build javadocs
+        if: matrix.java == 23
         run: |
           mvn javadoc:javadoc javadoc:aggregate -Pnone \
             --batch-mode \


### PR DESCRIPTION
This tests build Opencast with two Java versions, but they run the integration tests only with one version. The JavaDocs are also built with two versions.

It's somewhat unlikely that the JavaDocs break with a Java version update, nor do we really care that much. That is why this patch makes them run only once on the version that is not running the integration tests, so that they can run in parallel. This should make tests finish about 5 minutes faster.


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
