### PR TITLE
Update r/18.x Editor to 18.x-2025-08-29

### DIFF
--- a/modules/editor/pom.xml
+++ b/modules/editor/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <editor.url>https://github.com/opencast/opencast-editor/releases/download/18.x-2025-07-23/oc-editor-18.x-2025-07-23.tar.gz</editor.url>
-    <editor.sha256>44a1059adb47955d9f0e5054ee03b45c4e420ab4299cbed4b7f990adfb6725c9</editor.sha256>
+    <editor.url>https://github.com/opencast/opencast-editor/releases/download/18.x-2025-08-29/oc-editor-18.x-2025-08-29.tar.gz</editor.url>
+    <editor.sha256>2035c25c5bbc89086de8cf4796bba3199e59918a7b4524d7d91a8900a85f607b</editor.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
Updating Opencast r/18.x Editor module to [18.x-2025-08-29](https://github.com/opencast/opencast-editor/releases/tag/18.x-2025-08-29)