### PR TITLE
Fix subtitles when used in series that contain watermarks

### DIFF
--- a/etc/workflows/partial-theming-watermark.xml
+++ b/etc/workflows/partial-theming-watermark.xml
@@ -10,7 +10,7 @@
       id="tag"
       description="Select tracks for watermarking">
       <configurations>
-        <configuration key="source-flavors">*/trimmed</configuration>
+        <configuration key="source-flavors">presenter/trimmed,presentation/trimmed</configuration>
         <configuration key="target-flavor">*/branding</configuration>
       </configurations>
     </operation>


### PR DESCRIPTION
Fixes #6897 

Before the captions with flavor captions/trimmed will be changed to captions/branding which breaks the further processing of subtitles in workflows. They will be generated and in the archive, but not published. This PR changes that, so that only presenter and presentation tracks will be changed in the partial-theming-watermark.xml.

## How to test
Create brandings with watermarks and uploade events where subtitles will be generated. The subtitles should be published and be available in the video player as expected.