### PR TITLE
Split whispercpp args

### DIFF
--- a/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/WhisperCppEngine.java
+++ b/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/WhisperCppEngine.java
@@ -276,7 +276,7 @@ public class WhisperCppEngine implements SpeechToTextEngine {
       logger.debug("WhisperC++ no fallback set to {}", whispercppNoFallback);
     }
 
-    whispercppArgs = StringUtils.split(Objects.toString(cc.getProperties().get(WHISPERCPP_ARGS_CONFIG_KEY), ""));
+    whispercppArgs = StringUtils.split(Objects.toString(cc.getProperties().get(WHISPERCPP_ARGS_CONFIG_KEY), ""), " ");
     logger.debug("Additional args for WhisperC++: {}", (Object) whispercppArgs);
 
     autoEncode = BooleanUtils.toBoolean(Objects.toString(

--- a/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/WhisperCppEngine.java
+++ b/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/WhisperCppEngine.java
@@ -276,7 +276,7 @@ public class WhisperCppEngine implements SpeechToTextEngine {
       logger.debug("WhisperC++ no fallback set to {}", whispercppNoFallback);
     }
 
-    whispercppArgs = StringUtils.split(Objects.toString(cc.getProperties().get(WHISPERCPP_ARGS_CONFIG_KEY), ""), " ");
+    whispercppArgs = Objects.toString(cc.getProperties().get(WHISPERCPP_ARGS_CONFIG_KEY), "").trim().split("\\s+");
     logger.debug("Additional args for WhisperC++: {}", (Object) whispercppArgs);
 
     autoEncode = BooleanUtils.toBoolean(Objects.toString(

--- a/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/WhisperEngine.java
+++ b/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/WhisperEngine.java
@@ -28,7 +28,6 @@ import org.opencastproject.util.OsgiUtil;
 import org.opencastproject.util.data.Option;
 
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.osgi.service.component.ComponentContext;
@@ -123,7 +122,7 @@ public class WhisperEngine implements SpeechToTextEngine {
     isVADEnabled = OsgiUtil.getOptCfgAsBoolean(prop, WHISPER_VAD);
     logger.debug("Whisper Voice Activity Detection set to {}", isVADEnabled.getOrElse(false));
 
-    whisperArgs = StringUtils.split(Objects.toString(prop.get(WHISPER_ARGS_CONFIG_KEY), ""));
+    whisperArgs = Objects.toString(prop.get(WHISPER_ARGS_CONFIG_KEY), "").trim().split("\\s+");
     logger.debug("Additional args for Whisper: {}", (Object) whisperArgs);
 
     logger.debug("Finished activating/updating speech-to-text service");


### PR DESCRIPTION
This PR adds string splitting to the extra args for whispercpp, as identified as a defect in #6966 after I merged it.  This is needed to properly handle multiple arguments being passed.

This should go into 17 since the original PR also went into 17!

### How to test this patch


Test with multiple arguments

<!--
Explain how to test this patch. If this requires a particular set-up or configuration, explain that as well and provide
the necessary configuration if possible. The easier it is for others to test the patch, the faster this will get
reviewed and merged.
-->


### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
