### PR TITLE
Switch to static reference

### DIFF
--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/ElasticsearchIndex.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/ElasticsearchIndex.java
@@ -53,9 +53,6 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicy;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -116,11 +113,7 @@ public class ElasticsearchIndex extends AbstractElasticsearchIndex {
 
   private ListProvidersService listProvidersService;
 
-  @Reference(
-      cardinality = ReferenceCardinality.OPTIONAL,
-      policy = ReferencePolicy.DYNAMIC,
-      policyOption = ReferencePolicyOption.GREEDY
-  )
+  @Reference
   public void setListProvidersService(ListProvidersService listProvidersService) {
     this.listProvidersService = listProvidersService;
   }


### PR DESCRIPTION
Using dynamic references is usually not a good idea unless you really need them since the service you reference can potentially not exist which means your reference is `null`. That's something you have to check everywhere.

Opencast clearly doesn't do that, resulting in errors like this:

```
2025-09-11T06:21:19,711 | WARN  | (IngestRestService:926) - Unable to add mediapackage
java.lang.NullPointerException: Cannot invoke "org.opencastproject.list.api.ListProvidersService.hasProvider(String)" because "listProvidersService" is null
        at org.opencastproject.elasticsearch.index.objects.event.EventIndexUtils.addAuthorization(EventIndexUtils.java:393) ~[?:?]
        at org.opencastproject.elasticsearch.index.objects.event.EventIndexUtils.toSearchMetadata(EventIndexUtils.java:249) ~[?:?]
        at org.opencastproject.elasticsearch.index.ElasticsearchIndex.update(ElasticsearchIndex.java:370) ~[?:?]
        at org.opencastproject.elasticsearch.index.ElasticsearchIndex.addOrUpdateEvent(ElasticsearchIndex.java:348) ~[?:?]
        at org.opencastproject.assetmanager.impl.AssetManagerImpl.updateEventInIndex(AssetManagerImpl.java:585) ~[?:?]
        at org.opencastproject.assetmanager.impl.AssetManagerImpl.takeSnapshot(AssetManagerImpl.java:441) ~[?:?]
        at org.opencastproject.assetmanager.util.WorkflowPropertiesUtil.storeProperties(WorkflowPropertiesUtil.java:118) ~[?:?]
        at org.opencastproject.workflow.impl.WorkflowServiceImpl.start(WorkflowServiceImpl.java:502) ~[?:?]
        at org.opencastproject.workflow.impl.WorkflowServiceImpl.start(WorkflowServiceImpl.java:477) ~[?:?]
        at org.opencastproject.ingest.impl.IngestServiceImpl.ingest(IngestServiceImpl.java:1287) ~[?:?]
        at org.opencastproject.ingest.impl.IngestServiceImpl.ingest(IngestServiceImpl.java:1217) ~[?:?]
        at org.opencastproject.ingest.endpoint.IngestRestService.addMediaPackage(IngestRestService.java:917) ~[?:?]
        …
```

Looking into this, it seems like this dynamic reference isn't actually necessary. Therefor, let's turn this into a static reference.

### How to test this patch

If this wouldn't work, you should see an error in the Opencast logs at startup. For more details, you can also take a look at the services in the Karaf console.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
