### PR TITLE
Add role filter for groups to admin ui

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/GroupsEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/GroupsEndpoint.java
@@ -193,12 +193,13 @@ public class GroupsEndpoint {
 
     Map<String, String> filters = RestUtils.parseFilter(filter);
     Optional<String> optNameFilter = Optional.ofNullable(filters.get(GroupsListQuery.FILTER_NAME_NAME));
+    Optional<String> optRoleFilter = Optional.ofNullable(filters.get(GroupsListQuery.FILTER_ROLE_NAME));
     Optional<String> optTextFilter = Optional.ofNullable(filters.get(GroupsListQuery.FILTER_TEXT_NAME));
 
     ArrayList<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(sort);
 
-    List<JpaGroup> results = jpaGroupRoleProvider.getGroups(optLimit, optOffset, optNameFilter, optTextFilter,
-            sortCriteria);
+    List<JpaGroup> results = jpaGroupRoleProvider.getGroups(optLimit, optOffset, optNameFilter, optRoleFilter,
+        optTextFilter, sortCriteria);
 
     // load users
     List<String> userNames = results.stream().flatMap(item -> item.getMembers().stream())
@@ -218,7 +219,7 @@ public class GroupsEndpoint {
       groupsJSON.add(obj(fields));
     }
 
-    long dbTotal = jpaGroupRoleProvider.countTotalGroups(optNameFilter, optTextFilter);
+    long dbTotal = jpaGroupRoleProvider.countTotalGroups(optNameFilter, optRoleFilter, optTextFilter);
     long resultsTotal = optOffset.orElse(0) + results.size();
 
     // groups could've been added or deleted in the meantime, so...

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/GroupsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/GroupsEndpoint.java
@@ -190,8 +190,8 @@ public class GroupsEndpoint {
       sortCriteria.removeAll(deprecatedSortCriteria);
     }
 
-    List<JpaGroup> results = jpaGroupRoleProvider.getGroups(optLimit, optOffset, optNameFilter, Optional.empty(),
-            sortCriteria);
+    List<JpaGroup> results = jpaGroupRoleProvider.getGroups(optLimit, optOffset, optNameFilter,
+        Optional.empty(), Optional.empty(), sortCriteria);
 
     // sorting by members & roles is only available for api versions < 1.6.0
     if (requestedVersion.isSmallerThan(VERSION_1_6_0)) {

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/GroupsListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/GroupsListProvider.java
@@ -24,6 +24,7 @@ package org.opencastproject.index.service.resources.list.provider;
 import org.opencastproject.list.api.ResourceListProvider;
 import org.opencastproject.list.api.ResourceListQuery;
 import org.opencastproject.security.api.JaxbGroup;
+import org.opencastproject.security.api.Role;
 import org.opencastproject.userdirectory.JpaGroupRoleProvider;
 
 import org.osgi.framework.BundleContext;
@@ -51,8 +52,9 @@ public class GroupsListProvider implements ResourceListProvider {
 
   public static final String DESCRIPTION = PROVIDER_PREFIX + ".DESCRIPTION";
   public static final String NAME = PROVIDER_PREFIX + ".NAME";
+  public static final String ROLE_ONLY = PROVIDER_PREFIX + ".ROLE.ONLY"; // Role: Role
 
-  protected static final String[] NAMES = { PROVIDER_PREFIX, NAME, DESCRIPTION };
+  protected static final String[] NAMES = { PROVIDER_PREFIX, NAME, DESCRIPTION, ROLE_ONLY };
   private static final Logger logger = LoggerFactory.getLogger(GroupsListProvider.class);
 
   private JpaGroupRoleProvider groupRoleProvider;
@@ -100,6 +102,10 @@ public class GroupsListProvider implements ResourceListProvider {
         groupsList.put(g.getName(), g.getName());
       } else if (DESCRIPTION.equals(listName)) {
         groupsList.put(g.getDescription(), g.getDescription());
+      } else if (ROLE_ONLY.equals(listName) && g.getRoles().size() > 0) {
+        for (Role role : g.getRoles()) {
+          groupsList.put(role.getName(), role.getName());
+        }
       } else {
         groupsList.put(g.getGroupId(), g.getName());
       }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/GroupsListQuery.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/GroupsListQuery.java
@@ -41,12 +41,15 @@ import org.opencastproject.util.data.Option;
 public class GroupsListQuery extends ResourceListQueryImpl {
 
   public static final String FILTER_NAME_NAME = "Name";
+  public static final String FILTER_ROLE_NAME = "Role";
   private static final String FILTER_NAME_LABEL = "FILTERS.USERS.NAME.LABEL";
+  private static final String FILTER_ROLE_LABEL = "FILTERS.USERS.ROLE.LABEL";
 
   public static final String FILTER_TEXT_NAME = "textFilter";
 
   public GroupsListQuery() {
     super();
+    this.availableFilters.add(createRoleFilter(Option.none()));
   }
 
   /**
@@ -69,6 +72,25 @@ public class GroupsListQuery extends ResourceListQueryImpl {
   }
 
   /**
+   * Add a {@link ResourceListFilter} filter to the query with the given role
+   *
+   * @param role
+   *          the role to filter for
+   */
+  public void withRole(String role) {
+    this.addFilter(createRoleFilter(Option.option(role)));
+  }
+
+  /**
+   * Returns an {@link Option} containing the role used to filter if set
+   *
+   * @return an {@link Option} containing the role or none.
+   */
+  public Option<String> getRole() {
+    return this.getFilterValue(FILTER_ROLE_NAME);
+  }
+
+  /**
    * Create a new {@link ResourceListFilter} based on a name
    *
    * @param name
@@ -78,6 +100,11 @@ public class GroupsListQuery extends ResourceListQueryImpl {
   public static ResourceListFilter<String> createNameFilter(Option<String> name) {
     return FiltersUtils.generateFilter(name, FILTER_NAME_NAME, FILTER_NAME_LABEL, SourceType.SELECT,
             Option.some(GroupsListProvider.NAME));
+  }
+
+  public static ResourceListFilter<String> createRoleFilter(Option<String> role) {
+    return FiltersUtils.generateFilter(role, FILTER_ROLE_NAME, FILTER_ROLE_LABEL, SourceType.SELECT,
+        Option.some(GroupsListProvider.ROLE_ONLY));
   }
 
 }

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaGroupRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaGroupRoleProvider.java
@@ -493,10 +493,10 @@ public class JpaGroupRoleProvider implements AAIRoleProvider, GroupProvider, Gro
    * @return a list of groups
    */
   public List<JpaGroup> getGroups(Optional<Integer> limit, Optional<Integer> offset, Optional<String> nameFilter,
-          Optional<String> textFilter, ArrayList<SortCriterion> sortCriteria) {
+          Optional<String> roleFilter, Optional<String> textFilter, ArrayList<SortCriterion> sortCriteria) {
     String orgId = securityService.getOrganization().getId();
-    return db.exec(UserDirectoryPersistenceUtil.findGroupsQuery(orgId, limit, offset, nameFilter, textFilter,
-        sortCriteria));
+    return db.exec(UserDirectoryPersistenceUtil.findGroupsQuery(orgId, limit, offset, nameFilter, roleFilter,
+        textFilter, sortCriteria));
   }
 
   /**
@@ -509,9 +509,9 @@ public class JpaGroupRoleProvider implements AAIRoleProvider, GroupProvider, Gro
    *
    * @return a list of groups
    */
-  public long countTotalGroups(Optional<String> nameFilter, Optional<String> textFilter) {
+  public long countTotalGroups(Optional<String> nameFilter, Optional<String> roleFilter, Optional<String> textFilter) {
     String orgId = securityService.getOrganization().getId();
-    return db.exec(UserDirectoryPersistenceUtil.countTotalGroupsQuery(orgId, nameFilter, textFilter));
+    return db.exec(UserDirectoryPersistenceUtil.countTotalGroupsQuery(orgId, nameFilter, roleFilter, textFilter));
   }
 
   /**

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserDirectoryPersistenceUtil.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserDirectoryPersistenceUtil.java
@@ -48,6 +48,7 @@ import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Join;
 import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Order;
 import javax.persistence.criteria.Predicate;
@@ -161,14 +162,14 @@ public final class UserDirectoryPersistenceUtil {
    * @throws IllegalArgumentException
    */
   public static Function<EntityManager, Long> countTotalGroupsQuery(String orgId, Optional<String> nameFilter,
-      Optional<String> textFilter) {
+      Optional<String> roleFilter, Optional<String> textFilter) {
     return em -> {
       CriteriaBuilder cb = em.getCriteriaBuilder();
       final CriteriaQuery<Long> query = cb.createQuery(Long.class);
       Root<JpaGroup> group = query.from(JpaGroup.class);
       query.select(cb.count(group));
 
-      addWhereToQuery(query, cb, group, orgId, nameFilter, textFilter);
+      addWhereToQuery(query, cb, group, orgId, nameFilter, roleFilter, textFilter);
 
       TypedQuery<Long> typedQuery = em.createQuery(query);
       return typedQuery.getSingleResult();
@@ -192,13 +193,17 @@ public final class UserDirectoryPersistenceUtil {
    *          fulltext filter (optional)
    */
   private static <E> void addWhereToQuery(CriteriaQuery<E> query, CriteriaBuilder cb, Root<JpaGroup> group,
-          String orgId, Optional<String> nameFilter, Optional<String> textFilter) {
+          String orgId, Optional<String> nameFilter, Optional<String> roleFilter, Optional<String> textFilter) {
     List<Predicate> conditions = new ArrayList<>();
     conditions.add(cb.equal(group.join("organization").get("id"), orgId));
 
     // exact match, case sensitive
     if (nameFilter.isPresent()) {
       conditions.add(cb.equal(group.get("name"), nameFilter.get()));
+    }
+    if (roleFilter.isPresent()) {
+      Join<JpaGroup, JpaRole> roleJoin = group.joinSet("roles", JoinType.LEFT);
+      conditions.add(cb.equal(roleJoin.get("name"), roleFilter.get()));
     }
     // not exact match, case-insensitive, each token needs to match at least one field
     if (textFilter.isPresent()) {
@@ -245,7 +250,7 @@ public final class UserDirectoryPersistenceUtil {
    * @return the group list
    */
   public static Function<EntityManager, List<JpaGroup>> findGroupsQuery(String orgId, Optional<Integer> limit,
-      Optional<Integer> offset, Optional<String> nameFilter, Optional<String> textFilter,
+      Optional<Integer> offset, Optional<String> nameFilter, Optional<String> roleFilter, Optional<String> textFilter,
       ArrayList<SortCriterion> sortCriteria) {
     return em -> {
       CriteriaBuilder cb = em.getCriteriaBuilder();
@@ -255,7 +260,7 @@ public final class UserDirectoryPersistenceUtil {
       query.distinct(true);
 
       // filter
-      addWhereToQuery(query, cb, group, orgId, nameFilter, textFilter);
+      addWhereToQuery(query, cb, group, orgId, nameFilter, roleFilter, textFilter);
 
       // sort
       List<Order> orders = new ArrayList<>();


### PR DESCRIPTION
Helps with https://github.com/opencast/opencast-admin-interface/issues/1287.

Creates a new listprovider filter for groups that allows filtering groups by the roles assigned to them. This filter can then be selected in the admin ui.

Unlike for users, I don't foresee any performance concerns for groups, since this only queries our internal group provider.

### How to test this patch

Send a GET request to /admin-ng/resources/GROUPS.ROLE.ONLY.json.
Or open the admin interface, go the groups tab and set a role filter there. Note: The string displayed in the "role" column of the groups table is not what this filter is filtering by. It is filtering by the assigned roles you can see in the group details.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
