### PR TITLE
Reactivate user role filter for admin ui

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/UsersEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/UsersEndpoint.java
@@ -83,7 +83,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -236,9 +235,7 @@ public class UsersEndpoint {
 
     // Filter users by filter criteria
     List<User> filteredUsers = new ArrayList<>();
-    for (Iterator<User> i = userDirectoryService.getUsers(); i.hasNext();) {
-      User user = i.next();
-
+    for (User user : userDirectoryService.getUsers()) {
       // Filter list
       final String finalFilterRole = filterRole;
       if (filterName != null && !filterName.equals(user.getName())

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestUsersEndpoint.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestUsersEndpoint.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 
 import javax.ws.rs.Path;
@@ -76,7 +77,7 @@ public class TestUsersEndpoint extends UsersEndpoint {
     users.add(user3);
     users.add(user4);
 
-    expect(userDirectoryService.getUsers()).andStubReturn(users.iterator());
+    expect(userDirectoryService.getUsers()).andStubReturn(users);
     EasyMock.expect(userDirectoryService.findUsers(EasyMock.anyString(), EasyMock.anyInt(), EasyMock.anyInt()))
             .andDelegateTo(new TestUsers()).anyTimes();
     replay(userDirectoryService);
@@ -88,7 +89,7 @@ public class TestUsersEndpoint extends UsersEndpoint {
   public class TestUsers implements UserDirectoryService {
 
     @Override
-    public Iterator<User> getUsers() {
+    public List<User> getUsers() {
       return null;
     }
 

--- a/modules/common/src/main/java/org/opencastproject/security/api/UserDirectoryService.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/UserDirectoryService.java
@@ -36,7 +36,7 @@ public interface UserDirectoryService {
    *
    * @return the users
    */
-  Iterator<User> getUsers();
+  List<User> getUsers();
 
   /**
    * Loads a user by username, or returns null if this user is not known to the thread's current organization.

--- a/modules/graphql/src/main/java/org/opencastproject/graphql/datafetcher/user/UserOffsetDataFetcher.java
+++ b/modules/graphql/src/main/java/org/opencastproject/graphql/datafetcher/user/UserOffsetDataFetcher.java
@@ -31,7 +31,6 @@ import org.opencastproject.util.SmartIterator;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import graphql.schema.DataFetchingEnvironment;
@@ -54,9 +53,7 @@ public class UserOffsetDataFetcher extends ParameterDataFetcher<GqlUserList> {
 
     // Filter users by filter criteria
     List<User> filteredUsers = new ArrayList<>();
-    for (Iterator<User> i = userDirectoryService.getUsers(); i.hasNext();) {
-      User user = i.next();
-
+    for (User user : userDirectoryService.getUsers()) {
       // Filter list
       if (filter != null && !match(filter, user.getUsername(), user.getName(), user.getEmail(), user.getProvider())) {
         continue;

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/UsersListQuery.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/UsersListQuery.java
@@ -53,6 +53,7 @@ public class UsersListQuery extends ResourceListQueryImpl {
 
   public UsersListQuery() {
     super();
+    this.availableFilters.add(createRoleFilter(Option.<String> none()));
     this.availableFilters.add(createProviderFilter(Option.<String> none()));
   }
 

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/resources/list/provider/ContributorsListProviderTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/resources/list/provider/ContributorsListProviderTest.java
@@ -83,7 +83,7 @@ public class ContributorsListProviderTest {
       }
 
       @Override
-      public Iterator<User> getUsers() {
+      public List<User> getUsers() {
         return null;
       }
 

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/resources/list/provider/UsersListProviderTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/resources/list/provider/UsersListProviderTest.java
@@ -72,7 +72,7 @@ public class UsersListProviderTest {
       }
 
       @Override
-      public Iterator<User> getUsers() {
+      public List<User> getUsers() {
         return null;
       }
 

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
@@ -233,7 +233,7 @@ public class UserAndRoleDirectoryServiceImpl implements UserDirectoryService, Us
    * @see org.opencastproject.security.api.UserDirectoryService#getUsers()
    */
   @Override
-  public Iterator<User> getUsers() {
+  public List<User> getUsers() {
     final Organization org = securityService.getOrganization();
     if (org == null) {
       throw new IllegalStateException("No organization is set");
@@ -247,7 +247,8 @@ public class UserAndRoleDirectoryServiceImpl implements UserDirectoryService, Us
         userProvider.getUsers().forEachRemaining(users::add);
       }
     }
-    return users.stream().sorted(Comparator.comparing(User::getUsername)).iterator();
+    users.sort(Comparator.comparing(User::getUsername));
+    return users;
   }
 
   /**

--- a/modules/userdirectory/src/test/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImplTest.java
+++ b/modules/userdirectory/src/test/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImplTest.java
@@ -185,7 +185,7 @@ public class UserAndRoleDirectoryServiceImplTest {
   @Test
   @SuppressWarnings("unchecked")
   public void testGetUsers() {
-    List<User> users = IteratorUtils.toList(directory.getUsers());
+    List<User> users = directory.getUsers();
     Assert.assertEquals(2, users.size());
   }
 


### PR DESCRIPTION
Helps with https://github.com/opencast/opencast-admin-interface/issues/1287.

Allows users of the admin interface to filter the users table by roles once again. This was originally removed in https://github.com/opencast/opencast/pull/3172.

The filter was originally removed due to performance concerns and to this day it is still not terribly performant. On my local testing instance with about 20000 users, a request with a role filter could take between 350 ~ 400ms, compared to 80 ~ 120ms without a role filter. However, we are allowing admin interface users to use the textFilter (aka the search bar) to filter by role, which has the exact same performance concerns as using the role filter directly. Therefore I argue that we should either allow users to use the role filter, or disable the textFilter either just for roles or alltogether.

Since allowing role filters hinges on performance, I would like the help of adopters with many users (thousands or more) and ideally multiple user providers to test this.

### How to test this patch

After installing this, open the admin interface. Go to the users table and set a role filter. Open your browsers dev tools(F12), open the network tab and observe the time the GET users.json... request takes.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
