### PR TITLE
Simplify metadata editor by removing some data by default

### DIFF
--- a/etc/ui-config/mh_default_org/editor/editor-settings.toml
+++ b/etc/ui-config/mh_default_org/editor/editor-settings.toml
@@ -66,6 +66,21 @@
 #
 # # This catalog is specified but empty, and as such will not be displayed
 # [metadata.configureFields."NameOfAnExtendedMetadataCatalog"]
+#
+# We disable some metadata by default.
+# Remove or comment out the following block to show all metadata:
+#
+[metadata.configureFields."EVENTS.EVENTS.DETAILS.CATALOG.EPISODE"]
+subject = {show = false}
+rightsHolder = {show = false}
+location = {show = false}
+source = {show = false}
+duration = {show = false}
+publisher = {show = false}
+created = {show = false}
+license = {show = false}
+contributor = {show = false}
+identifier = {show = false}
 
 
 ####


### PR DESCRIPTION
The editor should be simple, but the mass of metadata is quite complex. This patch updates the default configuration for the editor to removes a number of less-used metadata by defaukt:

This fixes https://github.com/opencast/opencast-editor/issues/1635

### How to test this patch

Apply patch and open the metadata editor


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
