### PR TITLE
Fix maven central publication

### DIFF
--- a/modules/db/pom.xml
+++ b/modules/db/pom.xml
@@ -98,6 +98,18 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <detectJavaApiLink>true</detectJavaApiLink>
+          <maxmemory>512m</maxmemory>
+          <quiet>false</quiet>
+          <!-- This is required to work around checker-qual's changes, which munge the javadoc options file
+                and lead to very misleading errors about not finding classes in the org.osgi.framework.* namespace -->
+          <sourcepath>src/main/java</sourcepath>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <extensions>true</extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -477,14 +477,14 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.13</version>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.8.0</version>
         <extensions>true</extensions>
         <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>false</autoReleaseAfterClose>
+          <publishingServerId>central</publishingServerId>
+          <autoPublish>true</autoPublish>
+          <waitUntil>published</waitUntil>
         </configuration>
       </plugin>
     </plugins>
@@ -1519,11 +1519,6 @@
   </reporting>
   <repositories>
     <repository>
-      <id>central</id>
-      <name>Central Maven Repository</name>
-      <url>https://repo.maven.apache.org/maven2/</url>
-    </repository>
-    <repository>
       <id>mvn.opencast.org</id>
       <name>Opencast 3rd-Party Repository</name>
       <url>https://mvn.opencast.org/</url>
@@ -1536,14 +1531,6 @@
     </repository>
   </repositories>
   <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
     <site>
       <!-- Note that we do not deploy the site using maven, so this is totally fake -->
       <id>fakesite.opencast.org</id>


### PR DESCRIPTION
This PR updates the our maven central publication modules to the new standard.  This should fix maven central release publication since the previous method EOL'd at the end of June 2025.  This has no bearing on our tarball releases, this is for things like the annotation tool.

This PR includes, and depends on https://github.com/opencast/opencast/pull/6980.  This should land in `r/17.x` since we still have releases in that branch and they won't publish without this.

### How to test this patch

`./mvnw deploy -P release` should fail with a 403 since you don't have credentials.

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [X] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
