### PR TITLE
Update r/18.x Admin UI to 18.x-2025-09-16

### DIFF
--- a/modules/admin-ui-interface/pom.xml
+++ b/modules/admin-ui-interface/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <interface.url>https://github.com/opencast/opencast-admin-interface/releases/download/18.x-2025-08-29/oc-admin-ui-18.x-2025-08-29.tar.gz</interface.url>
-    <interface.sha256>ae67cdc583679c7e0b745b14d9683182d7716ae920e3e318010493ff6cfb859d</interface.sha256>
+    <interface.url>https://github.com/opencast/opencast-admin-interface/releases/download/18.x-2025-09-16/oc-admin-ui-18.x-2025-09-16.tar.gz</interface.url>
+    <interface.sha256>2112bec44a98581f770719f8f0ede7c4b766959611ed31e3e58a5ec08a48ce03</interface.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
Updating Opencast r/18.x Admin UI module to [18.x-2025-09-16](https://github.com/opencast/opencast-admin-interface/releases/tag/18.x-2025-09-16)