### PR TITLE
WIP: Disable keyboard shortcuts in Paella 7 transcription search

### DIFF
--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.transcriptionsPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.transcriptionsPlugin.js
@@ -115,6 +115,7 @@ export default class TranscriptionsPlugin extends PopUpButtonPlugin {
     searchContainer.addEventListener('click', evt => evt.stopPropagation());
     searchContainer.addEventListener('keyup', evt => {
       this.rebuildList(evt.target.value);
+      evt.stopPropagation();
     });
     const transcriptionsContainer = createElementWithHtmlText(`
         <ul class="transcriptions-list"></ul>`, container);


### PR DESCRIPTION
Use `stopPropagation()` when searching for slide text in the Paella 7 Transcriptions Plugin, so key events do not bubble and trigger general keyboard shortcuts like f for fullscreeen.

Resolves #7044

<!--
Explain what this pull request does.  If this fixes a bug, also explain how to reproduce the issue.
-->

<!--
If your pull request is targeting the legacy (second oldest release branch), explain why this patch is so important that
it needs to go into the legacy and can not go just into stable or develop.
-->

### How to test this patch

<!--
Explain how to test this patch. If this requires a particular set-up or configuration, explain that as well and provide
the necessary configuration if possible. The easier it is for others to test the patch, the faster this will get
reviewed and merged.
-->


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
