### PR TITLE
Allow `mvnw` to work with symlinks

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -192,7 +192,7 @@ log() {
   fi
 }
 
-BASE_DIR=$(find_maven_basedir "$(dirname "$0")")
+BASE_DIR=$(find_maven_basedir "$(dirname "$(readlink -f "$0")")")
 if [ -z "$BASE_DIR" ]; then
   exit 1
 fi


### PR DESCRIPTION
We have `mvnw` to make running Maven easier. When compiling just one module, it is somewhat annoying to type `../../mvnw` however. To solve that, just create a symlink… except that doesn't work since the script then thinks the symlink directory is the project's base directory.

That is fixed by this patch. It resolves symlink and will use the actual path to the `mvnw` binary to determine the project's base path.

### How to test this patch

- Create a symlink: `ln -s /path/to/mvnw`
- Make sure the link is in the `PATH`
- Run `mvnw`

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
