### PR TITLE
Fix javadoc build

### DIFF
--- a/modules/db/pom.xml
+++ b/modules/db/pom.xml
@@ -98,6 +98,18 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <detectJavaApiLink>true</detectJavaApiLink>
+          <maxmemory>512m</maxmemory>
+          <quiet>false</quiet>
+          <!-- This is required to work around checker-qual's changes, which munge the javadoc options file
+                and lead to very misleading errors about not finding classes in the org.osgi.framework.* namespace -->
+          <sourcepath>src/main/java</sourcepath>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <extensions>true</extensions>


### PR DESCRIPTION
This PR fixes the database javadoc build so that releases can happen.  Unclear what `checker-qual` is doing to break the build, but it was munging the javadocs options file, which lead to bad builds.  This workaround likely breaks whatever `checker-qual` is doing in our javadocs (if anything), but would not break the actual compiled code itself.

This should go into `r/17.x` since we would like to be able to push new builds into maven central.  This won't fix the previous builds, but new ones should work.

### How to test this patch

`./mvnw deploy`, which should fail with errors about missing classes in `org.osgi.framework` in the `db` module without this, and fail with HTTP 40(1|3) errors with this since you don't have permissions to deploy things (and the deploy is still broken regardless, that's next :)).

### Your pull request should…

* [x] have a concise title
* [x] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
