### PR TITLE
Update r/17.x Admin UI to 17.x-2025-09-26

### DIFF
--- a/modules/admin-ui-interface/pom.xml
+++ b/modules/admin-ui-interface/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <interface.url>https://github.com/opencast/opencast-admin-interface/releases/download/17.x-2025-08-29/oc-admin-ui-17.x-2025-08-29.tar.gz</interface.url>
-    <interface.sha256>b16b71589bd8732db49b2f86a7500ee95f89df5c18af78102d8ebf83b434a513</interface.sha256>
+    <interface.url>https://github.com/opencast/opencast-admin-interface/releases/download/17.x-2025-09-26/oc-admin-ui-17.x-2025-09-26.tar.gz</interface.url>
+    <interface.sha256>7d44670ec562593a54eaf7d0b85a0aa99067f6c2eca72728f897d00da5905fac</interface.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
Updating Opencast r/17.x Admin UI module to [17.x-2025-09-26](https://github.com/opencast/opencast-admin-interface/releases/tag/17.x-2025-09-26)