### PR TITLE
Fix snapshot deletion for remote only MediaPackages

### DIFF
--- a/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/AbstractFileSystemAssetStore.java
+++ b/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/AbstractFileSystemAssetStore.java
@@ -150,6 +150,15 @@ public abstract class AbstractFileSystemAssetStore implements AssetStore {
   @Override
   public boolean delete(DeletionSelector sel) throws AssetStoreException {
     File dir = getDeletionSelectorDir(sel);
+    if (dir == null) {
+      // MediaPackage could not be found locally. This could mean
+      //   - all snapshots live in a remote asset store
+      //   - mount failed and files are temporary not available
+      //   - file was deleted out-of-band
+      //   - other fs problem
+      // In any case, we cannot continue and return "false" to indicate that the files could not be found.
+      return false;
+    }
     try {
       FileUtils.deleteDirectory(dir);
       // also delete the media package directory if all versions have been deleted
@@ -171,11 +180,14 @@ public abstract class AbstractFileSystemAssetStore implements AssetStore {
    *
    * @param sel
    *          the deletion selector
-   * @return the directory file
+   * @return the directory file or null if it does not exist (e.g. MediaPackage does not exist locally)
    */
   private File getDeletionSelectorDir(DeletionSelector sel) {
-    final String basePath = path(getRootDirectory(sel.getOrganizationId(), sel.getMediaPackageId()),
-            sel.getOrganizationId(), sel.getMediaPackageId());
+    final String rootPath = getRootDirectory(sel.getOrganizationId(), sel.getMediaPackageId());
+    if (rootPath == null) {
+      return null;
+    }
+    final String basePath = path(rootPath, sel.getOrganizationId(), sel.getMediaPackageId());
     if (sel.getVersion().isPresent()) {
       return file(basePath, sel.getVersion().get().toString());
     }


### PR DESCRIPTION
Deletion of snapshots will currently fail if all snapshots live in remote asset stores. When trying to delete from the local asset store the base directory of the MediaPackage will not be found leading to an exception when trying to concatenate a path. This patch adds a null check that will skip the deletion from the local asset store if the base directory cannot be found.

### How to test this patch

1. Configure S3 as asset store.
2. Move all snapshots to S3, e.g. with the `move-storage` operation.
3. Delete snapshots, e.g. with the `asset-delete` operation including `keep-last-snapshot: true`.
4. Step 3 will fail without this patch.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
