### PR TITLE
Remove unused admin interface config

### DIFF
--- a/etc/listproviders/acl.default.create.properties
+++ b/etc/listproviders/acl.default.create.properties
@@ -26,10 +26,6 @@ list.name=ACL.DEFAULTS
 # Default: ROLE_USER_
 #role_user_prefix=ROLE_USER_
 
-# Sanitize user roles. Should be the same as in org.opencastproject.userdirectory.UserIdRoleProvider.cfg
-# Default: true
-#sanitize=true
-
 # When switching to a new template, all roles that don't belong to the new template are removed
 # To keep roles between template switches, specify role prefixes below
 # Example: ROLE_AAI_USER_,ROLE_ADMIN


### PR DESCRIPTION
The removed config option is currently going unused and I don't expect it to see use ever again. So let's get rid of it.

