### PR TITLE
Fix partial path traversal vulnerability in UI config

### DIFF
--- a/modules/user-interface-configuration/src/main/java/org/opencastproject/uiconfig/UIConfigRest.java
+++ b/modules/user-interface-configuration/src/main/java/org/opencastproject/uiconfig/UIConfigRest.java
@@ -166,7 +166,7 @@ public class UIConfigRest {
     File configFile = Paths.get(uiConfigFolder, orgId, component, filename).toFile();
 
     try {
-      final String basePath = new File(uiConfigFolder, orgId).getCanonicalPath();
+      final String basePath = new File(uiConfigFolder, orgId).getCanonicalPath() + File.separator;
       final String configFileCanPath = configFile.getCanonicalPath();
 
       // is configFile a subdirectory of basePath (additional directory traversal protection), if not stop


### PR DESCRIPTION
The protections against path traversal attacks in the UI config module are insufficient, still partially allowing for attacks in very specific cases.

The path is checked without checking for the file separator. This could allow attackers access to files within another folder which starts with the same path. For example, the default UI config directory is placed at `/etc/opencast/ui-config`. Without this patch, an attacker can get access to files in a folder `/etc/opencast/ui-config-hidden` if those files are readable by Opencast.

General path traversal is not possible. For example, an attacker **cannot** exploit this to access files in `/etc/opencast/encoding` or even in `/etc/opencast/` directly.

**How dangerous is this?**

Theoretically, this vulnerability may be exploited to get access to some non-public files. However, given the default structure of Opencast's configuration, this is extremely unlikely to hit any users. There can be but one `ui-config` folders. This makes it quite unlikely for any user to have created an additional folder starting with `ui-config`. Users could also rename this folder, but since there is no real reason for anyone to do this, this, again is extremely unlikely to trigger this issue.

Thanks to @odaysec for pointing this out.
This closes #6937

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
