### PR TITLE
Fixes direct publishing of live events

### DIFF
--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
@@ -379,6 +379,9 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
   private void checkSearchEntityWritePermission(final String mediaPackageId) throws SearchException {
     User user = securityService.getUser();
     try {
+      if (!persistence.isAvailable(mediaPackageId)) {
+        throw new NotFoundException();
+      }
       AccessControlList acl = persistence.getAccessControlList(mediaPackageId);
       if (!authorizationService.hasPermission(acl, Permissions.Action.WRITE.toString())) {
         boolean isAdmin = user.getRoles().stream()


### PR DESCRIPTION
This already was fixed in the past, but the lines in this commit got lost while merging 16.x into 17.x

Original Issue and problem description: https://github.com/opencast/opencast/issues/6386
And here the original PR: https://github.com/opencast/opencast/pull/6385

I didn't see a commit that explicitly removed the lines, so I think that this was just a mistake. I added the condition back and it seemed to work again.

To test this, schedule a live event and run a workflow that directly publishes the recording afterwards (like the default schedule-and-upload workflow).