### PR TITLE
Add option to pass additional args to WhisperCpp

### DIFF
--- a/etc/org.opencastproject.speechtotext.impl.engine.WhisperCppEngine.cfg
+++ b/etc/org.opencastproject.speechtotext.impl.engine.WhisperCppEngine.cfg
@@ -10,7 +10,7 @@
 
 # Additional args to pass to whispercpp separated by spaces
 # Default: none
-#whisper.args=
+#whispercpp.args=
 
 ## Optional settings to configure the underlying whispercpp engine
 

--- a/etc/org.opencastproject.speechtotext.impl.engine.WhisperCppEngine.cfg
+++ b/etc/org.opencastproject.speechtotext.impl.engine.WhisperCppEngine.cfg
@@ -8,6 +8,9 @@
 # Default: /usr/share/ggml/ggml-base.bin
 #whispercpp.model=/usr/share/ggml/ggml-base.bin
 
+# Additional args to pass to whispercpp separated by spaces
+# Default: none
+#whisper.args=
 
 ## Optional settings to configure the underlying whispercpp engine
 

--- a/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/WhisperCppEngine.java
+++ b/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/WhisperCppEngine.java
@@ -50,6 +50,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -87,6 +88,12 @@ public class WhisperCppEngine implements SpeechToTextEngine {
 
   /** Currently used whispercpp model */
   private String whispercppModel = WHISPERCPP_MODEL_DEFAULT;
+
+  /** Config key for additional Whisper args */
+  private static final String WHISPERCPP_ARGS_CONFIG_KEY = "whisper.args";
+
+  /** Currently used Whisper args */
+  private String[] whispercppArgs;
 
   /** Config key for setting whispercpp beam size */
   private static final String WHISPERCPP_BEAM_SIZE_CONFIG_KEY = "whispercpp.beam-size";
@@ -269,6 +276,9 @@ public class WhisperCppEngine implements SpeechToTextEngine {
       logger.debug("WhisperC++ no fallback set to {}", whispercppNoFallback);
     }
 
+    whispercppArgs = StringUtils.split(Objects.toString(cc.getProperties().get(WHISPERCPP_ARGS_CONFIG_KEY), ""));
+    logger.debug("Additional args for WhisperC++: {}", (Object) whispercppArgs);
+
     autoEncode = BooleanUtils.toBoolean(Objects.toString(
         cc.getProperties().get(AUTO_ENCODING_CONFIG_KEY),
         AUTO_ENCODING_DEFAULT.toString()));
@@ -395,6 +405,7 @@ public class WhisperCppEngine implements SpeechToTextEngine {
       subtitleLanguage = language;
     }
 
+    command.addAll(Arrays.asList(whispercppArgs));
 
     logger.info("Executing WhisperC++'s transcription command: {}", command);
 

--- a/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/WhisperCppEngine.java
+++ b/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/WhisperCppEngine.java
@@ -90,7 +90,7 @@ public class WhisperCppEngine implements SpeechToTextEngine {
   private String whispercppModel = WHISPERCPP_MODEL_DEFAULT;
 
   /** Config key for additional Whisper args */
-  private static final String WHISPERCPP_ARGS_CONFIG_KEY = "whisper.args";
+  private static final String WHISPERCPP_ARGS_CONFIG_KEY = "whispercpp.args";
 
   /** Currently used Whisper args */
   private String[] whispercppArgs;


### PR DESCRIPTION
This PR is the equivalent of https://github.com/opencast/opencast/pull/5342 for whispercpp. 
It adds the option to set additional arguments to the whispercpp command. 

This can for example be used if you want to enable VAD in OC17 to improve subtitle results and automatic language detection, but should also work for any other arguments.

### How to test this patch

Install whispercpp and your desired models, configure it in Opencast including some additional arguments and test if the correct command is executed when subtitles are being generated. 

For VAD activation you would configure something like:

`whispercpp.args= --vad --vad-model /usr/share/whisper.cpp/models/ggml-silero-v5.1.2.bin
`
(with the path pointing to your VAD model)

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
