### PR TITLE
Have admin ui endpoint for workflow errors return root job id

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/JobEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/JobEndpoint.java
@@ -388,7 +388,15 @@ public class JobEndpoint {
     } catch (IncidentServiceException e) {
       throw new JobEndpointException(String.format("Not able to get the incident %d: %s", id, e), e.getCause());
     }
+    Long rootJobId = null;
+    try {
+      Job job = serviceRegistry.getJob(incident.getJobId());
+      rootJobId = job.getRootJobId();
+    } catch (ServiceRegistryException e) {
+      logger.info("Could not find job \"{}\" in service registry", incident.getJobId());
+    }
     return obj(f("id", v(incident.getId(), Jsons.BLANK)), f("job_id", v(incident.getJobId(), Jsons.BLANK)),
+            f("root_job_id", v(rootJobId, Jsons.BLANK)),
             f("severity", v(incident.getSeverity(), Jsons.BLANK)),
             f("timestamp", v(toUTC(incident.getTimestamp().getTime()), Jsons.BLANK)),
             f("processing_host", v(incident.getProcessingHost(), Jsons.BLANK)), f("service_type", v(incident.getServiceType(), Jsons.BLANK)),


### PR DESCRIPTION
Adds the id of the root job to the incident information that is returned by the admin ui endpoint {eventId}/workflows/{workflowId}/errors/{errorId}.json. This should let the admin ui relate an incident to the workflow operation during which the incident occurred.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
