### PR TITLE
Fix getCalendar endpoint

### DIFF
--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/Database.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/Database.java
@@ -40,6 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -558,6 +559,9 @@ public class Database {
   }
 
   public List<Snapshot> getLatestSnapshotsByMediaPackageIds(Collection mediaPackageIds, String orgId) {
+    if (mediaPackageIds.isEmpty()) {
+      return Collections.emptyList();
+    }
     return db.execTx(em -> {
       List<SnapshotDto> snapshotDto = namedQuery.findAll(
           "Snapshot.findLatestByMpIds",

--- a/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AssetManagerSelectTest.java
+++ b/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AssetManagerSelectTest.java
@@ -42,6 +42,7 @@ import org.opencastproject.security.api.DefaultOrganization;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -215,6 +216,7 @@ public class AssetManagerSelectTest extends AssetManagerTestBase {
     )).size());
     assertEquals("series-1",
         am.getLatestSnapshots(List.of(mp1.getIdentifier().toString())).get(0).getMediaPackage().getSeries());
+    assertEquals(0, am.getLatestSnapshots(Collections.emptyList()).size());
   }
 
   @Test


### PR DESCRIPTION
This PR fixes an issue where CAs polling for calendars where there are no events would generate stack traces and errors cf

```
2025-10-21T12:23:20,591 | ERROR | (SchedulerRestService:578) - Unable to get calendar for capture agent 'pyca@fw13':
org.opencastproject.scheduler.api.SchedulerException: javax.persistence.PersistenceException: Exception [EclipseLink-4002] (Eclipse Persistence Services - 2.7.15.v20240516-53511fdbd8): org.eclipse.persistence.exceptions.DatabaseException
Internal Exception: java.sql.SQLSyntaxErrorException: (conn=7) You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ')) AND ((null IS NULL) OR (t0.organization_id = null))) AND (t0.version = (SE...' at line 1
Error Code: 1064
Call: SELECT t0.id, t0.archival_date, t0.availability, t0.mediapackage_id, t0.mediapackage_xml, t0.organization_id, t0.owner, t0.series_id, t0.storage_id, t0.version FROM oc_assets_snapshot t0 WHERE (((t0.mediapackage_id IN ()) AND ((? IS NULL) OR (t0.organization_id = ?))) AND (t0.version = (SELECT MAX(t1.version) FROM oc_assets_snapshot t1 WHERE (t1.mediapackage_id = t0.mediapackage_id))))
        bind => [2 parameters bound]
Query: ReadAllQuery(name="Snapshot.findLatestByMpIds" referenceClass=SnapshotDto sql="SELECT t0.id, t0.archival_date, t0.availability, t0.mediapackage_id, t0.mediapackage_xml, t0.organization_id, t0.owner, t0.series_id, t0.storage_id, t0.version FROM oc_assets_snapshot t0 WHERE (((t0.mediapackage_id IN ?) AND ((? IS NULL) OR (t0.organization_id = ?))) AND (t0.version = (SELECT MAX(t1.version) FROM oc_assets_snapshot t1 WHERE (t1.mediapackage_id = t0.mediapackage_id))))")
        at org.opencastproject.scheduler.impl.SchedulerServiceImpl.getCalendar(SchedulerServiceImpl.java:1175) ~[?:?]
        at org.opencastproject.scheduler.endpoint.SchedulerRestService.getCalendar(SchedulerRestService.java:570) ~[?:?]
        at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[?:?]
```

The underlying issue is that we attempt to query the AM for snapshots, but if we don't have any events in the queried window we would pass in an empty list as the list of mediapackage IDs.  This caused the `(t0.mediapackage_id IN ())` part of the query, which (correctly) barfs.  I've added a check here to ensure that an empty list begets an empty list.  This does not affect 18.x or earlier because we did a query here - the removal of the QueryBuilder code in 7956b975e31fa3c8f6dd675d6e2cbd5294ae2de3 replaced the previous direct query with asking the AM instead.

### How to test this patch

Start up a blank OC, then GET `http://localhost/recordings/calendars`

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] ~explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch~
