### PR TITLE
Fixed user permission check for search service operations

### DIFF
--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
@@ -21,6 +21,7 @@
 
 package org.opencastproject.search.impl;
 
+import static org.opencastproject.security.api.Permissions.Action.WRITE;
 import static org.opencastproject.security.util.SecurityUtil.getEpisodeRoleId;
 
 import org.opencastproject.elasticsearch.index.ElasticsearchIndex;
@@ -45,12 +46,10 @@ import org.opencastproject.search.impl.persistence.SearchServiceDatabase;
 import org.opencastproject.search.impl.persistence.SearchServiceDatabaseException;
 import org.opencastproject.security.api.AccessControlEntry;
 import org.opencastproject.security.api.AccessControlList;
+import org.opencastproject.security.api.AccessControlUtil;
 import org.opencastproject.security.api.AuthorizationService;
 import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.OrganizationDirectoryService;
-import org.opencastproject.security.api.Permissions;
-import org.opencastproject.security.api.Role;
-import org.opencastproject.security.api.SecurityConstants;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.security.api.User;
@@ -395,16 +394,9 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
     User user = securityService.getUser();
     try {
       AccessControlList acl = persistence.getAccessControlList(mediaPackageId);
-      if (!authorizationService.hasPermission(acl, Permissions.Action.WRITE.toString())) {
-        boolean isAdmin = user.getRoles().stream()
-            .map(Role::getName)
-            .anyMatch(r -> r.equals(SecurityConstants.GLOBAL_ADMIN_ROLE));
-        if (!isAdmin) {
-          throw new UnauthorizedException(user, "Write permission denied for " + mediaPackageId, acl);
-        } else {
-          logger.debug("Write for {} is not allowed by ACL, but user has {}",
-              mediaPackageId, SecurityConstants.GLOBAL_ADMIN_ROLE);
-        }
+      if (!AccessControlUtil.isAuthorized(acl, user, securityService.getOrganization(), WRITE.toString(),
+          mediaPackageId)) {
+        throw new UnauthorizedException(user, "Write permission denied for " + mediaPackageId, acl);
       }
     } catch (NotFoundException e) {
       logger.debug("Mediapackage {} does not exist or was deleted, allowing writes for user {}", mediaPackageId, user);


### PR DESCRIPTION
In some cases, the user permission check fails for search service write operations. This occurs if:

- the user is an org admin
- the user does not have any write permissions other than ROLE_EPISODE_<ID>_WRITE.

Using an existing helper function resolves the issue and reduces code duplication.

## How to test

### First case - Org admin
1. Upload a video file and publish it to Engage. Make sure you restrict write access to either `ROLE_ADMIN` or the current user.
2. Log in as an Org Admin (the Org Admin role is configured [here](https://github.com/opencast/opencast/blob/develop/etc/org.opencastproject.organization-mh_default_org.cfg#L72), please change it to something other than `ROLE_ADMIN`).
3. Start the republish metadata workflow.
4. Without this patch the publish-engage workflow operation will fail due to a permission check.

### Second case - implicit episode write permission

1. Enable `episode.id.role.access` [here](https://github.com/opencast/opencast/blob/r/17.x/etc/custom.properties#L363).
2. Upload a video file and publish it to Engage. Make sure to restrict the write access to `ROLE_ADMIN` or the current user itself.
3. Login as unprivileged user with role `ROLE_EPISODE_<EPISODEID>_WRITE`.
5. Start the republish metadata workflow.
6. Without this patch the publish-engage workflow operation will fail due to a permission check.
