### PR TITLE
Add Caddy Reverse Proxy documentation

### DIFF
--- a/docs/guides/admin/docs/configuration/https/caddy.md
+++ b/docs/guides/admin/docs/configuration/https/caddy.md
@@ -1,0 +1,70 @@
+Enable HTTPS using Caddy
+========================
+
+> [Using Nginx as reverse proxy for Opencast](nginx.md) is the preferred way of running Opencast.
+> Refer to the [Nginx guide for configuration instructions](nginx.md) for that type of setup.
+
+This guide will help you to configure Caddy 2 to act as HTTP(S) proxy for Opencast.
+
+
+Opencast Configuration
+----------------------
+
+Make sure to use `https` as protocol for `org.opencastproject.server.url` in `etc/custom.properties`.
+
+```ini
+org.opencastproject.server.url=https://example.opencast.org
+```
+
+No other configuration is required. Do not enable TLS in Opencast. Listen to local connections only. Both are the
+default settings.
+
+
+Minimal Set-up
+--------------
+
+The following configuration is an example for `/etc/caddy/Caddyfile`.
+
+Explanations for the configuration directives are provided inline. Please make sure to replace `example.opencast.org`
+with your node's domain name.
+
+The main goals of this set-up are:
+
+- Always redirect to HTTPS
+- Proxy to Opencast and take care of TLS
+
+The great benefit of Caddy is that it takes care of most of the stuff without extra configuration, for example:
+
+- Automatically redirects HTTP to HTTPS
+- Has built-in support for ACME and automatically obtains certificates from Let's Encrypt
+- Only uses secure TLS-Versions and Ciphers by default
+- Automatically sets/passes the required headers
+
+
+```caddy
+example.opencast.org {
+
+    # Proxy requests to Opencast. This expects Opencast to be running locally on port 8080 which
+    # should be the default set-up.
+    reverse_proxy 127.0.0.1:8080 {
+
+        # Make sure to redirect location headers to HTTPS. This is just a precaution and shouldn't
+        # strictly be necessary but it did prevent some issues in the past and it does not cost
+        # much performance.
+        header_down Location http:// https://
+
+        # Make sure to serve cookies only via secure connections.
+        header_down Set-Cookie (.*) "$1; HttpOnly; Secure; Partitioned;"
+
+        # Depending on your integration, you may also want to allow cookies to be used on other
+        # sites. In that case, use this instead:
+        #header_down Set-Cookie (.*) "$1; HttpOnly; Secure; SameSite=None; Partitioned;"
+    }
+
+    # Optional - Set a custom certificate and key. This disables ACME.
+    #tls /path/to/example.opencast.org.crt /path/to/example.opencast.org.key
+}
+```
+
+> It is also possible to use a custom ACME CA. For instructions, please take a look at the "acme_..." options
+> [here](https://caddyserver.com/docs/caddyfile/options).

--- a/docs/guides/admin/docs/configuration/https/caddy.md
+++ b/docs/guides/admin/docs/configuration/https/caddy.md
@@ -1,8 +1,6 @@
 Enable HTTPS using Caddy
 ========================
 
-> [Using Nginx as reverse proxy for Opencast](nginx.md) is the preferred way of running Opencast.
-> Refer to the [Nginx guide for configuration instructions](nginx.md) for that type of setup.
 
 This guide will help you to configure Caddy 2 to act as HTTP(S) proxy for Opencast.
 

--- a/docs/guides/admin/docs/configuration/https/index.md
+++ b/docs/guides/admin/docs/configuration/https/index.md
@@ -2,11 +2,12 @@ Serve Content Via HTTPS
 =======================
 
 To make your installation available from the outside worls, you want to allow non-local traffic and want to secure
-connections from and to Opencast.  To archieve that, you can either use an HTTP(S) proxy like Apache httpd or Nginx
-(recommended) or enable HTTPS directly in Opencast.
+connections from and to Opencast.  To archieve that, you can either use an HTTP(S) proxy like Apache httpd, Caddy or
+Nginx (recommended) or enable HTTPS directly in Opencast.
 
 - [Using Nginx to enable HTTPS](nginx.md) (recommended)
 - [Using Apache httpd to enable HTTPS](apache-httpd.md)
+- [Using Caddy to enable HTTPS](caddy.md)
 - [Enable HTTPS directly in Opencast](opencast.only.md)
 
 

--- a/docs/guides/admin/mkdocs.yml
+++ b/docs/guides/admin/mkdocs.yml
@@ -82,7 +82,8 @@ nav:
       - HTTPS:
           - Overview: "configuration/https/index.md"
           - Using Nginx: "configuration/https/nginx.md"
-          - Using Apache httpd: configuration/https/apache-httpd.md
+          - Using Apache httpd: "configuration/https/apache-httpd.md"
+          - Using Caddy: "configuration/https/caddy.md"
           - Internal HTTPS: "configuration/https/opencast.only.md"
           - Self-Signed Certificates: "configuration/https/self-signed-certificates.md"
       - Domain change/HTTPS migration: "configuration/migration-domain-https.md"


### PR DESCRIPTION
This pull request adds documentation on how to use Caddy as an alternative Reverse Proxy for Opencast.


### How to test this patch

- Install Caddy either from a method listed [here](https://caddyserver.com/docs/install) or, if you are using Debian, from the official repositories.
- Copy the Caddyfile to `/etc/caddy/Caddyfile` and modify the values to match what is needed in your setup
- Reload the Caddy service


### Your pull request should…

* [x] have a concise title
* [ ] ~~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~~include migration scripts and documentation, if appropriate~~
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] ~~explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch~~