### PR TITLE
Run tests on changes to the maven wrapper

### DIFF
--- a/.github/workflows/test-opencast-build.yml
+++ b/.github/workflows/test-opencast-build.yml
@@ -9,6 +9,8 @@ on:
       - 'docs/log4j/**'
       - 'assemblies/**'
       - '.github/**'
+      - 'mvnw'
+      - '.mvn'
   push:
     paths:
       - 'pom.xml'
@@ -17,6 +19,8 @@ on:
       - 'docs/log4j/**'
       - 'assemblies/**'
       - '.github/**'
+      - 'mvnw'
+      - '.mvn'
     branches-ignore:
       - 'dependabot/**'  # Don't run dependabot branches, as they are already covered by pull requests
 

--- a/.github/workflows/test-opencast-site.yml
+++ b/.github/workflows/test-opencast-site.yml
@@ -9,6 +9,8 @@ on:
       - 'docs/log4j/**'
       - 'assemblies/**'
       - '.github/**'
+      - 'mvnw'
+      - '.mvn'
   push:
     paths:
       - 'pom.xml'
@@ -17,6 +19,8 @@ on:
       - 'docs/log4j/**'
       - 'assemblies/**'
       - '.github/**'
+      - 'mvnw'
+      - '.mvn'
     branches-ignore:
       - 'dependabot/**'  # Don't run dependabot branches, as they are already covered by pull requests
 


### PR DESCRIPTION
This patch adds the maven wrapper to the files which will trigger a test build of Opencast. A change to that could easily break the Opencast build after all.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
