### PR TITLE
Fix index rebuild stuff (again)

### DIFF
--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
@@ -534,65 +534,15 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
    *         The newest snapshot of the event to update
    */
   private void updateEventInIndex(Snapshot snapshot) {
-    final MediaPackage mp = snapshot.getMediaPackage();
-    String eventId = mp.getIdentifier().toString();
-    final String organization = securityService.getOrganization().getId();
+    final String eventId = snapshot.getMediaPackage().getIdentifier().toString();
+    final String orgId = securityService.getOrganization().getId();
     final User user = securityService.getUser();
+
     logger.debug("Updating event {} in the {} index.", eventId, index.getIndexName());
+    Function<Optional<Event>, Optional<Event>> updateFunction = getEventUpdateFunction(snapshot, orgId, user);
 
-    Function<Optional<Event>, Optional<Event>> updateFunction = (Optional<Event> eventOpt) -> {
-      Event event = eventOpt.orElse(new Event(eventId, organization));
-
-      AccessControlList acl = authorizationService.getActiveAcl(mp).getA();
-      List<ManagedAcl> acls = aclServiceFactory.serviceFor(securityService.getOrganization()).getAcls();
-      for (final ManagedAcl managedAcl : AccessInformationUtil.matchAcls(acls, acl)) {
-        event.setManagedAcl(managedAcl.getName());
-      }
-      event.setAccessPolicy(AccessControlParser.toJsonSilent(acl));
-      event.setArchiveVersion(Long.parseLong(snapshot.getVersion().toString()));
-      if (StringUtils.isBlank(event.getCreator())) {
-        event.setCreator(securityService.getUser().getName());
-      }
-      EventIndexUtils.updateEvent(event, mp);
-
-      // common metadata
-      for (Catalog catalog: mp.getCatalogs(MediaPackageElements.EPISODE)) {
-        try (InputStream in = workspace.read(catalog.getURI())) {
-          EventIndexUtils.updateEvent(event, DublinCores.read(in));
-        } catch (IOException | NotFoundException e) {
-          throw new IllegalStateException(String.format("Unable to load common dublin core catalog for event '%s'",
-                  mp.getIdentifier()), e);
-        }
-      }
-
-      // extended metadata
-      event.resetExtendedMetadata();  // getting rid of old data
-      for (EventCatalogUIAdapter extendedCatalogUIAdapter : extendedEventCatalogUIAdapters.getOrDefault(organization,
-              Collections.emptyList())) {
-        for (Catalog catalog: mp.getCatalogs(extendedCatalogUIAdapter.getFlavor())) {
-          try (InputStream in = workspace.read(catalog.getURI())) {
-            EventIndexUtils.updateEventExtendedMetadata(event, DublinCores.read(in),
-                    extendedCatalogUIAdapter.getFlavor());
-          } catch (IOException | NotFoundException e) {
-            throw new IllegalStateException(String.format("Unable to load extended dublin core catalog '%s' for event "
-                            + "'%s'", catalog.getFlavor(), mp.getIdentifier()), e);
-          }
-        }
-      }
-
-      // Update series name if not already done
-      try {
-        EventIndexUtils.updateSeriesName(event, organization, user, index);
-      } catch (SearchIndexException e) {
-        logger.error("Error updating the series name of the event {} in the {} index.", eventId, index.getIndexName(),
-                e);
-      }
-      return Optional.of(event);
-    };
-
-    // Persist the scheduling event
     try {
-      index.addOrUpdateEvent(eventId, updateFunction, organization, user);
+      index.addOrUpdateEvent(eventId, updateFunction, orgId, user);
       logger.debug("Event {} updated in the {} index.", eventId, index.getIndexName());
     } catch (SearchIndexException e) {
       logger.error("Error updating the event {} in the {} index.", eventId, index.getIndexName(), e);
@@ -1001,7 +951,7 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
                       .apply(updatedEventData);
                 } else if (dataType == DataType.ACL) {
                   // Only reindex ACLs
-                  updatedEventData = getEventUpdateFunctionOnlyAcl(snapshot, orgId, snapshotSystemUser)
+                  updatedEventData = getEventUpdateFunctionOnlyAcl(snapshot, orgId)
                       .apply(updatedEventData);
                 } else {
                   throw new IndexRebuildException(dataType + " is not a supported data type. "
@@ -1616,7 +1566,7 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
       String eventId = mp.getIdentifier().toString();
       Event event = eventOpt.orElse(new Event(eventId, orgId));
 
-      event = updateAclInEvent(event, mp, eventId);
+      event = updateAclInEvent(event, mp);
 
       event.setArchiveVersion(Long.parseLong(snapshot.getVersion().toString()));
       if (StringUtils.isBlank(event.getCreator())) {
@@ -1633,6 +1583,21 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
         }
       }
 
+      // extended metadata
+      event.resetExtendedMetadata();  // getting rid of old data
+      for (EventCatalogUIAdapter extendedCatalogUIAdapter : extendedEventCatalogUIAdapters.getOrDefault(orgId,
+              Collections.emptyList())) {
+        for (Catalog catalog: mp.getCatalogs(extendedCatalogUIAdapter.getFlavor())) {
+          try (InputStream in = workspace.read(catalog.getURI())) {
+            EventIndexUtils.updateEventExtendedMetadata(event, DublinCores.read(in),
+                    extendedCatalogUIAdapter.getFlavor());
+          } catch (IOException | NotFoundException e) {
+            throw new IllegalStateException(String.format("Unable to load extended dublin core catalog '%s' for event "
+                    + "'%s'", catalog.getFlavor(), mp.getIdentifier()), e);
+          }
+        }
+      }
+
       // Update series name if not already done
       try {
         EventIndexUtils.updateSeriesName(event, orgId, user, index);
@@ -1645,19 +1610,19 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
   }
 
   private Function<Optional<Event>, Optional<Event>> getEventUpdateFunctionOnlyAcl(Snapshot snapshot,
-      String orgId, User user) {
+      String orgId) {
     return (Optional<Event> eventOpt) -> {
       MediaPackage mp = snapshot.getMediaPackage();
       String eventId = mp.getIdentifier().toString();
       Event event = eventOpt.orElse(new Event(eventId, orgId));
 
-      event = updateAclInEvent(event, mp, eventId);
+      event = updateAclInEvent(event, mp);
 
       return Optional.of(event);
     };
   }
 
-  private Event updateAclInEvent(Event event, MediaPackage mp, String eventId) {
+  private Event updateAclInEvent(Event event, MediaPackage mp) {
     AccessControlList acl = authorizationService.getActiveAcl(mp).getA();
     List<ManagedAcl> acls = aclServiceFactory.serviceFor(securityService.getOrganization()).getAcls();
 

--- a/modules/event-comment/src/main/java/org/opencastproject/event/comment/persistence/EventCommentDatabaseServiceImpl.java
+++ b/modules/event-comment/src/main/java/org/opencastproject/event/comment/persistence/EventCommentDatabaseServiceImpl.java
@@ -202,7 +202,7 @@ public class EventCommentDatabaseServiceImpl extends AbstractIndexProducer imple
         em.remove(eventOpt.get());
         return eventOpt.get();
       });
-      updateIndices(event.getEventId());
+      updateCommentsInIndex(event.getEventId());
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
@@ -240,7 +240,7 @@ public class EventCommentDatabaseServiceImpl extends AbstractIndexProducer imple
 
     // send updates only if we actually modified anything
     if (count > 0) {
-      updateIndices(eventId);
+      updateCommentsInIndex(eventId);
     }
   }
 
@@ -249,8 +249,8 @@ public class EventCommentDatabaseServiceImpl extends AbstractIndexProducer imple
     try {
       final EventCommentDto commentDto = EventCommentDto.from(comment);
       final EventComment updatedComment = db.execTx(namedQuery.persistOrUpdate(commentDto))
-          .toComment(userDirectoryService, organizationDirectoryService);
-      updateIndices(updatedComment.getEventId());
+              .toComment(userDirectoryService, organizationDirectoryService);
+      updateCommentsInIndex(updatedComment.getEventId());
       return updatedComment;
     } catch (Exception e) {
       throw new EventCommentDatabaseException(e);
@@ -335,49 +335,11 @@ public class EventCommentDatabaseServiceImpl extends AbstractIndexProducer imple
     return orgEventsMap;
   }
 
-  private void updateIndices(String eventId) throws EventCommentDatabaseException {
-    List<EventComment> comments = getComments(eventId);
-    boolean hasOpenComments = comments.stream().anyMatch(filterOpenComments::apply);
-    boolean needsCutting = comments.stream().anyMatch(filterNeedsCuttingComment::apply);
-
+  private void updateCommentsInIndex(String eventId) throws EventCommentDatabaseException {
     String organization = securityService.getOrganization().getId();
     User user = securityService.getUser();
 
-    updateIndex(eventId, !comments.isEmpty(), hasOpenComments, comments, needsCutting, organization, user);
-  }
-
-  private void updateIndex(String eventId, boolean hasComments, boolean hasOpenComments, List<EventComment> comments,
-          boolean needsCutting, String organization, User user) {
-    logger.debug("Updating comment status of event {} in the {} index.", eventId, index.getIndexName());
-    if (!hasComments && hasOpenComments) {
-      throw new IllegalStateException(
-              "Invalid comment update request: You can't have open comments without having any comments!");
-    }
-    if (!hasOpenComments && needsCutting) {
-      throw new IllegalStateException(
-              "Invalid comment update request: You can't have an needs cutting comment without having any open "
-                      + "comments!");
-    }
-
-    Function<Optional<Event>, Optional<Event>> updateFunction = (Optional<Event> eventOpt) -> {
-      if (eventOpt.isEmpty()) {
-        logger.debug("Event {} not found for comment status updating", eventId);
-        return Optional.empty();
-      }
-      Event event = eventOpt.get();
-      event.setHasComments(hasComments);
-      event.setHasOpenComments(hasOpenComments);
-      List<Comment> indexComments = new ArrayList<Comment>();
-      for (EventComment comment : comments) {
-        indexComments.add(new Comment(
-                comment.getId().get().toString(), comment.getReason(), comment.getText(), comment.isResolvedStatus()
-        ));
-        // Do we want to include replies? Maybe not, no good reason to filter for them?
-      }
-      event.setComments(indexComments);
-      event.setNeedsCutting(needsCutting);
-      return Optional.of(event);
-    };
+    Function<Optional<Event>, Optional<Event>> updateFunction = getEventUpdateFunction(eventId);
 
     try {
       index.addOrUpdateEvent(eventId, updateFunction, organization, user);
@@ -448,6 +410,7 @@ public class EventCommentDatabaseServiceImpl extends AbstractIndexProducer imple
   public IndexRebuildService.Service getService() {
     return IndexRebuildService.Service.Comments;
   }
+
   /**
    * Get the function to update a commented event in the Elasticsearch index.
    *
@@ -457,44 +420,40 @@ public class EventCommentDatabaseServiceImpl extends AbstractIndexProducer imple
    */
   private Function<Optional<Event>, Optional<Event>> getEventUpdateFunction(String eventId) {
     return (Optional<Event> eventOpt) -> {
+      if (eventOpt.isEmpty()) {
+        logger.debug("Event {} not found for comment status updating", eventId);
+        return Optional.empty();
+      }
+      Event event = eventOpt.get();
       List<EventComment> comments;
       try {
-        if (eventOpt.isEmpty()) {
-          logger.debug("Event {} not found for comment status updating", eventId);
-          return Optional.empty();
-        }
         comments = getComments(eventId);
-        Boolean hasComments = !comments.isEmpty();
-        boolean hasOpenComments = comments.stream().anyMatch(filterOpenComments::apply);
-        boolean needsCutting = comments.stream().anyMatch(filterNeedsCuttingComment::apply);
-
-        logger.debug("Updating comment status of event {} in the {} index.", eventId, index.getIndexName());
-        if (!hasComments && hasOpenComments) {
-          throw new IllegalStateException(
-                  "Invalid comment update request: You can't have open comments without having any comments!");
-        }
-        if (!hasOpenComments && needsCutting) {
-          throw new IllegalStateException(
-                  "Invalid comment update request: You can't have an needs cutting comment without having any open "
-                          + "comments!");
-        }
-        Event event = eventOpt.get();
-        event.setHasComments(hasComments);
-        event.setHasOpenComments(hasOpenComments);
-        List<Comment> indexComments = new ArrayList<Comment>();
-        for (EventComment comment : comments) {
-          indexComments.add(new Comment(
-                  comment.getId().get().toString(), comment.getReason(), comment.getText(), comment.isResolvedStatus()
-          ));
-          // Do we want to include replies? Maybe not, no good reason to filter for them?
-        }
-        event.setComments(indexComments);
-        event.setNeedsCutting(needsCutting);
-        return Optional.of(event);
       } catch (EventCommentDatabaseException e) {
         logger.error("Unable to get comments from event {}", eventId, e);
         return Optional.empty();
       }
+      boolean hasComments = !comments.isEmpty();
+      boolean hasOpenComments = comments.stream().anyMatch(filterOpenComments::apply);
+      boolean needsCutting = comments.stream().anyMatch(filterNeedsCuttingComment::apply);
+
+      logger.debug("Updating comment status of event {} in the {} index.", eventId, index.getIndexName());
+      if (!hasOpenComments && needsCutting) {
+        throw new IllegalStateException(
+                "Invalid comment update request: You can't have an needs cutting comment without having any open "
+                        + "comments!");
+      }
+
+      event.setHasComments(hasComments);
+      event.setHasOpenComments(hasOpenComments);
+      List<Comment> indexComments = new ArrayList<Comment>();
+      for (EventComment comment : comments) {
+        indexComments.add(new Comment(comment.getId().get().toString(), comment.getReason(), comment.getText(),
+                comment.isResolvedStatus()));
+        // Do we want to include replies? Maybe not, no good reason to filter for them?
+      }
+      event.setComments(indexComments);
+      event.setNeedsCutting(needsCutting);
+      return Optional.of(event);
     };
   }
 }

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -1407,7 +1407,6 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
    * Update the event in the Elasticsearch index. Fields will only be updated of the corresponding Opt is not none.
    *
    * @param mediaPackageId
-   * @param index
    * @param acl
    * @param dublinCore
    * @param startTime
@@ -1424,48 +1423,8 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
     String organization = getSecurityService().getOrganization().getId();
     User user = getSecurityService().getUser();
 
-    Function<Optional<Event>, Optional<Event>> updateFunction = (Optional<Event> eventOpt) -> {
-      Event event = eventOpt.orElse(new Event(mediaPackageId, organization));
-
-      if (acl.isPresent()) {
-        event.setAccessPolicy(AccessControlParser.toJsonSilent(acl.get()));
-      }
-      if (dublinCore.isPresent()) {
-        EventIndexUtils.updateEvent(event, dublinCore.get());
-        if (isBlank(event.getCreator()))
-          event.setCreator(getSecurityService().getUser().getName());
-
-        // Update series name if not already done
-        try {
-          EventIndexUtils.updateSeriesName(event, organization, user, index);
-        } catch (SearchIndexException e) {
-          logger.error("Error updating the series name of the event {} in the {} index.", mediaPackageId,
-                  index.getIndexName(), e);
-        }
-      }
-      if (presenters.isPresent()) {
-        event.setTechnicalPresenters(new ArrayList<>(presenters.get()));
-      }
-      if (agentId.isPresent()) {
-        event.setAgentId(agentId.get());
-      }
-      if (recordingStatus.isPresent() && !recordingStatus.get().equals(RecordingState.UNKNOWN)) {
-        event.setRecordingStatus(recordingStatus.get());
-      }
-      if (properties.isPresent()) {
-        event.setAgentConfiguration(properties.get());
-      }
-      if (startTime.isPresent()) {
-        String startTimeStr = startTime == null ? null : DateTimeSupport.toUTC(startTime.get().getTime());
-        event.setTechnicalStartTime(startTimeStr);
-      }
-      if (endTime.isPresent()) {
-        String endTimeStr = endTime == null ? null : DateTimeSupport.toUTC(endTime.get().getTime());
-        event.setTechnicalEndTime(endTimeStr);
-      }
-
-      return Optional.of(event);
-    };
+    Function<Optional<Event>, Optional<Event>> updateFunction = getEventUpdateFunction(mediaPackageId, acl, dublinCore,
+            startTime, endTime, presenters, agentId, properties, recordingStatus, organization, user);
 
     try {
       index.addOrUpdateEvent(mediaPackageId, updateFunction, organization, user);
@@ -1479,7 +1438,6 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
    * Set recording status to null for this event in the Elasticsearch index.
    *
    * @param mediaPackageId
-   * @param index
    */
   private void removeRecordingStatusFromIndex(String mediaPackageId) {
     String organization = getSecurityService().getOrganization().getId();
@@ -1504,7 +1462,6 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
    * Remove scheduling information for this event from the Elasticsearch index.
    *
    * @param mediaPackageId
-   * @param index
    */
   private void removeSchedulingInfoFromIndex(String mediaPackageId) {
     String orgId = getSecurityService().getOrganization().getId();
@@ -1736,8 +1693,17 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
                       current[0]++;
 
                       var updatedEventData = Optional.of(new Event(event.getMediaPackageId(), organization.getId()));
-                      updatedEventData = getEventUpdateFunction(event, organization.getId(),
-                                  securityService.getUser()).apply(updatedEventData);
+
+                      final Set<String> presenters = getPresenters(
+                              Optional.ofNullable(event.getPresenters()).orElse(""));
+                      final Map<String, String> caMetadata = deserializeExtendedEventProperties(
+                              event.getCaptureAgentProperties());
+
+                      updatedEventData = getEventUpdateFunction(event.getMediaPackageId(), Optional.empty(), Optional.empty(),
+                              Optional.of(event.getStartDate()), Optional.of(event.getEndDate()), Optional.of(presenters),
+                              Optional.of(event.getCaptureAgentId()), Optional.of(caMetadata),
+                              Optional.ofNullable(event.getRecordingState()), organization.getId(),
+                              securityService.getUser()).apply(updatedEventData);
                       updatedEventRange.add(updatedEventData.get());
 
                       if (updatedEventRange.size() >= n || current[0] >= events.size()) {
@@ -1745,6 +1711,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
                         logIndexRebuildProgress(logger, total, current[0], n);
                         updatedEventRange.clear();
                       }
+
                     } catch (SearchIndexException e) {
                       logger.error("Error while updating event '{}' from search index:", event.getMediaPackageId(), e);
                     } catch (Exception e) {
@@ -1767,37 +1734,20 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
   public SecurityService getSecurityService() {
     return securityService;
   }
+
   /**
    * Get the function to update a scheduled event in the Elasticsearch index.
    *
-   * @param scheduledEvent
-   *          The theme to update
-   * @param orgId
-   *          The id of the current organization
-   * @param user
-   *          The user
+   * @param orgId          The id of the current organization
+   * @param user           The user
    * @return the function to do the update
    */
-  private Function<Optional<Event>, Optional<Event>> getEventUpdateFunction(ExtendedEventDto scheduledEvent,
-          String orgId, User user) {
+  private Function<Optional<Event>, Optional<Event>> getEventUpdateFunction(String mediaPackageId,
+          Optional<AccessControlList> acl, Optional<DublinCoreCatalog> dublinCore, Optional<Date> startTime,
+          Optional<Date> endTime, Optional<Set<String>> presenters, Optional<String> agentId,
+          Optional<Map<String, String>> properties, Optional<String> recordingStatus, String orgId, User user) {
     return (Optional<Event> eventOpt) -> {
-      Event event = eventOpt.orElse(new Event(scheduledEvent.getMediaPackageId(), orgId));
-      final Set<String> presenters = getPresenters(Optional.ofNullable(scheduledEvent.getPresenters()).orElse(""));
-      final Map<String, String> caMetadata = deserializeExtendedEventProperties(scheduledEvent.
-              getCaptureAgentProperties());
-      AQueryBuilder query = assetManager.createQuery();
-      final AResult result = query.select(query.snapshot())
-              .where(query.mediaPackageId(scheduledEvent.getMediaPackageId()).and(query.version().isLatest())).run();
-      final Snapshot snapshot = result.getRecords().stream().findFirst().get().getSnapshot().get();
-
-      Optional<AccessControlList> acl = Optional.of(authorizationService.getActiveAcl(snapshot.getMediaPackage()).getA());
-      Optional<DublinCoreCatalog> dublinCore = loadEpisodeDublinCoreFromAsset(snapshot);
-      Optional<Date> startTime = Optional.of(scheduledEvent.getStartDate());
-      Optional<Date> endTime = Optional.of(scheduledEvent.getEndDate());
-      Optional<Set<String>> presentersOpt = Optional.of(presenters);
-      Optional<String> agentId = Optional.of(scheduledEvent.getCaptureAgentId());
-      Optional<Map<String, String>> properties = Optional.of(caMetadata);
-      Optional<String> recordingStatus = Optional.ofNullable(scheduledEvent.getRecordingState());
+      Event event = eventOpt.orElse(new Event(mediaPackageId, orgId));
 
       if (acl.isPresent()) {
         event.setAccessPolicy(AccessControlParser.toJsonSilent(acl.get()));
@@ -1811,12 +1761,12 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
         try {
           EventIndexUtils.updateSeriesName(event, orgId, user, index);
         } catch (SearchIndexException e) {
-          logger.error("Error updating the series name of the event {} in the {} index.",
-                  scheduledEvent.getMediaPackageId(), index.getIndexName(), e);
+          logger.error("Error updating the series name of the event {} in the {} index.", mediaPackageId,
+                  index.getIndexName(), e);
         }
       }
-      if (presentersOpt.isPresent()) {
-        event.setTechnicalPresenters(new ArrayList<>(presentersOpt.get()));
+      if (presenters.isPresent()) {
+        event.setTechnicalPresenters(new ArrayList<>(presenters.get()));
       }
       if (agentId.isPresent()) {
         event.setAgentId(agentId.get());

--- a/modules/themes/src/main/java/org/opencastproject/themes/persistence/ThemesServiceDatabaseImpl.java
+++ b/modules/themes/src/main/java/org/opencastproject/themes/persistence/ThemesServiceDatabaseImpl.java
@@ -365,49 +365,20 @@ public class ThemesServiceDatabaseImpl extends AbstractIndexProducer implements 
    *           the organization the theme belongs to
    * @param user
    */
-  private void updateThemeInIndex(Theme theme, String orgId,
-          User user) {
+  private void updateThemeInIndex(Theme theme, String orgId, User user) {
     logger.debug("Updating the theme with id '{}', name '{}', description '{}', organization '{}' in the {} index.",
             theme.getId(), theme.getName(), theme.getDescription(),
             orgId, index.getIndexName());
+    if (theme.getId().isNone()) {
+      throw new IllegalArgumentException("Can't put theme in index without valid id!");
+    }
+    Long id = theme.getId().get();
     try {
-      if (theme.getId().isNone()) {
-        throw new IllegalArgumentException("Can't put theme in index without valid id!");
-      }
-      Long id = theme.getId().get();
-
-      // the function to do the actual updating
-      Function<Optional<IndexTheme>, Optional<IndexTheme>> updateFunction = (Optional<IndexTheme> indexThemeOpt) -> {
-        IndexTheme indexTheme;
-        indexTheme = indexThemeOpt.orElseGet(() -> new IndexTheme(id, orgId));
-        String creator = StringUtils.isNotBlank(theme.getCreator().getName())
-                ? theme.getCreator().getName() : theme.getCreator().getUsername();
-
-        indexTheme.setCreationDate(theme.getCreationDate());
-        indexTheme.setDefault(theme.isDefault());
-        indexTheme.setName(theme.getName());
-        indexTheme.setDescription(theme.getDescription());
-        indexTheme.setCreator(creator);
-        indexTheme.setBumperActive(theme.isBumperActive());
-        indexTheme.setBumperFile(theme.getBumperFile());
-        indexTheme.setTrailerActive(theme.isTrailerActive());
-        indexTheme.setTrailerFile(theme.getTrailerFile());
-        indexTheme.setTitleSlideActive(theme.isTitleSlideActive());
-        indexTheme.setTitleSlideBackground(theme.getTitleSlideBackground());
-        indexTheme.setTitleSlideMetadata(theme.getTitleSlideMetadata());
-        indexTheme.setLicenseSlideActive(theme.isLicenseSlideActive());
-        indexTheme.setLicenseSlideBackground(theme.getLicenseSlideBackground());
-        indexTheme.setLicenseSlideDescription(theme.getLicenseSlideDescription());
-        indexTheme.setWatermarkActive(theme.isWatermarkActive());
-        indexTheme.setWatermarkFile(theme.getWatermarkFile());
-        indexTheme.setWatermarkPosition(theme.getWatermarkPosition());
-        return Optional.of(indexTheme);
-      };
-
+      Function<Optional<IndexTheme>, Optional<IndexTheme>> updateFunction = getThemeUpdateFunction(theme, orgId);
       index.addOrUpdateTheme(id, updateFunction, orgId, user);
-      logger.debug("Updated the theme {} in the {} index", theme.getId(), index.getIndexName());
+      logger.debug("Updated the theme {} in the {} index", id, index.getIndexName());
     } catch (SearchIndexException e) {
-      logger.error("Error updating the theme {} in the {} index", theme.getId(), index.getIndexName(), e);
+      logger.error("Error updating the theme {} in the {} index", id, index.getIndexName(), e);
     }
   }
   /**
@@ -421,8 +392,7 @@ public class ThemesServiceDatabaseImpl extends AbstractIndexProducer implements 
    */
   private Function<Optional<IndexTheme>, Optional<IndexTheme>> getThemeUpdateFunction(Theme theme, String orgId) {
     return (Optional<IndexTheme> indexThemeOpt) -> {
-      IndexTheme indexTheme;
-      indexTheme = indexThemeOpt.orElseGet(() -> new IndexTheme(theme.getId().get(), orgId));
+      IndexTheme indexTheme = indexThemeOpt.orElseGet(() -> new IndexTheme(theme.getId().get(), orgId));
       String creator = theme.getCreator() == null ? "?" : (
           StringUtils.isNotBlank(theme.getCreator().getName())
               ? theme.getCreator().getName()

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowIndexData.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowIndexData.java
@@ -40,7 +40,8 @@ import javax.persistence.Table;
 @NamedNativeQueries({
         @NamedNativeQuery(
                 name = "WorkflowIndexData.getAll",
-                query = "SELECT id, state, mediapackage_id, organization_id FROM oc_workflow ORDER BY mediapackage_id, id DESC",
+                query = "SELECT id, state, mediapackage_id, organization_id, template FROM oc_workflow "
+                        + "ORDER BY mediapackage_id, id DESC",
                 resultSetMapping = "DataResult"
         ),
 })
@@ -53,7 +54,8 @@ import javax.persistence.Table;
                                   @FieldResult(name = "id",column = "id"),
                                   @FieldResult(name = "state", column = "state"),
                                   @FieldResult(name = "mediaPackageId", column = "mediapackage_id"),
-                                  @FieldResult(name = "organizationId", column = "organization_id")
+                                  @FieldResult(name = "organizationId", column = "organization_id"),
+                                  @FieldResult(name = "template", column = "template")
                         }
                 )
 })
@@ -70,6 +72,9 @@ public class WorkflowIndexData {
   @Column(name = "organization_id") //NB: This column definition needs to match WorkflowInstance!
   private String organizationId;
 
+  @Column(name = "template") //NB: This column definition needs to match WorkflowInstance!
+  private String template;
+
 
   /**
    * Default constructor without any import.
@@ -78,11 +83,12 @@ public class WorkflowIndexData {
 
   }
 
-  public WorkflowIndexData(Long id, int state, String mediaPackageId, String organizationId) {
+  public WorkflowIndexData(Long id, int state, String mediaPackageId, String organizationId, String template) {
     this.id = id;
     this.state = state;
     this.mediaPackageId = mediaPackageId;
     this.organizationId = organizationId;
+    this.template = template;
   }
 
   public Long getId() {
@@ -99,6 +105,10 @@ public class WorkflowIndexData {
 
   public String getOrganizationId() {
     return organizationId;
+  }
+
+  public String getTemplate() {
+    return template;
   }
 
 }

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -2240,7 +2240,9 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
                   }
                 }
                 var updatedWorkflowData = index.getEvent(indexData.getMediaPackageId(), orgid, securityService.getUser());
-                updatedWorkflowData = getStateUpdateFunction(indexData).apply(updatedWorkflowData);
+                updatedWorkflowData = getStateUpdateFunction(indexData.getId(),indexData.getState(),
+                        indexData.getMediaPackageId(), indexData.getTemplate(), indexData.getOrganizationId())
+                        .apply(updatedWorkflowData);
                 updatedWorkflowRange.add(updatedWorkflowData.get());
 
                 if (updatedWorkflowRange.size() >= n || current >= total) {
@@ -2274,8 +2276,6 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
    *
    * @param workflowInstanceId
    *         the identifier of the workflow instance to remove
-   * @param index
-   *         the index to update
    */
   private void removeWorkflowInstanceFromIndex(long workflowInstanceId) {
     final String orgId = securityService.getOrganization().getId();
@@ -2345,18 +2345,11 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
    *         workflow organization id
    */
   private void updateWorkflowInstanceInIndex(long id, int state, String wfDefId, String mpId, String orgId) {
-    final WorkflowState workflowState = WorkflowState.values()[state];
     final User user = securityService.getUser();
 
     logger.debug("Updating workflow instance {} of event {} in the {} index.", id, mpId,
             index.getIndexName());
-    Function<Optional<Event>, Optional<Event>> updateFunction = (Optional<Event> eventOpt) -> {
-      Event event = eventOpt.orElse(new Event(mpId, orgId));
-      event.setWorkflowId(id);
-      event.setWorkflowState(workflowState);
-      event.setWorkflowDefinitionId(wfDefId);
-      return Optional.of(event);
-    };
+    Function<Optional<Event>, Optional<Event>> updateFunction = getStateUpdateFunction(id, state, wfDefId, mpId, orgId);
 
     try {
       index.addOrUpdateEvent(mpId, updateFunction, orgId, user);
@@ -2371,15 +2364,16 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
   /**
    * Get the function to update the workflow state for an event in the Elasticsearch index.
    *
-   * @param wfData
-   *          The workflow index data package
    * @return the function to do the update
    */
-  private Function<Optional<Event>, Optional<Event>> getStateUpdateFunction(WorkflowIndexData wfData) {
+  private Function<Optional<Event>, Optional<Event>> getStateUpdateFunction(long workflowId,
+          int workflowState, String workflowDefinitionId, String mediaPackageId,
+          String orgId) {
     return (Optional<Event> eventOpt) -> {
-      Event event = eventOpt.orElse(new Event(wfData.getMediaPackageId(), wfData.getOrganizationId()));
-      event.setWorkflowId(wfData.getId());
-      event.setWorkflowState(WorkflowState.values()[wfData.getState()]);
+      Event event = eventOpt.orElse(new Event(mediaPackageId, orgId));
+      event.setWorkflowId(workflowId);
+      event.setWorkflowState(WorkflowState.values()[workflowState]);
+      event.setWorkflowDefinitionId(workflowDefinitionId);
       return Optional.of(event);
     };
   }


### PR DESCRIPTION
This was initially just trying to fix #3274 for events which was broken by #4120. But the longer I looked at the code the more I found. So this now does the following:

- Remove code duplication that was introduced by #4120 by merging the methods responsible for updating objects in the index for pretty much all relevant services
- As a result, the AssetManager now indexes extended metadata during the index rebuild again
- Inadvertently, this also fixes two other instances where the code had diverged:
  - The Workflow Service now also indexes the workflow definition during the index rebuild
  - A small patch by Lars from last year had only been applied to one method in the Comments Service
- In the Scheduler Service, I removed the request to the Asset Manager during the index rebuild. In my opinion, this is unnecessary since the Scheduler should only re-index the data it's responsible for and leave the rest to the Asset Manager. This should improve performance as we no longer need to read the catalogs from disk. However, this might be controversial.
-  Very minor code cleanup for stuff that was flagged by Intellij.

I did my best to provide a clear commit history for easier review. I'm uncertain what we should aim this at because it's a little more than a bug fix now. Opinions?

Also, short rant at the end:

In my opinion, #4120 _should not have been merged_ like this. The idea was good but the implementation is subpar. In addition to these issues (and the ones that have been already fixed in the meantime, like #5150 ), we no longer do locking during the index rebuild, which is not a problem when the system is idle, but could lead to lost updates when it is not. But I didn't want to spend more time than reasonable on this since things will most likely change because of the new data model anyway. Really, I just wanted to index extended metadata :sob: 

:warning: **I thought a great deal about this, but I didn't have time to test this yet before my vacation!**
