### PR TITLE
Fix paella download plugins.

### DIFF
--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.downloadsPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.downloadsPlugin.js
@@ -164,9 +164,14 @@ export default class DownloadsPlugin extends PopUpButtonPlugin {
           let cmeta = '';
           const lang_tag = d?.tags?.filter(x => x.startsWith('lang:'));
           if (lang_tag.length > 0) {
-            const captions_lang = lang_tag[0].split(':')[1];
-            const languageNames = new Intl.DisplayNames([window.navigator.language], {type: 'language'});
-            cmeta = languageNames.of(captions_lang) || translate('Unknown language');
+            try {
+              const captions_lang = lang_tag[0].split(':')[1];
+              const languageNames = new Intl.DisplayNames([window.navigator.language], {type: 'language'});
+              cmeta = languageNames.of(captions_lang.replace(/_/g, '-')) || translate('Unknown language');
+            }
+            catch (error) {
+              cmeta = translate('Unknown language');
+            }
           }
 
           const elm = createElementWithHtmlText(`


### PR DESCRIPTION
If the subtitle element is tagged with en_US, the downloader plugin throws an exception and does not load because it expects the language to be en-US.

This PR attempts to replace the `_` with `-` and handles a possible error.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
