### PR TITLE
Fix 17.x site build

### DIFF
--- a/.github/workflows/test-opencast-site.yml
+++ b/.github/workflows/test-opencast-site.yml
@@ -67,17 +67,27 @@ jobs:
         run: |
           .github/check-jacoco-deps.sh
 
+      - name: build opencast, skipping tests which run during site
+        run: |
+          ./mvnw install -DskipTests -T1C -Pnone \
+            --batch-mode \
+            -Dsurefire.rerunFailingTestsCount=2 \
+            -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+            -Dhttp.keepAlive=false \
+            -Dmaven.wagon.http.pool=false \
+            -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+
         #This has to happen in a separate step or else various service classes aren't visible
       - name: build maven site
         run: |
-          mvn site -T1C -Pnone \
+          ./mvnw site -T1C -Pnone \
             --batch-mode \
             -Dsurefire.rerunFailingTestsCount=2 \
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
             -Dhttp.keepAlive=false \
             -Dmaven.wagon.http.pool=false \
             -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 && \
-          mvn site:stage -Pnone
+          ./mvnw site:stage -Pnone
 
       - name: Save site build
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test-opencast-site.yml
+++ b/.github/workflows/test-opencast-site.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           ./mvnw install -DskipTests -T1C -Pnone \
             --batch-mode \
-            -Dsurefire.rerunFailingTestsCount=2 \
+            -Dcheckstyle.skip=true \
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
             -Dhttp.keepAlive=false \
             -Dmaven.wagon.http.pool=false \


### PR DESCRIPTION
The site plugin requires install to have run, lest it be unable to find
artifacts.  This makes sense since install is what actually puts them
into your repo.  The catch here is that install + site in the same build
hits issues with checkerqual, which conflicts with site.  The solution
is a two pass approach, which avoids the conflict.

We deliberately disabled the first build-only test pass since we don't care
about the results of the tests *and* we still run the tests in the site
pass.  If we don't build the tests during the site pass we don't get the
code coverage metrics that we're after with the site build in the first
place.

This should go into 17 since this has broken the build in 17, and having
coverage data for 17 would be useful.

### Your pull request should…

* [x] have a concise title
* [x] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
