### PR TITLE
Add support for source-tags to speechtotext woh

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/speechtotext-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/speechtotext-woh.md
@@ -18,7 +18,8 @@ Parameter Table
 
 | Configuration Keys       | Required | Example          | Description
 |--------------------------|----------|------------------|-------------
-| source-flavor            | yes      | presenter/source | The source media package to use
+| source-flavor            | yes      | presenter/source | The source media element flavor to use
+| source-tags              | no       | master-video  | Comma-separated list of tags to help select the appropriate track
 | target-flavor            | yes      | archive          | Flavor of the produced subtitle
 | target-tags              | no       | captions/source  | Tags applies to the resulting subtitle element²³.
 | target-element           | no       | track            | Define where to append the subtitles file. Possibilities are: as a 'track' or as an 'attachment' (default: `track`).

--- a/modules/speech-to-text-workflowoperation/src/main/java/org/opencastproject/workflow/handler/speechtotext/SpeechToTextWorkflowOperationHandler.java
+++ b/modules/speech-to-text-workflowoperation/src/main/java/org/opencastproject/workflow/handler/speechtotext/SpeechToTextWorkflowOperationHandler.java
@@ -168,13 +168,17 @@ public class
     var async = BooleanUtils.toBoolean(workflowInstance.getCurrentOperation().getConfiguration(ASYNCHRONOUS));
 
     ConfiguredTagsAndFlavors tagsAndFlavors = getTagsAndFlavors(workflowInstance,
-            Configuration.none, Configuration.one,
+            Configuration.many, Configuration.one,
             Configuration.many, Configuration.one);
     MediaPackageElementFlavor sourceFlavor = tagsAndFlavors.getSingleSrcFlavor();
+    List<String> srcTags = tagsAndFlavors.getSrcTags();
 
     TrackSelector trackSelector = new TrackSelector();
     trackSelector.addFlavor(sourceFlavor);
-    Collection<Track> tracks = trackSelector.select(mediaPackage, false);
+    for (String tag : srcTags) {
+      trackSelector.addTag(tag);
+    }
+    Collection<Track> tracks = trackSelector.select(mediaPackage, true);
 
     if (tracks.isEmpty()) {
       throw new WorkflowOperationException(


### PR DESCRIPTION
This PR adds the 'source-tags' configuration to the speechtotext workflow operation as an additional way to select the appropriate track.

### How to test this patch

Use a workflow that produces serverless HLS and tags the media with the encoding profile. Then, in the speechtotext woh, use the source-tags to select the desired track by the encoding profile tag in addition to flavor. If selecting by element flavor only, there's a chance that the m3u8 manifest is selected and the operation fails.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
