### PR TITLE
Fix missing `isPresent` check for optional workflow

### DIFF
--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -1651,7 +1651,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
     }
 
     // Make sure we are not excluding ourselves
-    if (workflow.getId() != workflowInstance.get().getId()) {
+    if (workflowInstance.isPresent() && workflow.getId() != workflowInstance.get().getId()) {
       delayWorkflow(workflow, mediaPackageId);
       return false;
     }


### PR DESCRIPTION
Fixes #6630.

Check if there even is a running workflow instance before we try to access it. We don't need to delay our workflow if there is no workflow running
