### PR TITLE
Mux WOH

### DIFF
--- a/docs/guides/admin/docs/releasenotes/mux-woh.txt
+++ b/docs/guides/admin/docs/releasenotes/mux-woh.txt
@@ -1,0 +1,1 @@
+New mux WOH, see [documentation](../workflowoperationhandlers/mux-woh.md).

--- a/docs/guides/admin/docs/workflowoperationhandlers/index.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/index.md
@@ -71,6 +71,7 @@ The following table contains the workflow operations that are available in an ou
 | microsoft-azure-start-transcription  | Start Microsoft Azure Transcription                                                       | [Documentation](microsoft-azure-start-transcription-woh.md)  |
 | move-storage                         | Move files between asset manager storage systems                                          | [Documentation](move-storage-woh.md)                         |
 | multiencode                          | Encode to multiple profiles in one operation                                              | [Documentation](multiencode-woh.md)                          |
+| mux                                  | Mux multiple media tracks into one                                                        | [Documentation](mux-woh.md)                                  |
 | partial-import                       | Import partial tracks and process according to a SMIL document                            | [Documentation](partial-import-woh.md)                       |
 | post-mediapackage                    | Send mediapackage to remote service                                                       | [Documentation](postmediapackage-woh.md)                     |
 | prepare-av                           | Preparing audio and video work versions                                                   | [Documentation](prepareav-woh.md)                            |

--- a/docs/guides/admin/docs/workflowoperationhandlers/mux-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/mux-woh.md
@@ -1,0 +1,101 @@
+Mux Workflow Operation
+=======================================
+
+ID: `mux`
+
+
+Description
+-----------
+
+The MuxWorkflowOprationHandler is used to combine multiple tracks into one. Some use-cases may be
+
+- add additional audio streams
+- integrate subtitle tracks
+- apply organisational theme
+- etc.
+
+The encoding profile defines what should happen with each stream. Streams can be named to pick them up in the encoding profile specifically.
+
+
+Parameter Table
+---------------
+
+| configuration keys      | example                           | description                                                                                                          |
+|-------------------------|-----------------------------------|----------------------------------------------------------------------------------------------------------------------|
+| source-flavors          | presenter/work, presentation/work | Which media should be used as input. In the encoding profile the inputs are named `video`¹                           |
+| source-tags             | engage-player                     | Comma-separated list of tags of media to encode                                                                      |
+| source-flavors-\<name\> | captions/work                     | Flavor of input tracks with specific `name`¹. This name can be used in the encoding profile to pick the right stream |
+| source-tags-\<name\>    | lang:en, lang:de                  | Comma-separated list of tags of named media to encode.                                                               |
+| target-flavor           | download/delivery                 | Flavor of the new media                                                                                              |
+| target-tags             | download                          | Comma-separated list of tags to be assigned to the new media                                                         |
+| encoding-profile        | mux.http                          | Encoding profile to use                                                                                              |
+¹ Several tracks may potentially match, so the name will be suffixed with `.<index>`, where index begins with 1.
+
+In some cases, encoding profiles require a specific order of input streams. One way to achieve this is by naming the inputs. For example, the first stream must be video, and all subsequent streams must be subtitles. To ensure this, the subtitle inputs are named differently. Multiple values with the same name are numbered consecutively and have the suffix `.<index>` (begins with 1).
+
+Working with dynamic inputs may require to adjust ffmpeg command based on the inputs count. You will be able to do this with ffmpeg command extensions that will be automatically enabled. The extensions pattern are
+
+| extension name                | example              | description                                                        |
+|-------------------------------|----------------------|--------------------------------------------------------------------|
+| if-input-count-eq-\<number\>  | if-input-count-eq-3  | On exact \<number\> input tracks (`eq` means equals)               |
+| if-input-count-geq-\<number\> | if-input-count-geq-3 | On \<number\> or more input tracks (`geq` means greater or equals) |
+
+See the example below for instructions on how to use the ffmpeg command extensions.
+
+For tracks, having `lang:<locale>` tag set, special encoding parameter variable `#{in.<name>.language}` will be set with the locale value as ISO 639 (3 characters code).
+
+### Operation Example
+The captions should be included as separate streams for each language for the `download/video` track. Captions are available in three languages.
+The workflow operation may look like
+
+```xml
+<operation
+    id="mux"
+    description="Mux captions with video">
+  <configurations>
+    <configuration key="source-flavor">download/video</configuration>
+    <!-- Captions language information are set as tags on the tracks as documented here: -->
+    <!-- https://docs.opencast.org/r/15.x/admin/#configuration/subtitles/#tags -->
+    <configuration key="source-flavors-captions">captions/delivery</configuration>
+    <configuration key="target-flavor">download/delivery</configuration>
+    <configuration key="target-tags">download</configuration>
+    <configuration key="encoding-profile">mp4-mux-captions.http</configuration>
+  </configurations>
+</operation>
+```
+
+Since there are four input tracks — the video itself and three caption tracks — the encoding profile option `if-input-count-eq-4` will be enabled. The video track (here, we assume it's only one) will be named `video` because it's the default name for unnamed inputs. The caption tracks are named `captions` and numbered beginning with 1. The encoding profile input variable for the first caption track is `#{in.captions.1.path}`, the second is `#{in.captions.2.path}`, and so on. The language values are set as variable `#{in.<name>.language}`. In our case `#{in.captions.1.language}`, `#{in.captions.2.language}`, and so on. 
+
+```properties
+profile.mp4-mux-captions.http.name = Mux multiple captions (up to three) to the media track
+profile.mp4-mux-captions.http.input = visual
+profile.mp4-mux-captions.http.output = visual
+profile.mp4-mux-captions.http.jobload = 1
+profile.mp4-mux-captions.http.suffix = .mp4
+profile.mp4-mux-captions.http.ffmpeg.command = \
+  -i #{in.video.1.path} \
+  #{if-input-count-eq-2} \
+  #{if-input-count-eq-3} \
+  #{if-input-count-eq-4} \
+  #{out.dir}/#{out.name}#{out.suffix}
+profile.mp4-mux-captions.http.ffmpeg.command.if-input-count-eq-2 = \
+  -i #{in.captions.1.path} \
+  -c:v copy -c:a copy -c:s mov_text \
+  -map 0:v -map 0:a -map 1:s -metadata:s:s:0 language=#{in.captions.1.language}
+profile.mp4-mux-captions.http.ffmpeg.command.if-input-count-eq-3 = \
+  -i #{in.captions.1.path} \
+  -i #{in.captions.2.path} \
+  -c:v copy -c:a copy -c:s mov_text \
+  -map 0:v -map 0:a \
+  -map 1:s -metadata:s:s:0 language=#{in.captions.1.language} \
+  -map 2:s -metadata:s:s:1 language=#{in.captions.2.language}
+profile.mp4-mux-captions.http.ffmpeg.command.if-input-count-eq-4 = \
+  -i #{in.captions.1.path} \
+  -i #{in.captions.2.path} \
+  -i #{in.captions.3.path} \
+  -c:v copy -c:a copy -c:s mov_text \
+  -map 0:v -map 0:a \
+  -map 1:s -metadata:s:s:0 language=#{in.captions.1.language} \
+  -map 2:s -metadata:s:s:1 language=#{in.captions.2.language} \
+  -map 3:s -metadata:s:s:2 language=#{in.captions.3.language}
+```

--- a/docs/guides/admin/mkdocs.yml
+++ b/docs/guides/admin/mkdocs.yml
@@ -231,6 +231,7 @@ nav:
       - Microsoft Azure Start Transcription: "workflowoperationhandlers/microsoft-azure-start-transcription-woh.md"
       - Move Storage: "workflowoperationhandlers/move-storage-woh.md"
       - Multiencode: "workflowoperationhandlers/multiencode-woh.md"
+      - Mux: "workflowoperationhandlers/mux-woh.md"
       - Partial Import: "workflowoperationhandlers/partial-import-woh.md"
       - Post Media Package: "workflowoperationhandlers/postmediapackage-woh.md"
       - Prepare A/V: "workflowoperationhandlers/prepareav-woh.md"

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
@@ -708,7 +708,7 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
    */
   @Override
   public Job mux(Track videoTrack, Track audioTrack, String profileId) throws EncoderException, MediaPackageException {
-    return mux(Map.of("video", videoTrack, "audio", audioTrack), profileId);
+    return mux(Collections.map(Tuple.tuple("video", videoTrack), Tuple.tuple("audio", audioTrack)), profileId);
   }
 
   /**

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
@@ -82,6 +82,7 @@ import com.google.gson.Gson;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.LocaleUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.osgi.service.cm.ConfigurationException;
@@ -363,8 +364,6 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
    *          tracks to use for processing
    * @param profileId
    *          the encoding profile
-   * @param properties
-   *          encoding properties
    * @return the encoded track or none if the operation does not return a track. This may happen for example when doing
    *         two pass encodings where the first pass only creates metadata for the second one
    * @throws EncoderException
@@ -372,34 +371,79 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
    */
   private Option<Track> encode(final Job job, Map<String, Track> tracks, String profileId)
           throws EncoderException, MediaPackageException {
+    return encode(job, tracks, profileId, null);
+  }
+
+  /**
+   * Mux tracks into one movie container.
+   *
+   * @param tracks
+   *          tracks to use for processing
+   * @param profileId
+   *          the encoding profile
+   * @param properties
+   *          encoding properties
+   * @return the encoded track or none if the operation does not return a track. This may happen for example when doing
+   *         two pass encodings where the first pass only creates metadata for the second one
+   * @throws EncoderException
+   *           if encoding fails
+   */
+  private Option<Track> encode(final Job job, Map<String, Track> tracks, String profileId,
+      Map<String, String> properties) throws EncoderException, MediaPackageException {
 
     final String targetTrackId = IdImpl.fromUUID().toString();
 
     Map<String, File> files = new HashMap<>();
     // Get the tracks and make sure they exist
-    for (Entry<String, Track> track: tracks.entrySet()) {
-      files.put(track.getKey(), loadTrackIntoWorkspace(job, track.getKey(), track.getValue(), false));
+    for (Entry<String, Track> trackEntry: tracks.entrySet()) {
+      files.put(trackEntry.getKey(), loadTrackIntoWorkspace(job, trackEntry.getKey(),
+          trackEntry.getValue(), false));
     }
 
     // Get the encoding profile
     final EncodingProfile profile = getProfile(job, profileId);
-
-    List <String> trackMsg = new LinkedList<>();
-    for (Entry<String, Track> track: tracks.entrySet()) {
-      trackMsg.add(format("%s: %s", track.getKey(), track.getValue().getIdentifier()));
+    Map<String, String> props = new HashMap<>();
+    if (properties != null) {
+      props.putAll(properties);
     }
-    logger.info("Encoding {} into {} using profile {}", StringUtils.join(trackMsg, ", "), targetTrackId, profileId);
+
+    // Handle input count substitution
+    String substitutionKey = String.format("if-input-count-eq-%d", tracks.size());
+    String substitution = profile.getExtension(StringUtils.join(CMD_SUFFIX, '.', substitutionKey));
+    if (StringUtils.isNotBlank(substitution)) {
+      props.put(substitutionKey, substitution);
+    }
+    for (int i = 1; i <= tracks.size(); i++) {
+      substitutionKey = String.format("if-input-count-geq-%d", i);
+      substitution = profile.getExtension(StringUtils.join(CMD_SUFFIX, '.', substitutionKey));
+      if (StringUtils.isNotBlank(substitution)) {
+        props.put(substitutionKey, substitution);
+      }
+    }
+    // Handle lang:<LOCALE> tags
+    tracks.entrySet().stream()
+        .map(e -> new Tuple<>(e.getKey(), Arrays.stream(e.getValue().getTags())
+            .filter(t -> StringUtils.startsWith(t, "lang:"))
+            .map(t -> StringUtils.substring(t, 5))
+            .filter(StringUtils::isNotBlank)
+            .findFirst()))
+        .filter(e -> e.getB().isPresent())
+        .forEach(e -> props.put(String.format("in.%s.language", e.getA()),
+            LocaleUtils.toLocale(e.getB().get()).getISO3Language()));
+    logger.info("Encoding {} into {} using profile {}",
+        tracks.entrySet().stream()
+          .map(entry -> String.format("%s: %s", entry.getKey(), entry.getValue().getIdentifier()))
+          .collect(Collectors.joining(", ")),
+        targetTrackId, profileId);
 
     // Do the work
     final EncoderEngine encoder = getEncoderEngine();
     List<File> output;
     try {
-      output = encoder.process(files, profile, null);
+      output = encoder.process(files, profile, props);
     } catch (EncoderException e) {
       Map<String, String> params = new HashMap<>();
-      for (Entry<String, Track> track: tracks.entrySet()) {
-        params.put(track.getKey(), track.getValue().getIdentifier());
-      }
+      tracks.forEach((key, value) -> params.put(key, value.getIdentifier()));
       params.put("profile", profile.getIdentifier());
       params.put("properties", "EMPTY");
       incident().recordFailure(job, ENCODING_FAILED, e, params, detailsFor(e, encoder));
@@ -409,7 +453,7 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
     }
 
     // We expect zero or one file as output
-    if (output.size() == 0) {
+    if (output.isEmpty()) {
       return none();
     } else if (output.size() != 1) {
       // Ensure we do not leave behind old files in the workspace
@@ -664,25 +708,40 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
    */
   @Override
   public Job mux(Track videoTrack, Track audioTrack, String profileId) throws EncoderException, MediaPackageException {
+    return mux(Map.of("video", videoTrack, "audio", audioTrack), profileId);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @see org.opencastproject.composer.api.ComposerService#mux(Map, String)
+   */
+  @Override
+  public Job mux(Map<String, Track> sourceTracks, String profileId) throws EncoderException, MediaPackageException {
     try {
+      if (sourceTracks == null || sourceTracks.size() < 2) {
+        throw new EncoderException("At least two source tracks must be given.");
+      }
       final EncodingProfile profile = profileScanner.getProfile(profileId);
-      return serviceRegistry.createJob(JOB_TYPE, Operation.Mux.toString(),
-              Arrays.asList(profileId, MediaPackageElementParser.getAsXml(videoTrack),
-                      MediaPackageElementParser.getAsXml(audioTrack)), profile.getJobLoad());
+      List<String> jobArgs = new ArrayList<>();
+      jobArgs.add(profileId);
+      for (Entry<String, Track> entry : sourceTracks.entrySet()) {
+        jobArgs.add(entry.getKey());
+        jobArgs.add(MediaPackageElementParser.getAsXml(entry.getValue()));
+      }
+      return serviceRegistry.createJob(JOB_TYPE, Operation.Mux.toString(), jobArgs, profile.getJobLoad());
     } catch (ServiceRegistryException e) {
       throw new EncoderException("Unable to create a job", e);
     }
   }
 
   /**
-   * Muxes the audio and video track into one movie container.
+   * Muxes tracks into one movie container.
    *
    * @param job
    *          the associated job
-   * @param videoTrack
-   *          the video track
-   * @param audioTrack
-   *          the audio track
+   * @param tracks
+   *          the tracks to mux
    * @param profileId
    *          the profile identifier
    * @return the muxed track
@@ -691,9 +750,9 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
    * @throws MediaPackageException
    *           if serializing the mediapackage elements fails
    */
-  private Option<Track> mux(Job job, Track videoTrack, Track audioTrack, String profileId) throws EncoderException,
-          MediaPackageException {
-    return encode(job, Collections.map(tuple("audio", audioTrack), tuple("video", videoTrack)), profileId);
+  private Option<Track> mux(Job job, Map<String, Track> tracks, String profileId) throws EncoderException,
+      MediaPackageException {
+    return encode(job, tracks, profileId);
   }
 
   /**
@@ -1500,10 +1559,14 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
           serialized = MediaPackageElementParser.getArrayAsXml(convertedImages);
           break;
         case Mux:
-          firstTrack = (Track) MediaPackageElementParser.getFromXml(arguments.get(1));
-          secondTrack = (Track) MediaPackageElementParser.getFromXml(arguments.get(2));
-          serialized = mux(job, firstTrack, secondTrack, encodingProfile).map(
-                  MediaPackageElementParser.getAsXml()).getOrElse("");
+          Map<String, Track> sourceTracks = new HashMap<>();
+          for (int i = 1; i < arguments.size(); i += 2) {
+            String key = arguments.get(i);
+            firstTrack = (Track) MediaPackageElementParser.getFromXml(arguments.get(i + 1));
+            sourceTracks.put(key, firstTrack);
+          }
+          serialized = mux(job, sourceTracks, encodingProfile).map(MediaPackageElementParser.getAsXml())
+              .getOrElse("");
           break;
         case Trim:
           firstTrack = (Track) MediaPackageElementParser.getFromXml(arguments.get(1));

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/EncoderEngine.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/EncoderEngine.java
@@ -194,7 +194,8 @@ public class EncoderEngine implements AutoCloseable {
       params.put(pre + ".filename", FilenameUtils.getName(input));
       params.put(pre + ".mimetype", MimetypesFileTypeMap.getDefaultFileTypeMap().getContentType(input));
     }
-    final File parentFile = source.getOrDefault("video", source.get("audio"));
+    final File parentFile = source.getOrDefault("video", source.getOrDefault("audio",
+        source.values().stream().findAny().get()));
 
     final String outDir = parentFile.getAbsoluteFile().getParent();
     final String outFileName = FilenameUtils.getBaseName(parentFile.getName())
@@ -366,19 +367,12 @@ public class EncoderEngine implements AutoCloseable {
       }
     }
 
-    String[] arguments;
-    try {
-      arguments = CommandLineUtils.translateCommandline(commandline);
-    } catch (Exception e) {
-      throw new EncoderException("Could not parse encoding profile command line", e);
-    }
-
-    for (String arg: arguments) {
-      String result = processParameters(arg, argumentReplacements);
-      if (StringUtils.isNotBlank(result)) {
-        command.add(result);
+    String processedCommandLine = processParameters(commandline, argumentReplacements);
+      try {
+        command.addAll(Arrays.asList(CommandLineUtils.translateCommandline(processedCommandLine)));
+      } catch (Exception e) {
+        throw new EncoderException("Could not process encoding profile command line", e);
       }
-    }
     return command;
   }
 
@@ -407,8 +401,13 @@ public class EncoderEngine implements AutoCloseable {
    * @return the commandline
    */
   private String processParameters(String cmd, final Map<String, String> args) {
-    for (Map.Entry<String, String> e: args.entrySet()) {
-      cmd = cmd.replace("#{" + e.getKey() + "}", e.getValue());
+    // multi level templates handling
+    String cmdBefore = null;
+    while (!cmd.equals(cmdBefore)) {
+      cmdBefore = cmd;
+      for (Map.Entry<String, String> e : args.entrySet()) {
+        cmd = cmd.replace("#{" + e.getKey() + "}", e.getValue());
+      }
     }
 
     // Also replace spaces

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/EncoderEngine.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/EncoderEngine.java
@@ -195,7 +195,7 @@ public class EncoderEngine implements AutoCloseable {
       params.put(pre + ".mimetype", MimetypesFileTypeMap.getDefaultFileTypeMap().getContentType(input));
     }
     final File parentFile = source.getOrDefault("video", source.getOrDefault("audio",
-        source.values().stream().findAny().get()));
+        source.values().stream().findFirst().get()));
 
     final String outDir = parentFile.getAbsoluteFile().getParent();
     final String outFileName = FilenameUtils.getBaseName(parentFile.getName())

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/endpoint/ComposerRestService.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/endpoint/ComposerRestService.java
@@ -375,8 +375,8 @@ public class ComposerRestService extends AbstractJobProducerEndpoint {
       Job job;
       Map<String, Track> sourceTracks = new HashMap<>();
       if (StringUtils.isNotBlank(sourceTracksXml)) {
-        for (String sourceTrackEntry : StringUtils.split(sourceTracksXml, "#|#")) {
-          String[] sourceTrackEntryTuple = StringUtils.split(sourceTrackEntry, "#=#", 2);
+        for (String sourceTrackEntry : StringUtils.splitByWholeSeparator(sourceTracksXml, "#|#")) {
+          String[] sourceTrackEntryTuple = StringUtils.splitByWholeSeparator(sourceTrackEntry, "#=#", 2);
           if (sourceTrackEntryTuple.length != 2) {
             return Response.status(Response.Status.BAD_REQUEST).entity("sourceTracks value invalid").build();
           }

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/endpoint/ComposerRestService.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/endpoint/ComposerRestService.java
@@ -65,8 +65,10 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.DefaultValue;
@@ -349,34 +351,53 @@ public class ComposerRestService extends AbstractJobProducerEndpoint {
   @Path("mux")
   @Produces(MediaType.TEXT_XML)
   @RestQuery(name = "mux", description = "Starts an encoding process, which will mux the two tracks using the given encoding profile", restParameters = {
-          @RestParameter(description = "The track containing the audio stream", isRequired = true, name = "sourceAudioTrack", type = Type.TEXT, defaultValue = AUDIO_TRACK_DEFAULT),
-          @RestParameter(description = "The track containing the video stream", isRequired = true, name = "sourceVideoTrack", type = Type.TEXT, defaultValue = VIDEO_TRACK_DEFAULT),
+          @RestParameter(description = "The track containing the audio stream", isRequired = false, name = "sourceAudioTrack", type = Type.TEXT, defaultValue = AUDIO_TRACK_DEFAULT),
+          @RestParameter(description = "The track containing the video stream", isRequired = false, name = "sourceVideoTrack", type = Type.TEXT, defaultValue = VIDEO_TRACK_DEFAULT),
+          @RestParameter(description = "The track containing the video stream", isRequired = false, name = "sourceTracks", type = Type.TEXT),
           @RestParameter(description = "The encoding profile to use", isRequired = true, name = "profileId", type = Type.STRING, defaultValue = "mp4-medium.http") }, responses = {
           @RestResponse(description = "Results in an xml document containing the job for the encoding task", responseCode = HttpServletResponse.SC_OK),
           @RestResponse(description = "If required parameters aren't set or if the source tracks aren't from the type Track", responseCode = HttpServletResponse.SC_BAD_REQUEST) }, returnDescription = "")
   public Response mux(@FormParam("audioSourceTrack") String audioSourceTrackXml,
-          @FormParam("videoSourceTrack") String videoSourceTrackXml, @FormParam("profileId") String profileId)
+          @FormParam("videoSourceTrack") String videoSourceTrackXml,
+          @FormParam("sourceTracks") String sourceTracksXml, @FormParam("profileId") String profileId)
           throws Exception {
     // Ensure that the POST parameters are present
-    if (StringUtils.isBlank(audioSourceTrackXml) || StringUtils.isBlank(videoSourceTrackXml)
-            || StringUtils.isBlank(profileId)) {
+    if (StringUtils.isBlank(profileId)) {
+      return Response.status(Response.Status.BAD_REQUEST).entity("profileId must not be null").build();
+    }
+    if ((StringUtils.isBlank(audioSourceTrackXml) || StringUtils.isBlank(videoSourceTrackXml))
+        && StringUtils.isBlank(sourceTracksXml)) {
       return Response.status(Response.Status.BAD_REQUEST)
-              .entity("audioSourceTrack, videoSourceTrack, and profileId must not be null").build();
+          .entity("audioSourceTrack, videoSourceTrack or sourceTracks must not be null").build();
     }
 
-    // Deserialize the audio track
-    MediaPackageElement audioSourceTrack = MediaPackageElementParser.getFromXml(audioSourceTrackXml);
-    if (!Track.TYPE.equals(audioSourceTrack.getElementType()))
-      return Response.status(Response.Status.BAD_REQUEST).entity("audioSourceTrack must be of type track").build();
-
-    // Deserialize the video track
-    MediaPackageElement videoSourceTrack = MediaPackageElementParser.getFromXml(videoSourceTrackXml);
-    if (!Track.TYPE.equals(videoSourceTrack.getElementType()))
-      return Response.status(Response.Status.BAD_REQUEST).entity("videoSourceTrack must be of type track").build();
-
     try {
-      // Asynchronously encode the specified tracks
-      Job job = composerService.mux((Track) videoSourceTrack, (Track) audioSourceTrack, profileId);
+      Job job;
+      Map<String, Track> sourceTracks = new HashMap<>();
+      if (StringUtils.isNotBlank(sourceTracksXml)) {
+        for (String sourceTrackEntry : StringUtils.split(sourceTracksXml, "#|#")) {
+          String[] sourceTrackEntryTuple = sourceTrackEntry.split("#=#", 2);
+          if (sourceTrackEntryTuple.length != 2) {
+            return Response.status(Response.Status.BAD_REQUEST).entity("sourceTracks value invalid").build();
+          }
+          sourceTracks.put(sourceTrackEntryTuple[0],
+              (Track) MediaPackageElementParser.getFromXml(sourceTrackEntryTuple[1]));
+        }
+        // Asynchronously encode the specified tracks
+        job = composerService.mux(sourceTracks, profileId);
+      } else {
+        // Deserialize the audio track
+        MediaPackageElement audioSourceTrack = MediaPackageElementParser.getFromXml(audioSourceTrackXml);
+        if (!Track.TYPE.equals(audioSourceTrack.getElementType()))
+          return Response.status(Response.Status.BAD_REQUEST).entity("audioSourceTrack must be of type track").build();
+
+        // Deserialize the video track
+        MediaPackageElement videoSourceTrack = MediaPackageElementParser.getFromXml(videoSourceTrackXml);
+        if (!Track.TYPE.equals(videoSourceTrack.getElementType()))
+          return Response.status(Response.Status.BAD_REQUEST).entity("videoSourceTrack must be of type track").build();
+
+        job = composerService.mux((Track) videoSourceTrack, (Track) audioSourceTrack, profileId);
+      }
       return Response.ok().entity(new JaxbJob(job)).build();
     } catch (EncoderException e) {
       logger.warn("Unable to mux tracks: " + e.getMessage());

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/endpoint/ComposerRestService.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/endpoint/ComposerRestService.java
@@ -376,7 +376,7 @@ public class ComposerRestService extends AbstractJobProducerEndpoint {
       Map<String, Track> sourceTracks = new HashMap<>();
       if (StringUtils.isNotBlank(sourceTracksXml)) {
         for (String sourceTrackEntry : StringUtils.split(sourceTracksXml, "#|#")) {
-          String[] sourceTrackEntryTuple = sourceTrackEntry.split("#=#", 2);
+          String[] sourceTrackEntryTuple = StringUtils.split(sourceTrackEntry, "#=#", 2);
           if (sourceTrackEntryTuple.length != 2) {
             return Response.status(Response.Status.BAD_REQUEST).entity("sourceTracks value invalid").build();
           }

--- a/modules/composer-ffmpeg/src/test/java/org/opencastproject/composer/impl/endpoint/ComposerRestServiceTest.java
+++ b/modules/composer-ffmpeg/src/test/java/org/opencastproject/composer/impl/endpoint/ComposerRestServiceTest.java
@@ -126,13 +126,16 @@ public class ComposerRestServiceTest {
     response = restService.encode(null, "profile");
     Assert.assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
 
-    response = restService.mux(generateAudioTrack(), null, "profile");
+    response = restService.mux(generateAudioTrack(), null, null, "profile");
     Assert.assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
 
-    response = restService.mux(null, generateVideoTrack(), "profile");
+    response = restService.mux(null, generateVideoTrack(), null, "profile");
     Assert.assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
 
-    response = restService.mux(generateAudioTrack(), generateVideoTrack(), null);
+    response = restService.mux(generateAudioTrack(), generateVideoTrack(), null, null);
+    Assert.assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+
+    response = restService.mux(null, null, null, "profile");
     Assert.assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
   }
 
@@ -145,7 +148,7 @@ public class ComposerRestServiceTest {
 
   @Test
   public void testMux() throws Exception {
-    Response response = restService.mux(generateAudioTrack(), generateVideoTrack(), profileId);
+    Response response = restService.mux(generateAudioTrack(), generateVideoTrack(),null, profileId);
     Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
     Assert.assertEquals(new JaxbJob(job), response.getEntity());
   }
@@ -205,5 +208,4 @@ public class ComposerRestServiceTest {
             + "    <bitdepth>0</bitdepth>\n" + "    <bitrate>128004.0</bitrate>\n"
             + "    <samplingrate>44100</samplingrate>\n" + "  </audio>\n" + "</track>";
   }
-
 }

--- a/modules/composer-ffmpeg/src/test/resources/encodingprofiles.properties
+++ b/modules/composer-ffmpeg/src/test/resources/encodingprofiles.properties
@@ -194,7 +194,7 @@ profile.mux-av.copy.name = mux audio and video
 profile.mux-av.copy.input = stream
 profile.mux-av.copy.output = visual
 profile.mux-av.copy.suffix = -work.#{in.video.suffix}
-profile.mux-av.copy.ffmpeg.command = -i #{in.video.path} -i #{in.audio.path} -shortest -c copy #{out.dir}/#{out.name}#{out.suffix}
+profile.mux-av.copy.ffmpeg.command = -i #{in.video.path} -i #{in.audio.path} -strict -1 -shortest -c copy #{out.dir}/#{out.name}#{out.suffix}
 
 #Multi encode - One profile with multiple outputs
 #Useful for demuxing epiphan muxed streams

--- a/modules/composer-service-api/src/main/java/org/opencastproject/composer/api/ComposerService.java
+++ b/modules/composer-service-api/src/main/java/org/opencastproject/composer/api/ComposerService.java
@@ -81,6 +81,21 @@ public interface ComposerService {
           MediaPackageException;
 
   /**
+   * Mux multiple tracks into a new Track.
+   *
+   * @param sourceTracks
+   *          The source tracks
+   * @param profileId
+   *          The profile to use for encoding
+   * @return The receipt for this encoding job
+   * @throws EncoderException
+   *           if encoding fails
+   * @throws MediaPackageException
+   *           if the mediapackage is invalid
+   */
+  Job mux(Map<String, Track> sourceTracks, String profileId) throws EncoderException, MediaPackageException;
+
+  /**
    * Compose two videos into one with an optional watermark.
    *
    * @param outputDimension

--- a/modules/composer-service-remote/src/main/java/org/opencastproject/composer/remote/ComposerServiceRemoteImpl.java
+++ b/modules/composer-service-remote/src/main/java/org/opencastproject/composer/remote/ComposerServiceRemoteImpl.java
@@ -246,6 +246,46 @@ public class ComposerServiceRemoteImpl extends RemoteBase implements ComposerSer
   /**
    * {@inheritDoc}
    *
+   * @see org.opencastproject.composer.api.ComposerService#mux(java.util.Map, java.lang.String)
+   */
+  @Override
+  public Job mux(Map<String, Track> sourceTracks, String profileId) throws EncoderException {
+    HttpPost post = new HttpPost("/mux");
+    try {
+      List<BasicNameValuePair> params = new ArrayList<BasicNameValuePair>();
+      List<String> sourceTracksEntries = new ArrayList<>();
+      for (Entry<String, Track> sourceTrack : sourceTracks.entrySet()) {
+        String sourceTrackXml = MediaPackageElementParser.getAsXml(sourceTrack.getValue());
+        sourceTracksEntries.add(StringUtils.join(sourceTrack.getKey(), sourceTrackXml, "#=#"));
+      }
+      params.add(new BasicNameValuePair("sourceTracks", StringUtils.join(sourceTracksEntries, "#|#")));
+      params.add(new BasicNameValuePair("profileId", profileId));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
+    } catch (Exception e) {
+      throw new EncoderException("Unable to assemble a remote composer request", e);
+    }
+    HttpResponse response = null;
+    try {
+      response = getResponse(post);
+      if (response != null) {
+        String content = EntityUtils.toString(response.getEntity());
+        Job r = JobParser.parseJob(content);
+        logger.info("Muxing job {} started on a remote composer", r.getId());
+        return r;
+      }
+    } catch (IOException e) {
+      throw new EncoderException(e);
+    } finally {
+      closeConnection(response);
+    }
+    throw new EncoderException("Unable to mux tracks " + sourceTracks.entrySet().stream()
+        .map(entry -> String.format("%s: %s", entry.getKey(), entry.getValue().getIdentifier())).collect(
+        Collectors.joining(", ")) + " using a remote composer");
+  }
+
+  /**
+   * {@inheritDoc}
+   *
    * @see org.opencastproject.composer.api.ComposerService#getProfile(java.lang.String)
    */
   @Override

--- a/modules/composer-service-remote/src/main/java/org/opencastproject/composer/remote/ComposerServiceRemoteImpl.java
+++ b/modules/composer-service-remote/src/main/java/org/opencastproject/composer/remote/ComposerServiceRemoteImpl.java
@@ -256,7 +256,7 @@ public class ComposerServiceRemoteImpl extends RemoteBase implements ComposerSer
       List<String> sourceTracksEntries = new ArrayList<>();
       for (Entry<String, Track> sourceTrack : sourceTracks.entrySet()) {
         String sourceTrackXml = MediaPackageElementParser.getAsXml(sourceTrack.getValue());
-        sourceTracksEntries.add(StringUtils.join(sourceTrack.getKey(), sourceTrackXml, "#=#"));
+        sourceTracksEntries.add(StringUtils.join(sourceTrack.getKey(), "#=#", sourceTrackXml));
       }
       params.add(new BasicNameValuePair("sourceTracks", StringUtils.join(sourceTracksEntries, "#|#")));
       params.add(new BasicNameValuePair("profileId", profileId));

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/MuxWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/MuxWorkflowOperationHandler.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.workflow.handler.composer;
+
+import org.opencastproject.composer.api.ComposerService;
+import org.opencastproject.composer.api.EncoderException;
+import org.opencastproject.composer.api.EncodingProfile;
+import org.opencastproject.job.api.Job;
+import org.opencastproject.job.api.JobContext;
+import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.mediapackage.MediaPackageElementFlavor;
+import org.opencastproject.mediapackage.MediaPackageElementParser;
+import org.opencastproject.mediapackage.MediaPackageException;
+import org.opencastproject.mediapackage.Track;
+import org.opencastproject.mediapackage.selector.AbstractMediaPackageElementSelector;
+import org.opencastproject.mediapackage.selector.TrackSelector;
+import org.opencastproject.serviceregistry.api.ServiceRegistry;
+import org.opencastproject.util.NotFoundException;
+import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
+import org.opencastproject.workflow.api.ConfiguredTagsAndFlavors;
+import org.opencastproject.workflow.api.WorkflowInstance;
+import org.opencastproject.workflow.api.WorkflowOperationException;
+import org.opencastproject.workflow.api.WorkflowOperationHandler;
+import org.opencastproject.workflow.api.WorkflowOperationInstance;
+import org.opencastproject.workflow.api.WorkflowOperationResult;
+import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
+import org.opencastproject.workspace.api.Workspace;
+
+import org.apache.commons.lang3.StringUtils;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * The workflow definition for handling "mux" operations
+ */
+@Component(
+    immediate = true,
+    service = WorkflowOperationHandler.class,
+    property = {
+        "service.description=Mux Workflow Operation Handler",
+        "workflow.operation=mux"
+    }
+)
+public class MuxWorkflowOperationHandler extends AbstractWorkflowOperationHandler {
+
+  /** The logging facility */
+  private static final Logger logger = LoggerFactory.getLogger(MuxWorkflowOperationHandler.class);
+
+  /** The composer service */
+  private ComposerService composerService = null;
+
+  /** The local workspace */
+  private Workspace workspace = null;
+
+  /**
+   * Callback for the OSGi declarative services configuration.
+   *
+   * @param composerService
+   *          the local composer service
+   */
+  @Reference
+  protected void setComposerService(ComposerService composerService) {
+    this.composerService = composerService;
+  }
+
+  /**
+   * Callback for declarative services configuration that will introduce us to the local workspace service.
+   * Implementation assumes that the reference is configured as being static.
+   *
+   * @param workspace
+   *          an instance of the workspace
+   */
+  @Reference
+  public void setWorkspace(Workspace workspace) {
+    this.workspace = workspace;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @see WorkflowOperationHandler#start(WorkflowInstance,
+   *      JobContext)
+   */
+  public WorkflowOperationResult start(final WorkflowInstance workflowInstance, JobContext context)
+          throws WorkflowOperationException {
+    logger.debug("Running mux workflow operation on workflow {}", workflowInstance.getId());
+
+    try {
+      return mux(workflowInstance);
+    } catch (Exception e) {
+      throw new WorkflowOperationException(e);
+    }
+  }
+
+  /**
+   * Mux tracks from MediaPackage using profiles stored in properties and updates current MediaPackage.
+   *
+   * @param workflowInstance
+   *          the current workflow instance
+   * @return the operation result containing the updated media package
+   * @throws EncoderException
+   *           if encoding fails
+   * @throws WorkflowOperationException
+   *           if errors occur during processing
+   * @throws IOException
+   *           if the workspace operations fail
+   * @throws NotFoundException
+   *           if the workspace doesn't contain the requested file
+   */
+  private WorkflowOperationResult mux(WorkflowInstance workflowInstance)
+          throws EncoderException, IOException, NotFoundException, MediaPackageException, WorkflowOperationException {
+    MediaPackage src = workflowInstance.getMediaPackage();
+    MediaPackage mediaPackage = (MediaPackage) src.clone();
+    WorkflowOperationInstance operation = workflowInstance.getCurrentOperation();
+    // Check which tags have been configured
+    ConfiguredTagsAndFlavors tagsAndFlavors = getTagsAndFlavors(workflowInstance,
+        Configuration.many, Configuration.many, Configuration.many, Configuration.many);
+    List<String> targetTagsOption = tagsAndFlavors.getTargetTags();
+    MediaPackageElementFlavor targetFlavor = tagsAndFlavors.getSingleTargetFlavor();
+
+    AbstractMediaPackageElementSelector<Track> elementSelector = new TrackSelector();
+
+    Map<String, List<Track>> inputTracks = new HashMap<>();
+    for (MediaPackageElementFlavor srcFlavor : tagsAndFlavors.getSrcFlavors()) {
+      elementSelector.addFlavor(srcFlavor);
+    }
+    for (String srcTag : tagsAndFlavors.getSrcTags()) {
+      elementSelector.addTag(srcTag);
+    }
+    Collection<Track> srcTracks = elementSelector.select(mediaPackage, false);
+    inputTracks.put("video", srcTracks.stream().toList());
+
+    // handle mux woh specific input keys
+    final String sourceFlavorPrefix = "source-flavor-";
+    final String sourceFlavorsPrefix = "source-flavors-";
+    final String sourceTagPrefix = "source-tag-";
+    final String sourceTagsPrefix = "source-tags-";
+    for (String flavorConfKey : operation.getConfigurationKeys().stream().filter(
+        confKey -> StringUtils.startsWith(confKey, sourceFlavorPrefix) || StringUtils.startsWith(confKey,
+            sourceFlavorsPrefix)).collect(Collectors.toSet())) {
+      elementSelector = new TrackSelector();
+      for (String srcFlavor : StringUtils.split(operation.getConfiguration(flavorConfKey), ",")) {
+        elementSelector.addFlavor(srcFlavor);
+      }
+      String srcType = StringUtils.split(flavorConfKey, "-", 3)[2];
+      for (String srcTag : operation.getConfigurationKeys().stream().filter(
+          confKey -> StringUtils.equals(confKey, sourceTagPrefix + srcType)
+              || StringUtils.equals(confKey, sourceTagsPrefix + srcType)).collect(Collectors.toSet())) {
+        asList(StringUtils.trimToNull(srcTag)).stream().filter(Objects::nonNull).forEach(elementSelector::addTag);
+      }
+      srcTracks = elementSelector.select(mediaPackage, false);
+      if (!srcTracks.isEmpty()) {
+        if (inputTracks.containsKey(srcType)) {
+          inputTracks.get(srcType).addAll(srcTracks);
+        } else {
+          inputTracks.put(srcType, new ArrayList<>(srcTracks));
+        }
+      }
+    }
+    // Handle tags-only inputs
+    for (String tagConfKey : operation.getConfigurationKeys().stream().filter(
+        confKey -> StringUtils.startsWith(confKey, sourceTagPrefix) || StringUtils.startsWith(confKey,
+            sourceTagsPrefix)).collect(Collectors.toSet())) {
+      String srcType = StringUtils.split(tagConfKey, "-", 3)[2];
+      if (inputTracks.containsKey(srcType)) {
+        continue;
+      }
+      elementSelector = new TrackSelector();
+      asList(StringUtils.trimToNull(operation.getConfiguration(tagConfKey)))
+          .stream().filter(Objects::nonNull).forEach(elementSelector::addTag);
+      srcTracks = elementSelector.select(mediaPackage, false);
+      inputTracks.put(srcType, new ArrayList<>(srcTracks));
+    }
+
+    if (inputTracks.isEmpty()) {
+      logger.warn("No source tags or flavors have been specified, not matching anything");
+      return createResult(mediaPackage, Action.SKIP);
+    }
+    String profileOption = StringUtils.trimToNull(operation.getConfiguration("encoding-profile"));
+    if (profileOption == null) {
+      throw new WorkflowOperationException("No encoding profile was specified");
+    }
+    String profileId = StringUtils.trim(profileOption);
+    EncodingProfile profile = composerService.getProfile(profileId);
+    if (profile == null)
+      throw new WorkflowOperationException("Encoding profile '" + profileId + "' was not found");
+
+    Map<String, Track> muxSourceTracksMap = new HashMap<>();
+    for (String srcType : inputTracks.keySet()) {
+      List<Track> srcTypeTracks = inputTracks.get(srcType);
+      for (int i = 0; i < srcTypeTracks.size(); i++) {
+        muxSourceTracksMap.put(String.format("%s.%d", srcType, i + 1), srcTypeTracks.get(i));
+      }
+    }
+    Job muxJob = composerService.mux(muxSourceTracksMap, profileId);
+
+    // Wait for the jobs to return
+    if (!waitForStatus(muxJob).isSuccess()) {
+      throw new WorkflowOperationException("Mux job did not complete successfully");
+    }
+
+    Track encodedTrack = (Track) MediaPackageElementParser.getFromXml(muxJob.getPayload());
+    encodedTrack.setFlavor(targetFlavor);
+    encodedTrack.setTags(targetTagsOption.toArray(new String[0]));
+    // store new track to mediaPackage
+    String fileName = getFileNameFromElements(encodedTrack, encodedTrack);
+    encodedTrack.setURI(workspace.moveTo(encodedTrack.getURI(), mediaPackage.getIdentifier().toString(),
+        encodedTrack.getIdentifier(), fileName));
+    if (muxSourceTracksMap.size() == 1) {
+      mediaPackage.addDerived(encodedTrack, muxSourceTracksMap.get(0));
+    } else {
+      mediaPackage.add(encodedTrack);
+    }
+
+    WorkflowOperationResult result = createResult(mediaPackage, Action.CONTINUE);
+    logger.debug("Mux operation completed");
+    return result;
+  }
+
+  @Reference
+  @Override
+  public void setServiceRegistry(ServiceRegistry serviceRegistry) {
+    super.setServiceRegistry(serviceRegistry);
+  }
+}


### PR DESCRIPTION
The Mux WOH should encode multiple tracks into one. The encoding profile defines how the streams are handled. With Mux WOH, you can name input tracks that will be selected precisely in the encoding profile.

You can test the mux WOH with attached workflow and encoding profiles. It expects presenter/source, presentation/source and at least one captions/source tracks. Run it from the archive. It will generate and archive an download/delivery media file with all presenter, presentation media streams and all captions. Do not use it in production, only for testing.

[download.xml](https://github.com/user-attachments/files/21149133/download.xml.txt)
[mux.properties](https://github.com/user-attachments/files/21149135/mux.properties.txt)
