### PR TITLE
Trim plugin configuration data

### DIFF
--- a/modules/plugin-manager/src/main/java/org/opencastproject/plugin/impl/PluginManagerImpl.java
+++ b/modules/plugin-manager/src/main/java/org/opencastproject/plugin/impl/PluginManagerImpl.java
@@ -85,7 +85,7 @@ public class PluginManagerImpl implements PluginManager {
 
     // Load plugin configuration
     activePlugins = properties.entrySet().stream()
-            .filter(e -> BooleanUtils.toBoolean(Objects.toString(e.getValue(), "")))
+            .filter(e -> BooleanUtils.toBoolean(Objects.toString(e.getValue(), "").trim()))
             .map(Map.Entry::getKey)
             .collect(Collectors.toSet());
     logger.debug("Active plugin configuration: {}", activePlugins);


### PR DESCRIPTION
This PR trims the [plugin config file](https://github.com/opencast/opencast/blob/5a39e1d69031194daf75100d76a0d31da5faf3b5/etc/org.opencastproject.plugin.impl.PluginManagerImpl.cfg)'s values as it reads them, preventing things like trailing spaces from causing plugins to not load.

### How to test this patch

Turn plugins `on`, and `off `.  And `true `, and `false`.  And `cow`.

This should go into 17 since the plugin stuff affects all current OC versions.  There's an argument for this being in 16, but no adopter has complained so I didnt' put it there.

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [ ] ~[be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)~
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
