### PR TITLE
Series list provider performance

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/SeriesListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/SeriesListProvider.java
@@ -53,6 +53,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Component(
     service = ResourceListProvider.class,
@@ -136,6 +138,10 @@ public class SeriesListProvider implements ResourceListProvider {
         }
         SearchResult<Series> searchResult = searchIndex.getByQuery(seriesQuery);
         Calendar calendar = Calendar.getInstance();
+        //We might have duplicate series names, so let's count them and see
+        Map<String, Long> duplicates = Arrays.stream(searchResult.getItems())
+            .map(series -> series.getSource().getTitle())
+            .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
         for (SearchResultItem<Series> item : searchResult.getItems()) {
           Series s = item.getSource();
           if (TITLE_EXTENDED.equals(listName)) {
@@ -155,11 +161,7 @@ public class SeriesListProvider implements ResourceListProvider {
             result.put(s.getIdentifier(), sb.toString());
           } else if (PROVIDER_PREFIX.equals(listName)) {
             String newSeriesName = s.getTitle();
-            boolean isTitleRepeated = Arrays.stream(searchResult.getItems())
-                .anyMatch(series ->
-                    !series.equals(item) && series.getSource().getTitle().equals(s.getTitle())
-                );
-            if (isTitleRepeated) {
+            if (duplicates.get(newSeriesName) > 1L) {
               //If a series name is repeated, will add the first 7 characters of the series ID to the display name on the
               //admin-ui
               if (s.getIdentifier().length() > 8) {


### PR DESCRIPTION
This PR avoids recomputing duplicate checks for every search result, hopefully improving performance in large series count systems.  This may help with https://github.com/opencast/opencast-admin-interface/issues/1230, though I have not actually tested that.

PR going into 17.x since performance is important, and this should not affect output - just speed of output.

### How to test this patch

Make lots of series.  Check that `/admin-ng/event/new/metadata` loads faster than before


### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
