### PR TITLE
Don't query for series collection in admin ui event endpoints

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -1267,7 +1267,7 @@ public abstract class AbstractEventEndpoint {
     // We do this after extended metadata because we want to overwrite any extended metadata adapters with the same
     // flavor instead of the other way around.
     EventCatalogUIAdapter eventCatalogUiAdapter = getIndexService().getCommonEventCatalogUIAdapter();
-    DublinCoreMetadataCollection metadataCollection = eventCatalogUiAdapter.getRawFields(getCollectionQueryOverrides());
+    DublinCoreMetadataCollection metadataCollection = eventCatalogUiAdapter.getRawFields(getCollectionQueryDisable());
     EventUtils.setEventMetadataValues(event, metadataCollection);
     metadataList.add(eventCatalogUiAdapter, metadataCollection);
 
@@ -1283,19 +1283,16 @@ public abstract class AbstractEventEndpoint {
   }
 
   /**
-   * If we only want to show series with write access, create a special query to fill the collection of the series
-   * metadata field
+   * Create a special query that disables filling the collection of a series, for performance reasons.
+   * The collection can still be fetched via the listprovider endpoint.
    *
    * @return a map with resource list queries belonging to metadata fields
    */
-  private Map getCollectionQueryOverrides() {
+  private Map getCollectionQueryDisable() {
     HashMap<String, ResourceListQuery> collectionQueryOverrides = new HashMap();
-    if (getOnlySeriesWithWriteAccessEventModal()) {
-      SeriesListQuery seriesListQuery = new SeriesListQuery();
-      seriesListQuery.withReadPermission(true);
-      seriesListQuery.withWritePermission(true);
-      collectionQueryOverrides.put(DublinCore.PROPERTY_IS_PART_OF.getLocalName(), seriesListQuery);
-    }
+    SeriesListQuery seriesListQuery = new SeriesListQuery();
+    seriesListQuery.setLimit(0);
+    collectionQueryOverrides.put(DublinCore.PROPERTY_IS_PART_OF.getLocalName(), seriesListQuery);
     return collectionQueryOverrides;
   }
 
@@ -1358,7 +1355,7 @@ public abstract class AbstractEventEndpoint {
       // collect metadata
       EventCatalogUIAdapter eventCatalogUiAdapter = getIndexService().getCommonEventCatalogUIAdapter();
       DublinCoreMetadataCollection metadataCollection = eventCatalogUiAdapter.getRawFields(
-              getCollectionQueryOverrides());
+            getCollectionQueryDisable());
       EventUtils.setEventMetadataValues(event, metadataCollection);
       collectedMetadata.add(metadataCollection);
 
@@ -2332,7 +2329,7 @@ public abstract class AbstractEventEndpoint {
     // We do this after extended metadata because we want to overwrite any extended metadata adapters with the same
     // flavor instead of the other way around.
     EventCatalogUIAdapter commonCatalogUiAdapter = getIndexService().getCommonEventCatalogUIAdapter();
-    DublinCoreMetadataCollection commonMetadata = commonCatalogUiAdapter.getRawFields(getCollectionQueryOverrides());
+    DublinCoreMetadataCollection commonMetadata = commonCatalogUiAdapter.getRawFields(getCollectionQueryDisable());
 
     if (commonMetadata.getOutputFields().containsKey(DublinCore.PROPERTY_CREATED.getLocalName()))
       commonMetadata.removeField(commonMetadata.getOutputFields().get(DublinCore.PROPERTY_CREATED.getLocalName()));

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/SeriesListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/SeriesListProvider.java
@@ -206,6 +206,37 @@ public class SeriesListProvider implements ResourceListProvider {
     if (query.getOffset().isSome()) {
       seriesQuery.withOffset(query.getOffset().get());
     }
+
+    for (ResourceListFilter filter : query.getFilters()) {
+      if (filter.getValue().isNone()) {
+        continue;
+      } else if (SeriesListQuery.FILTER_CREATIONDATE_NAME.equals(filter.getName())) {
+        Tuple<Date, Date> creationDate = (Tuple<Date, Date>) filter.getValue().get();
+        if (creationDate.getA() != null) {
+          seriesQuery.withCreatedFrom(creationDate.getA());
+        }
+        if (creationDate.getB() != null) {
+          seriesQuery.withCreatedTo(creationDate.getB());
+        }
+      } else if (SeriesListQuery.FILTER_CREATOR_NAME.equals(filter.getName())) {
+        seriesQuery.withCreator((String)filter.getValue().get());
+      } else if (SeriesListQuery.FILTER_CONTRIBUTORS_NAME.equals(filter.getName())) {
+        seriesQuery.withContributor((String)filter.getValue().get());
+      } else if (SeriesListQuery.FILTER_LANGUAGE_NAME.equals(filter.getName())) {
+        seriesQuery.withLanguage((String)filter.getValue().get());
+      } else if (SeriesListQuery.FILTER_LICENSE_NAME.equals(filter.getName())) {
+        seriesQuery.withLicense((String)filter.getValue().get());
+      } else if (SeriesListQuery.FILTER_ORGANIZERS_NAME.equals(filter.getName())) {
+        seriesQuery.withOrganizer((String)filter.getValue().get());
+      } else if (SeriesListQuery.FILTER_SUBJECT_NAME.equals(filter.getName())) {
+        seriesQuery.withSubject((String)filter.getValue().get());
+      } else if (SeriesListQuery.FILTER_TEXT_NAME.equals(filter.getName())) {
+        seriesQuery.withText((String)filter.getValue().get());
+      } else if (SeriesListQuery.FILTER_TITLE_NAME.equals(filter.getName())) {
+        seriesQuery.withTitle((String)filter.getValue().get());
+      }
+    }
+
     if (query instanceof SeriesListQuery) {
       if (((SeriesListQuery) query).getReadPermission().isSome()
           || ((SeriesListQuery) query).getWritePermission().isSome()) {
@@ -215,35 +246,6 @@ public class SeriesListProvider implements ResourceListProvider {
         }
         if (((SeriesListQuery) query).getWritePermission().getOrElse(false)) {
           seriesQuery.withAction(Permissions.Action.WRITE);
-        }
-      }
-      for (ResourceListFilter filter : query.getFilters()) {
-        if (filter.getValue().isNone()) {
-          continue;
-        } else if (SeriesListQuery.FILTER_CREATIONDATE_NAME.equals(filter.getName())) {
-          Tuple<Date, Date> creationDate = (Tuple<Date, Date>) filter.getValue().get();
-          if (creationDate.getA() != null) {
-            seriesQuery.withCreatedFrom(creationDate.getA());
-          }
-          if (creationDate.getB() != null) {
-            seriesQuery.withCreatedTo(creationDate.getB());
-          }
-        } else if (SeriesListQuery.FILTER_CREATOR_NAME.equals(filter.getName())) {
-          seriesQuery.withCreator((String)filter.getValue().get());
-        } else if (SeriesListQuery.FILTER_CONTRIBUTORS_NAME.equals(filter.getName())) {
-          seriesQuery.withContributor((String)filter.getValue().get());
-        } else if (SeriesListQuery.FILTER_LANGUAGE_NAME.equals(filter.getName())) {
-          seriesQuery.withLanguage((String)filter.getValue().get());
-        } else if (SeriesListQuery.FILTER_LICENSE_NAME.equals(filter.getName())) {
-          seriesQuery.withLicense((String)filter.getValue().get());
-        } else if (SeriesListQuery.FILTER_ORGANIZERS_NAME.equals(filter.getName())) {
-          seriesQuery.withOrganizer((String)filter.getValue().get());
-        } else if (SeriesListQuery.FILTER_SUBJECT_NAME.equals(filter.getName())) {
-          seriesQuery.withSubject((String)filter.getValue().get());
-        } else if (SeriesListQuery.FILTER_TEXT_NAME.equals(filter.getName())) {
-          seriesQuery.withText((String)filter.getValue().get());
-        } else if (SeriesListQuery.FILTER_TITLE_NAME.equals(filter.getName())) {
-          seriesQuery.withTitle((String)filter.getValue().get());
         }
       }
     }


### PR DESCRIPTION
When getting event metadata from the respective listprovider,  we also get ALL series from the series listprovider (to which the user has write access).  This can be very time consuming in case there are many series.
This patch changes behaviour so that we do not get all series anymore. The admin ui frontend can query the series listprovider itself if needed.

***Breaks the frontend. Needs to be merged together with: https://github.com/opencast/opencast-admin-interface/pull/1375***


### How to test this patch

Install together with the required frontend PR. Try to change series for new or existing events.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
