### PR TITLE
Limit OpenMP Threads only for Tesseract

### DIFF
--- a/assemblies/resources/bin/setenv
+++ b/assemblies/resources/bin/setenv
@@ -41,7 +41,4 @@
 export EXTRA_JAVA_OPTS="${EXTRA_JAVA_OPTS} -Dorg.eclipse.jetty.server.Request.maxFormContentSize=1500000 -Dfile.encoding=UTF-8 -Dlog4j2.formatMsgNoLookups=true"
 export KARAF_NOROOT=true
 
-# Mitigation for new Tesseract 4.x locking up the system
-export OMP_THREAD_LIMIT=1
-
 . "$DIRNAME/check_ports"

--- a/modules/textextractor-tesseract/src/main/java/org/opencastproject/textextractor/tesseract/TesseractTextExtractor.java
+++ b/modules/textextractor-tesseract/src/main/java/org/opencastproject/textextractor/tesseract/TesseractTextExtractor.java
@@ -141,6 +141,8 @@ public class TesseractTextExtractor implements TextExtractor, ManagedService {
     try {
       ProcessBuilder processBuilder = new ProcessBuilder(command);
       processBuilder.redirectErrorStream(true);
+      // Mitigation for new Tesseract 4.x spawning too many threads locking up the system. Limit to one thread.
+      processBuilder.environment().put("OMP_THREAD_LIMIT", "1");
       Process tesseractProcess = processBuilder.start();
 
       // listen to output


### PR DESCRIPTION
Currently, Opencast sets the environment variable `OMP_THREAD_LIMIT` to 1, thus limiting all spawned subprocesses using OpenMP to only use one thread. This was initially introduced by #2051 to limit Tesseract that could otherwise lock up systems. However, this also limits any other binary built upon OpenMP, e.g. Whisper.cpp.

This PR removes the default from `setenv` and sets the environment variable only when spawning the Tesseract subprocess. As such, the environment variable is now hard-coded. If this is undesired, a configuration option could be introduced.

### How to test this patch

* Configure the system for Whisper.cpp
* Check before and after this patch how many threads are used. The default should be 4.

### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
