### PR TITLE
Remove reencoding to utf-8 of JWTs

### DIFF
--- a/modules/security-jwt/src/main/java/org/opencastproject/security/jwt/DynamicLoginHandler.java
+++ b/modules/security-jwt/src/main/java/org/opencastproject/security/jwt/DynamicLoginHandler.java
@@ -48,7 +48,6 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.util.Assert;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -223,7 +222,7 @@ public class DynamicLoginHandler implements InitializingBean, JWTLoginHandler {
    * @return The username.
    */
   private String extractUsername(DecodedJWT jwt) {
-    String username = evaluateMapping(jwt, usernameMapping, false);
+    String username = evaluateMapping(jwt, usernameMapping);
     Assert.isTrue(StringUtils.isNotBlank(username), "Extracted username is blank");
     return username;
   }
@@ -235,7 +234,7 @@ public class DynamicLoginHandler implements InitializingBean, JWTLoginHandler {
    * @return The name.
    */
   private String extractName(DecodedJWT jwt) {
-    String name = evaluateMapping(jwt, nameMapping, true);
+    String name = evaluateMapping(jwt, nameMapping);
     Assert.isTrue(StringUtils.isNotBlank(name), "Extracted name is blank");
     return name;
   }
@@ -247,7 +246,7 @@ public class DynamicLoginHandler implements InitializingBean, JWTLoginHandler {
    * @return The email.
    */
   private String extractEmail(DecodedJWT jwt) {
-    String email = evaluateMapping(jwt, emailMapping, true);
+    String email = evaluateMapping(jwt, emailMapping);
     Assert.isTrue(StringUtils.isNotBlank(email), "Extracted email is blank");
     return email;
   }
@@ -262,7 +261,7 @@ public class DynamicLoginHandler implements InitializingBean, JWTLoginHandler {
     JpaOrganization organization = fromOrganization(securityService.getOrganization());
     Set<JpaRole> roles = new HashSet<>();
     for (String mapping : roleMappings) {
-      String role = evaluateMapping(jwt, mapping, false);
+      String role = evaluateMapping(jwt, mapping);
       if (StringUtils.isNotBlank(role)) {
         roles.add(new JpaRole(role, organization));
       }
@@ -276,18 +275,13 @@ public class DynamicLoginHandler implements InitializingBean, JWTLoginHandler {
    *
    * @param jwt The decoded JWT.
    * @param mapping The mapping.
-   * @param ensureEncoding Whether to ensure UTF_8 encoding.
    *
    * @return The string evaluated from the mapping.
    */
-  private String evaluateMapping(DecodedJWT jwt, String mapping, boolean ensureEncoding) {
+  private String evaluateMapping(DecodedJWT jwt, String mapping) {
     ExpressionParser parser = new SpelExpressionParser();
     Expression exp = parser.parseExpression(mapping);
-    String value = exp.getValue(jwt.getClaims(), String.class);
-    if (ensureEncoding) {
-      value = new String(value.getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8);
-    }
-    return value;
+    return exp.getValue(jwt.getClaims(), String.class);
   }
 
   /**


### PR DESCRIPTION
This PR fixes https://github.com/opencast/opencast/issues/5335 . 

Before this patch some parts of the JWT like `name` and `mail` would be interpreted as ISO_8859_1 encoded and reencoded to UTF-8 to "ensure UTF_8 encoding". However if the string is already correctly UTF-8 encoded, this could have led to some characters being misinterpreted.

This patch removes the reencoding as to my understanding the auth0 library always decodes JWTs as UTF-8 anyways according to JWT specification.

### How to test this patch

See https://github.com/opencast/opencast/issues/5335 for a detailed explanation how to set up and test jwt in Opencast. 


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
