### PR TITLE
Ensure mvnw is used in our github actions workflows

### DIFF
--- a/.github/make-release
+++ b/.github/make-release
@@ -21,10 +21,10 @@ VERSION="${MAJOR}.${MINOR}"
 git status | grep modified: && exit 1
 
 # update pom.xml versions
-mvn versions:set -DnewVersion="${VERSION}" versions:commit
+./mvnw versions:set -DnewVersion="${VERSION}" versions:commit
 
 # build opencast
-mvn clean install \
+./mvnw clean install \
   -Pdev \
   -DskipTests \
   -Dcheckstyle.skip=true \

--- a/.github/workflows/build-maven-cache.yml
+++ b/.github/workflows/build-maven-cache.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: build opencast
         run: |
-          mvn clean install -Pdev \
+          ./mvnw clean install -Pdev \
             --batch-mode \
             -Dsurefire.rerunFailingTestsCount=2 \
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: build opencast
         run: |
-          mvn clean install \
+          ./mvnw clean install \
             --batch-mode \
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
             -Dhttp.keepAlive=false \

--- a/.github/workflows/ensure-mvnw.yml
+++ b/.github/workflows/ensure-mvnw.yml
@@ -1,0 +1,26 @@
+name: Ensure mvnw and not mvn
+
+on:
+  pull_request:
+    paths:
+      - '.github/**'
+      - 'mvnw'
+      - '.mvn/**'
+  push:
+    paths:
+      - '.github/**'
+      - 'mvnw'
+      - '.mvn/**'
+
+jobs:
+  mvn-check:
+    name: Ensure mvn isn't being used
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: check mvn isn't being used
+        run: |
+          if [ -n "$(grep -R 'mvn ' .github | grep -v 'name:')" ]; then
+            exit 1
+          fi

--- a/.github/workflows/test-opencast-build.yml
+++ b/.github/workflows/test-opencast-build.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: build opencast
         run: |
-          ../mvnw clean install -Pnone -T1C \
+          ./mvnw clean install -Pnone -T1C \
             --batch-mode \
             -Dsurefire.rerunFailingTestsCount=2 \
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \

--- a/.github/workflows/test-opencast-build.yml
+++ b/.github/workflows/test-opencast-build.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: build opencast
         run: |
-          ./mvn clean install -Pnone -T1C \
+          ../mvnw clean install -Pnone -T1C \
             --batch-mode \
             -Dsurefire.rerunFailingTestsCount=2 \
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \


### PR DESCRIPTION
This PR ensures we are using mvnw in our workflows, just in case the system provided version of mvn ever drifts from what we're expecting.  It does this by replacing all of the calls to `mvn` with `mvnw`, and adding a CI check to make sure no further instances show up later.

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] ~explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch~
