### PR TITLE
Fix captions not published from editor

### DIFF
--- a/etc/workflows/partial-theming.xml
+++ b/etc/workflows/partial-theming.xml
@@ -40,6 +40,17 @@
     </operation>
 
     <operation
+        id="tag"
+        if="NOT(${theme_active})"
+        description="If no shifting was necessary, mark the trimmed captions as shifted">
+      <configurations>
+        <configuration key="source-flavors">captions/trimmed</configuration>
+        <configuration key="target-flavor">captions/shifted</configuration>
+        <configuration key="copy">false</configuration>
+      </configurations>
+    </operation>
+
+    <operation
       id="tag"
       if="NOT(${theme_active})"
       description="Tag elements as themed">


### PR DESCRIPTION
When adding captions to an event through the editor, and the event was not themed, the captions would not be published. This fixes that.

Fixes the issue by adding another tag operation to the theming workflow that aims to ensure that captions end up with the expected flavor (captions/shifted) after the workflow has run.

Targeting legacy because I am considering this a bugfix. But since this is technically a configuration change, as workflows are technically configuration, I have no problem retargeting this.

### How to test this patch

- Configure the editor to allow for subtitle editing.
- Upload a test event to Opencast that does not belong to a themed series and without subtitles.
- Open the test event in the editor. Add a subtitle. Start the "publish" workflow from the editor.
- Let the workflow run.
- Check if the search endpoint (/search/episode.json?id={id}) returns a subtitle track.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
