### PR TITLE
Watermarks must be specific filetypes

### DIFF
--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/CompositeWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/CompositeWorkflowOperationHandler.java
@@ -694,6 +694,12 @@ public class CompositeWorkflowOperationHandler extends AbstractWorkflowOperation
         logger.warn("Unable to read the watermark image attachment {}", watermarkAttachment.get().getURI(), e);
         throw new WorkflowOperationException("Unable to read the watermark image attachment", e);
       }
+      //Such excellent documentation Orcale, much fun.  Because returning null is a totally sane thing to do here
+      //https://docs.oracle.com/javase/tutorial/2d/images/loadimage.html
+      if (null == image) {
+        logger.error("Unable to parse watermark file.  File must be gif, png, jp(e)g, or bmp");
+        throw new WorkflowOperationException("Unable to parse watermark file.  File must be gif, png, jp(e)g, or bmp");
+      }
       Dimension imageDimension = Dimension.dimension(image.getWidth(), image.getHeight());
       List<Tuple<Dimension, AbsolutePositionLayoutSpec>> watermarkShapes = new ArrayList<Tuple<Dimension, AbsolutePositionLayoutSpec>>();
       watermarkShapes.add(0, Tuple.tuple(imageDimension, compositeSettings.getWatermarkLayout().get()));


### PR DESCRIPTION
This PR adds a null check against Oracle's frankly *insane* decision to return `null` with no errors if it can't/won't read a file.  This manifested during testing of #6898 when I believed out admin UI's statement that SVG was an acceptable filetype.  We should fix this in the frontend as well, but that's a different PR.

Discussion question: Would it be sane to try and have the endpoint refuse ineligible filetypes, or should we just check null here then chuck an error?

### How to test this patch

Create a theme with an svg watermark, assign it to a series, and then process an event in that series.  You should not see:

```
2025-07-21T15:21:48,596 | ERROR | (WorkflowOperationWorker:140) - Workflow operation 'operation:'composite, state:'FAILED'' failed
org.opencastproject.workflow.api.WorkflowOperationException: java.lang.NullPointerException: Cannot invoke "java.awt.image.BufferedImage.getWidth()" because "image" is null
        at org.opencastproject.workflow.handler.composer.CompositeWorkflowOperationHandler.start(CompositeWorkflowOperationHandler.java:172) ~[?:?]
        at org.opencastproject.workflow.impl.WorkflowOperationWorker.start(WorkflowOperationWorker.java:212) ~[!/:?]
        at org.opencastproject.workflow.impl.WorkflowOperationWorker.execute(WorkflowOperationWorker.java:117) [!/:?]
        at org.opencastproject.workflow.impl.WorkflowServiceImpl.runWorkflowOperation(WorkflowServiceImpl.java:722) [!/:?]
        at org.opencastproject.workflow.impl.WorkflowServiceImpl.process(WorkflowServiceImpl.java:1755) [!/:?]
        at org.opencastproject.workflow.impl.WorkflowServiceImpl$JobRunner.call(WorkflowServiceImpl.java:2116) [!/:?]
        at org.opencastproject.workflow.impl.WorkflowServiceImpl$JobRunner.call(WorkflowServiceImpl.java:2082) [!/:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
        at java.lang.Thread.run(Thread.java:840) [?:?]
Caused by: java.lang.NullPointerException: Cannot invoke "java.awt.image.BufferedImage.getWidth()" because "image" is null
        at org.opencastproject.workflow.handler.composer.CompositeWorkflowOperationHandler.createWatermarkLaidOutElement(CompositeWorkflowOperationHandler.java:697) ~[?:?]
        at org.opencastproject.workflow.handler.composer.CompositeWorkflowOperationHandler.handleSingleTrack(CompositeWorkflowOperationHandler.java:638) ~[?:?]
        at org.opencastproject.workflow.handler.composer.CompositeWorkflowOperationHandler.composite(CompositeWorkflowOperationHandler.java:234) ~[?:?]
       at org.opencastproject.workflow.handler.composer.CompositeWorkflowOperationHandler.start(CompositeWorkflowOperationHandler.java:170) ~[?:?]
        ... 10 more
```

This was developed against 17, and thus targetted there, but I'm apathetic regarding whether it's actually *in* 17.  Presumably this has been present for a long time and no one's reported it, so it's low priority.

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
