### PR TITLE
Update r/17.x Editor to 17.x-2025-09-26

### DIFF
--- a/modules/editor/pom.xml
+++ b/modules/editor/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <editor.url>https://github.com/opencast/opencast-editor/releases/download/17.x-2025-08-28/oc-editor-17.x-2025-08-28.tar.gz</editor.url>
-    <editor.sha256>1791d297c82afff871f75a772119f116de4eadcb14ae5ec873dc34efc00403e0</editor.sha256>
+    <editor.url>https://github.com/opencast/opencast-editor/releases/download/17.x-2025-09-26/oc-editor-17.x-2025-09-26.tar.gz</editor.url>
+    <editor.sha256>53986948d97529726ba29a1332d4b50d30a2654cac839341bc93bce8075b63ce</editor.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
Updating Opencast r/17.x Editor module to [17.x-2025-09-26](https://github.com/opencast/opencast-editor/releases/tag/17.x-2025-09-26)