### PR TITLE
Switch to Ubuntu 24.04 Runner Image

### DIFF
--- a/.github/workflows/cut-release-tag.yml
+++ b/.github/workflows/cut-release-tag.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   cut-release-tag:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   deploy-documentation:
     if: github.repository_owner == 'opencast'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/test-configuration.yml
+++ b/.github/workflows/test-configuration.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test-documentation-build.yml
+++ b/.github/workflows/test-documentation-build.yml
@@ -16,7 +16,7 @@ jobs:
 
   # Check documentation with markdownlint and build it using mkdocs
   documentation:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test-lti-tools.yml
+++ b/.github/workflows/test-lti-tools.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/test-opencast-build.yml
+++ b/.github/workflows/test-opencast-build.yml
@@ -28,7 +28,7 @@ jobs:
           - 21
           - 23
     name: build (java ${{ matrix.java }})
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Ubuntu 24.04 is the default runner image for GitHub Actions for a while now. This patch will make our worklflows use that, rather than Ubuntu 22.04.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
