### PR TITLE
Update r/17.x Admin UI to 17.x-2025-08-29

### DIFF
--- a/modules/admin-ui-interface/pom.xml
+++ b/modules/admin-ui-interface/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <interface.url>https://github.com/opencast/opencast-admin-interface/releases/download/17.x-2025-07-24/oc-admin-ui-17.x-2025-07-24.tar.gz</interface.url>
-    <interface.sha256>4676f18b7177c5a30070d1cdc09b40bd6ba4a026b1b4cf1b9744879b9c516af4</interface.sha256>
+    <interface.url>https://github.com/opencast/opencast-admin-interface/releases/download/17.x-2025-08-29/oc-admin-ui-17.x-2025-08-29.tar.gz</interface.url>
+    <interface.sha256>b16b71589bd8732db49b2f86a7500ee95f89df5c18af78102d8ebf83b434a513</interface.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
Updating Opencast r/17.x Admin UI module to [17.x-2025-08-29](https://github.com/opencast/opencast-admin-interface/releases/tag/17.x-2025-08-29)