### PR TITLE
Update FFmpeg Cache

### DIFF
--- a/.github/workflows/store-ffmpeg-builds.yml
+++ b/.github/workflows/store-ffmpeg-builds.yml
@@ -6,15 +6,17 @@ on:
     - cron: '0 3 * * 6' # at 03:00 on Saturday
 
 jobs:
-  build:
+  cache-ffmpeg:
     strategy:
       matrix:
         arch:
           - linuxarm64
           - linux64
-    name: Get FFmpeg (${{ matrix.arch }})
+        release:
+          - latest
+          - autobuild
+    name: Get FFmpeg (${{ matrix.release }} ${{ matrix.arch }})
     runs-on: ubuntu-latest
-    if: github.repository == 'opencast/opencast'
     steps:
       - name: Install s3cmd
         run: |
@@ -30,7 +32,7 @@ jobs:
           https://api.github.com/repos/BtbN/FFmpeg-Builds/releases
           | jq -r '
             [
-              .[1].assets[]
+              .[] | select(.tag_name | contains("${{ matrix.release }}")).assets[]
               | select(.name | contains("${{ matrix.arch }}-gpl-"))
               | select(.name | contains("linux"))
               | select(.name | contains("shared") | not)

--- a/.github/workflows/store-ffmpeg-builds.yml
+++ b/.github/workflows/store-ffmpeg-builds.yml
@@ -32,6 +32,7 @@ jobs:
             [
               .[1].assets[]
               | select(.name | contains("${{ matrix.arch }}-gpl-"))
+              | select(.name | contains("linux"))
               | select(.name | contains("shared") | not)
             ]
             | sort_by(.name)

--- a/.github/workflows/store-ffmpeg-builds.yml
+++ b/.github/workflows/store-ffmpeg-builds.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       matrix:
         arch:
-          - amd64
-          - arm64
+          - linuxarm64
+          - linux64
     name: Get FFmpeg (${{ matrix.arch }})
     runs-on: ubuntu-latest
     if: github.repository == 'opencast/opencast'
@@ -20,21 +20,27 @@ jobs:
         run: |
           set -eu
           sudo apt update -q
-          sudo apt install -y -q s3cmd
+          sudo apt install -y -q jq s3cmd
+
+      - name: Get FFmpeg download URL
+        run: >
+          curl -fL
+          -H "Accept: application/vnd.github+json"
+          -H "X-GitHub-Api-Version: 2022-11-28"
+          https://api.github.com/repos/BtbN/FFmpeg-Builds/releases
+          | jq -r '
+            [
+              .[1].assets[]
+              | select(.name | contains("${{ matrix.arch }}-gpl-"))
+              | select(.name | contains("shared") | not)
+            ]
+            | sort_by(.name)
+            | reverse
+            | .[0].browser_download_url' | tee download.url
 
       - name: Download FFmpeg
         run: |
-          wget https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-${{ matrix.arch }}-static.tar.xz
-
-      - name: Unpack FFmpeg
-        run: |
-          tar xvf ffmpeg-release-${{ matrix.arch }}-static.tar.xz
-
-      - name: Repack FFmpeg
-        run: |
-          set -eu
-          NAME="$(ls -d ffmpeg-*-static)"
-          tar cfJ "${NAME}.tar.xz" "${NAME}"
+          wget "$(cat download.url)"
 
       - name: Configure s3cmd
         uses: lkiesow/configure-s3cmd@v1
@@ -44,5 +50,7 @@ jobs:
           secret_key: ${{ secrets.S3_SECRET_KEY }}
 
       - name: Upload tarball
-        run: |
-          s3cmd put -P *.tar.xz s3://opencast-ffmpeg-static/
+        run: >
+          s3cmd ls "s3://opencast-ffmpeg-static/$(ls ffmpeg-*.tar.xz)"
+          | grep -q ffmpeg
+          || s3cmd put -P ffmpeg-*.tar.xz s3://opencast-ffmpeg-static/


### PR DESCRIPTION
This patch updates the regular download of static FFmpeg binaries so that we have them in our own storage and can use them for packages and containers.

> The first run already happened:
> ```
> ❯ s3cmd ls s3://opencast-ffmpeg-static/ | grep ffmpeg-n
> 2025-07-08 23:35    115555760  s3://opencast-ffmpeg-static/ffmpeg-n7.1.1-54-g6400860b9d-linux64-gpl-7.1.tar.xz
> 2025-07-09 00:10     97982200  s3://opencast-ffmpeg-static/ffmpeg-n7.1.1-54-g6400860b9d-linuxarm64-gpl-7.1.tar.xz
> ```

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
