### PR TITLE
Add audio merging in partial ingest workflow

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/partial-import-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/partial-import-woh.md
@@ -44,6 +44,7 @@ Parameter Table
 |**force-encoding-profile**\*|String|Encoding profile to be used when *force-encoding* is set to *true* or a given target track has a file extension not included in *required-extensions*||
 |required-extensions|String , { "," , String }|Comma-separated list of file extension names (case insensitive). All generated target files whose file extensions are not in this list will be encoded using the encoding profile *force-encoding-profile*|"mp4"|
 |enforce-divisible-by-two|Boolean|If set, all video targets will have widths and heights divisible by two. This might be necessary depending since some encoder fail when encountering uneven widths or heights.|false|
+|audio-merge-encoding-profile| String | Encoding profile used for merging audio files.| codec: `-c:a flac`; suffix = `-merged.mkv` |
 
 \* **required keys**
 
@@ -228,12 +229,30 @@ order of occurrences of *video* and *audio* elements are independent from each o
 appearance in the SMIL file is not correct.
 
 
-### Overlapping Partial Tracks
+### Overlapping Partial Tracks (Videos)
 
-The behavior of overlapping partial tracks is unspecified, i.e. for a given element *e* (*video* or *audio*), the value
-of *begin* for the subsequent element *(e+1)* of the same type (*video* or *audio*) within the same sequence must be
+The behavior of overlapping partial tracks is unspecified for videos, i.e. for a given video *e*, the value
+of *begin* for the subsequent element *(e+1)* within the same sequence must be
 equal or greater than *e.begin + e.dur*, i.e. make sure that the following invariant holds: *(e+1).begin >= e.begin +
 e.dur*
+
+### Overlapping Partial Tracks (Audio)
+
+Regarding audio, the workflow operation will use filter_complex to enable overlapping audio tracks.
+The `adelay` filter is used to put silence in front the audio tracks to positioning them on the right place in the timeline.
+Afterward it uses amix to simply merge all the audio snippets into one audio track.
+
+Here is an example:
+```
+ffmpeg -i in1.mp3 -i in2.mp3 -i in3.mp3 -filter_complex \
+"[0:a]adelay=1500:all=1[a0]; \
+[1:a]adelay=2500:all=1[a1]; \
+[2:a]adelay=4000:all=1[a2]; \
+[a0][a1][a2]amix=inputs=3:duration=longest[aout]" \
+-map "[aout]" \
+-c:a flac \
+merged.mkv
+```
 
 Encoding Profiles
 -----------------

--- a/etc/encoding/opencast.properties
+++ b/etc/encoding/opencast.properties
@@ -246,11 +246,3 @@ profile.text-analysis.http.suffix = .#{time}.png
 profile.text-analysis.http.ffmpeg.command = -ss #{time} -i #{in.video.path} \
   -vf "fps=1,scale=1280:720:force_original_aspect_ratio=decrease,pad=1280:720:-1:-1 [in]; color=black:s=1280x720:r=1:d=1 [bg]; [bg][in] overlay=0:0 [mux]; [mux] curves=preset=increase_contrast,format=pix_fmts=gray [out]" \
   -frames:v 1 #{out.dir}/#{out.name}#{out.suffix}
-
-profile.audiomerge.work.name = audiomerge
-profile.audiomerge.work.input = visual
-profile.audiomerge.work.output = visual
-profile.audiomerge.work.suffix = -merged.mkv
-profile.audiomerge.work.ffmpeg.command = #{audioMergeCommand} \
-  -c:a flac \
-  #{out.dir}/#{out.name}#{out.suffix}

--- a/etc/encoding/opencast.properties
+++ b/etc/encoding/opencast.properties
@@ -246,3 +246,11 @@ profile.text-analysis.http.suffix = .#{time}.png
 profile.text-analysis.http.ffmpeg.command = -ss #{time} -i #{in.video.path} \
   -vf "fps=1,scale=1280:720:force_original_aspect_ratio=decrease,pad=1280:720:-1:-1 [in]; color=black:s=1280x720:r=1:d=1 [bg]; [bg][in] overlay=0:0 [mux]; [mux] curves=preset=increase_contrast,format=pix_fmts=gray [out]" \
   -frames:v 1 #{out.dir}/#{out.name}#{out.suffix}
+
+profile.audiomerge.work.name = audiomerge
+profile.audiomerge.work.input = visual
+profile.audiomerge.work.output = visual
+profile.audiomerge.work.suffix = -merged.mkv
+profile.audiomerge.work.ffmpeg.command = #{audioMergeCommand} \
+  -c:a flac \
+  #{out.dir}/#{out.name}#{out.suffix}

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
@@ -31,6 +31,7 @@ import static org.opencastproject.util.data.Tuple.tuple;
 import org.opencastproject.composer.api.ComposerService;
 import org.opencastproject.composer.api.EncoderException;
 import org.opencastproject.composer.api.EncodingProfile;
+import org.opencastproject.composer.api.EncodingProfileImpl;
 import org.opencastproject.composer.api.LaidOutElement;
 import org.opencastproject.composer.api.VideoClip;
 import org.opencastproject.composer.layout.Dimension;
@@ -166,6 +167,7 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
   private static final int PROCESS_SMIL_FAILED = 19;
   private static final int MULTI_ENCODE_FAILED = 20;
   private static final int NO_STREAMS = 23;
+  private static final int AUDIO_MERGE_FAILED = 24;
 
   /** The logging instance */
   private static final Logger logger = LoggerFactory.getLogger(ComposerServiceImpl.class);
@@ -254,6 +256,9 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
   /** Path to the FFmpeg binary */
   private String ffmpegBinary = FFMPEG_BINARY_DEFAULT;
 
+  /** Default audio-merge encoding profile if no one is set **/
+  private EncodingProfile defaultAudioMergeEncodingProfile;
+
   /** Creates a new composer service instance. */
   public ComposerServiceImpl() {
     super(JOB_TYPE);
@@ -272,6 +277,16 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
     ffmpegBinary = StringUtils.defaultString(cc.getBundleContext().getProperty(CONFIG_FFMPEG_PATH),
             FFMPEG_BINARY_DEFAULT);
     logger.debug("ffmpeg binary: {}", ffmpegBinary);
+
+    // creating default encoding profile in case none is set
+    EncodingProfileImpl profile = new EncodingProfileImpl("audiomerge.work", "audiomerge", null);
+    profile.setOutputType(EncodingProfile.MediaType.Audio);
+    profile.setSuffix("-merged.mkv");
+    profile.setApplicableType(EncodingProfile.MediaType.AudioVisual);
+    profile.addExtension("ffmpeg.command", "#{audioMergeCommand} -c:a flac #{out.dir}/#{out.name}#{out.suffix}");
+    this.defaultAudioMergeEncodingProfile = profile;
+    logger.info("Default audio merge encoding profile set: " + profile.getIdentifier());
+
     logger.info("Activating composer service");
   }
 
@@ -974,7 +989,20 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
       audioFiles.add(loadTrackIntoWorkspace(job, "audio_merge", t, false));
     }
 
-    EncodingProfile encodingProfile = getProfile(job, profileId);
+    // try to get encoding profile from file, use default as fallback
+    EncodingProfile encodingProfile = profileScanner.getProfile(profileId);
+    if (encodingProfile == null) {
+      final String msg = format("Profile %s is unknown.", profileId);
+      if ("audiomerge.work".equals(profileId)) {
+        logger.info(msg + " Using default");
+        encodingProfile = defaultAudioMergeEncodingProfile;
+      } else {
+        logger.error(msg);
+        incident().recordFailure(job, PROFILE_NOT_FOUND, Collections.map(tuple("profile", profileId)));
+        throw new EncoderException(msg);
+      }
+    }
+
     final EncoderEngine encoderEngine = getEncoderEngine();
 
     String audioMergeCommand = buildAudioMergeCommand(audioStarTimes, audioFiles);
@@ -993,7 +1021,7 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
       params.put("tracks", StringUtils.join(trackList, ","));
       params.put("profile", encodingProfile.getIdentifier());
       params.put("properties", properties.toString());
-      incident().recordFailure(job, CONCAT_FAILED, e, params, detailsFor(e, encoderEngine));
+      incident().recordFailure(job, AUDIO_MERGE_FAILED, e, params, detailsFor(e, encoderEngine));
       throw e;
     } finally {
       activeEncoder.remove(encoderEngine);

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
@@ -221,7 +221,7 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
 
   /** List of available operations on jobs */
   enum Operation {
-    Encode, Image, ImageConversion, Mux, Trim, Composite, Concat, ImageToVideo, ParallelEncode, Demux, ProcessSmil, MultiEncode
+    Encode, Image, ImageConversion, Mux, Trim, Composite, Concat, ImageToVideo, ParallelEncode, Demux, ProcessSmil, MultiEncode, MergeAudioTracks
   }
 
   /** tracked encoder engines */
@@ -919,6 +919,22 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
   }
 
   @Override
+  public Job mergeAudioTracks(String profileId, List<Long> audioStartTimes, List<Track> audioTracks) throws MediaPackageException, EncoderException {
+    try {
+      ArrayList<String> arguments = new ArrayList<String>();
+      arguments.add(0, profileId);
+      String audioStartsStringified = audioStartTimes.stream().map(String::valueOf).collect(Collectors.joining(","));
+      arguments.add(1, audioStartsStringified);
+      for (int i = 0; i < audioTracks.size(); i++) {
+        arguments.add(i + 2, MediaPackageElementParser.getAsXml(audioTracks.get(i)));
+      }
+      return serviceRegistry.createJob(JOB_TYPE, Operation.MergeAudioTracks.toString(), arguments);
+    } catch (ServiceRegistryException e) {
+      throw new EncoderException("Unable to create 'Merge Audio Tracks' job", e);
+    }
+  }
+
+  @Override
   public Job concat(String profileId, Dimension outputDimension, float outputFrameRate, boolean sameCodec, Track... tracks) throws EncoderException,
           MediaPackageException {
     ArrayList<String> arguments = new ArrayList<String>();
@@ -939,6 +955,65 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
     } catch (ServiceRegistryException e) {
       throw new EncoderException("Unable to create concat job", e);
     }
+  }
+
+  private Option<Track> mergeAudioTracks(Job job, String profileId, List<Long> audioStarTimes, List<Track> audioTracks) throws EncoderException {
+    if (audioTracks.size() < 2) {
+      throw new EncoderException(String.format("The track parameter must at least have two tracks present. Provided tracks: {}", audioTracks.size()));
+    }
+
+    if (audioTracks.size() != audioStarTimes.size()) {
+      throw new EncoderException(String.format("Number of audio tracks ({}) and 'audio start times' ({}) are not equal.", audioTracks.size(), audioStarTimes.size()));
+    }
+
+    List<File> audioFiles = new ArrayList<>();
+    for (Track t : audioTracks) {
+      if (t.hasVideo()) {
+        throw new EncoderException(String.format("There was at least one video in the audio track list: '{}'", t.getURI()));
+      }
+      audioFiles.add(loadTrackIntoWorkspace(job, "audio_merge", t, false));
+    }
+
+    EncodingProfile encodingProfile = getProfile(job, profileId);
+    final EncoderEngine encoderEngine = getEncoderEngine();
+
+    String audioMergeCommand = buildAudioMergeCommand(audioStarTimes, audioFiles);
+    Map<String, String> properties = new HashMap<>();
+    properties.put(CMD_SUFFIX + ".audioMergeCommand", audioMergeCommand);
+
+    File mergedAudioTrack;
+    try {
+      mergedAudioTrack = encoderEngine.encode(audioFiles.get(0), encodingProfile, properties);
+    } catch (EncoderException e) {
+      Map<String, String> params = new HashMap<>();
+      List<String> trackList = new ArrayList<>();
+      for (Track t : audioTracks) {
+        trackList.add(t.getURI().toString());
+      }
+      params.put("tracks", StringUtils.join(trackList, ","));
+      params.put("profile", encodingProfile.getIdentifier());
+      params.put("properties", properties.toString());
+      incident().recordFailure(job, CONCAT_FAILED, e, params, detailsFor(e, encoderEngine));
+      throw e;
+    } finally {
+      activeEncoder.remove(encoderEngine);
+    }
+
+    // audio merge did not return a file
+    if (!mergedAudioTrack.exists() || mergedAudioTrack.length() == 0) {
+      return none();
+    }
+
+    // Put the file in the workspace
+    URI workspaceURI = putToCollection(job, mergedAudioTrack, "merged audio file");
+
+    // Have the merged audio track inspected and return the result
+    Track inspectedTrack = inspect(job, workspaceURI);
+
+    final String targetTrackId = IdImpl.fromUUID().toString();
+    inspectedTrack.setIdentifier(targetTrackId);
+
+    return some(inspectedTrack);
   }
 
   private Option<Track> concat(Job job, List<Track> tracks, String profileId, Dimension outputDimension,
@@ -1583,6 +1658,15 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
           outTracks = multiEncode(job, firstTrack, encodingProfiles2);
           serialized = StringUtils.trimToEmpty(MediaPackageElementParser.getArrayAsXml(outTracks));
           break;
+        case MergeAudioTracks:
+          List<Long> audioStartTimes = Arrays.stream(arguments.get(1).split(",")).mapToLong(Long::parseLong).boxed().collect(Collectors.toList());
+          List<Track> audioTracks = new ArrayList<>();
+          for (int i = 2; i < arguments.size(); i++) {
+            audioTracks.add((Track) MediaPackageElementParser.getFromXml(arguments.get(i)));
+          }
+          serialized = mergeAudioTracks(job, encodingProfile, audioStartTimes, audioTracks).map(
+                  MediaPackageElementParser.getAsXml()).getOrElse("");
+          break;
         default:
           throw new IllegalStateException("Don't know how to handle operation '" + operation + "'");
       }
@@ -1727,6 +1811,42 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
     params.put("collection", collectionId);
     params.put("url", url.toString());
     return params;
+  }
+
+  private String buildAudioMergeCommand(List<Long> audioStartTimes, List<File> audioTrackFiles) {
+
+    // example:
+    // ffmpeg -i in1.mp3 -i in2.mp3 -i in3.mp3 -filter_complex \
+    // "[0:a]adelay=1500:all=1[a0]; \
+    // [1:a]adelay=2500:all=1[a1]; \
+    // [2:a]adelay=4000:all=1[a2]; \
+    // [a0][a1][a2]amix=inputs=3:duration=longest[aout]" \
+    // -map "[aout]" \
+    // -c:a flac \   <- thats in the encoding profile
+    // output.flac   <- thats managed by the encoding engine
+
+    StringBuilder command = new StringBuilder();
+
+    for (File f : audioTrackFiles) {
+      command.append("-i ").append(f.getAbsolutePath()).append(" ");
+    }
+    command.append("-filter_complex ");
+    command.append("\""); // opening double quote
+
+    StringBuilder audioMixParts = new StringBuilder();
+    for (int i = 0; i < audioStartTimes.size(); i++) {
+      // example: [0:a]adelay=1500:all=1[a0];
+      // note: '0' is the incremental index
+      command.append("[").append(i).append(":a]").append("adelay=").append(audioStartTimes.get(i)).append(":all=1[a").append(i).append("];");
+      audioMixParts.append("[a").append(i).append("]");
+    }
+    // example: [a0][a1][a2]amix=inputs=3:duration=longest[aout]"
+    command.append(audioMixParts).append("amix=inputs=").append(audioStartTimes.size()).append(":duration=longest[aout]");
+    command.append("\" "); // closing double quote
+
+    command.append("-map \"[aout]\" ");
+
+    return command.toString();
   }
 
   private String buildConcatCommand(boolean onlyAudio, Dimension dimension, float outputFrameRate, List<File> files, List<Track> tracks) {

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
@@ -972,13 +972,13 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
     }
   }
 
-  private Option<Track> mergeAudioTracks(Job job, String profileId, List<Long> audioStarTimes, List<Track> audioTracks) throws EncoderException {
+  private Option<Track> mergeAudioTracks(Job job, String profileId, List<Long> audioStartTimes, List<Track> audioTracks) throws EncoderException {
     if (audioTracks.size() < 2) {
       throw new EncoderException(String.format("The track parameter must at least have two tracks present. Provided tracks: {}", audioTracks.size()));
     }
 
-    if (audioTracks.size() != audioStarTimes.size()) {
-      throw new EncoderException(String.format("Number of audio tracks ({}) and 'audio start times' ({}) are not equal.", audioTracks.size(), audioStarTimes.size()));
+    if (audioTracks.size() != audioStartTimes.size()) {
+      throw new EncoderException(String.format("Number of audio tracks ({}) and 'audio start times' ({}) are not equal.", audioTracks.size(), audioStartTimes.size()));
     }
 
     List<File> audioFiles = new ArrayList<>();
@@ -1005,7 +1005,7 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
 
     final EncoderEngine encoderEngine = getEncoderEngine();
 
-    String audioMergeCommand = buildAudioMergeCommand(audioStarTimes, audioFiles);
+    String audioMergeCommand = buildAudioMergeCommand(audioStartTimes, audioFiles);
     Map<String, String> properties = new HashMap<>();
     properties.put(CMD_SUFFIX + ".audioMergeCommand", audioMergeCommand);
 

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/endpoint/ComposerRestService.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/endpoint/ComposerRestService.java
@@ -63,6 +63,7 @@ import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -79,6 +80,8 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
+import jdk.javadoc.doclet.Reporter;
 
 /**
  * A REST endpoint delegating functionality to the {@link ComposerService}
@@ -682,10 +685,17 @@ public class ComposerRestService extends AbstractJobProducerEndpoint {
       if (!Track.TYPE.equals(elem.getElementType())) {
         return Response.status(Response.Status.BAD_REQUEST).entity("Source tracks must be of type 'track'").build();
       }
+      if (((Track) elem).hasVideo()) {
+        return Response.status(Response.Status.BAD_REQUEST).entity("Just audio-only tracks are allowed. There was at least one video in the track list").build();
+      }
     }
 
     List<Long> audioStartTimes = Arrays.stream(audioStartTimesStringified.split(","))
           .mapToLong(Long::parseLong).boxed().collect(Collectors.toList());
+
+    if (audioStartTimes.size() != tracks.size()) {
+      return Response.status(Response.Status.BAD_REQUEST).entity("The number of tracks must match the number of start times.").build();
+    }
 
     try {
       // Merge the specified audio tracks together

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/endpoint/ComposerRestService.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/endpoint/ComposerRestService.java
@@ -63,7 +63,6 @@ import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -81,7 +80,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import jdk.javadoc.doclet.Reporter;
 
 /**
  * A REST endpoint delegating functionality to the {@link ComposerService}

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/endpoint/ComposerRestService.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/endpoint/ComposerRestService.java
@@ -67,6 +67,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.DefaultValue;
@@ -648,6 +649,51 @@ public class ComposerRestService extends AbstractJobProducerEndpoint {
       return Response.ok().entity(new JaxbJob(job)).build();
     } catch (EncoderException e) {
       logger.warn("Unable to concat videos: " + e.getMessage());
+      return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+    }
+  }
+
+  @POST
+  @Path("mergeaudio")
+  @Produces(MediaType.TEXT_XML)
+  @RestQuery(name = "mergeaudio", description = "Starts a audio merging process from multiple audio tracks, based on the specified encoding profile ID, the source tracks and a list of starting times", restParameters = {
+      @RestParameter(description = "The audio tracks to merge as xml", isRequired = true, name = "audioTracks", type = Type.TEXT),
+      @RestParameter(description = "The encoding profile to use", isRequired = true, name = "profileId", type = Type.STRING),
+      @RestParameter(description = "The audio start times as comma seperated list", isRequired = true, name = "audioStartTimes", type = Type.STRING), }, responses = {
+      @RestResponse(description = "Results in an xml document containing the merged audio track", responseCode = HttpServletResponse.SC_OK),
+      @RestResponse(description = "If required parameters aren't set or if sourceTracks aren't from the type Track or not at least two tracks are present", responseCode = HttpServletResponse.SC_BAD_REQUEST) }, returnDescription = "")
+  public Response mergeAudioTracks(@FormParam("audioTracks") String audioTracksXml,
+      @FormParam("profileId") String profileId, @FormParam("audioStartTimes") String audioStartTimesStringified)
+      throws Exception {
+    // Ensure that the POST parameters are present
+    if (StringUtils.isBlank(audioTracksXml) || StringUtils.isBlank(profileId) || StringUtils.isBlank(
+        audioStartTimesStringified)) {
+      return Response.status(Response.Status.BAD_REQUEST)
+          .entity("audioTracks, profileId and audioStartTimes must not be null").build();
+    }
+
+    // Deserialize the audio tracks
+    List<? extends MediaPackageElement> tracks = MediaPackageElementParser.getArrayFromXml(audioTracksXml);
+    if (tracks.size() < 2) {
+      return Response.status(Response.Status.BAD_REQUEST).entity("At least two tracks must be set to merge").build();
+    }
+
+    for (MediaPackageElement elem : tracks) {
+      if (!Track.TYPE.equals(elem.getElementType())) {
+        return Response.status(Response.Status.BAD_REQUEST).entity("Source tracks must be of type 'track'").build();
+      }
+    }
+
+    List<Long> audioStartTimes = Arrays.stream(audioStartTimesStringified.split(","))
+          .mapToLong(Long::parseLong).boxed().collect(Collectors.toList());
+
+    try {
+      // Merge the specified audio tracks together
+      List<Track> tracksAsList = tracks.stream().map(element -> (Track) element).collect(Collectors.toList());
+      Job job = composerService.mergeAudioTracks(profileId, audioStartTimes, tracksAsList);
+      return Response.ok().entity(new JaxbJob(job)).build();
+    } catch (EncoderException e) {
+      logger.warn("Unable to merge audio tracks: " + e.getMessage());
       return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
     }
   }

--- a/modules/composer-service-api/src/main/java/org/opencastproject/composer/api/ComposerService.java
+++ b/modules/composer-service-api/src/main/java/org/opencastproject/composer/api/ComposerService.java
@@ -143,6 +143,22 @@ public interface ComposerService {
           MediaPackageException;
 
   /**
+   * Merge multiple audio tracks together into one audio track.
+   * The audioStartTimes List determines, where the audio snippets begin.
+   * The also can overlap. Silence will be put in front of the audio track if all snippets start after 0.
+   * Silence will also be put between audio snippets.
+   *
+   * @param profileId The encoding profile to use
+   * @param audioStartTimes Start times of the audio tracks in milliseconds. Have to be in the same order like the tracks
+   * @param audioTracks The audio tracks that will be merged into one track.
+   * @return The merged audio track
+   * @throws EncoderException if encoding fails
+   * @throws MediaPackageException if the mediapackage is invalid
+   */
+  Job mergeAudioTracks(String profileId, List<Long> audioStartTimes, List<Track> audioTracks)
+          throws EncoderException, MediaPackageException;
+
+  /**
    * Transforms an image attachment to a video track
    *
    * @param sourceImageAttachment

--- a/modules/composer-service-remote/src/main/java/org/opencastproject/composer/remote/ComposerServiceRemoteImpl.java
+++ b/modules/composer-service-remote/src/main/java/org/opencastproject/composer/remote/ComposerServiceRemoteImpl.java
@@ -524,6 +524,35 @@ public class ComposerServiceRemoteImpl extends RemoteBase implements ComposerSer
     }
   }
 
+  public Job mergeAudioTracks(String profileId, List<Long> audioStartTimes, List<Track> audioTracks) throws EncoderException, MediaPackageException {
+    HttpPost post = new HttpPost("/mergeaudio");
+    try {
+      List<BasicNameValuePair> params = new ArrayList<BasicNameValuePair>();
+      params.add(new BasicNameValuePair("profileId", profileId));
+      params.add(new BasicNameValuePair("audioTracks", MediaPackageElementParser.getArrayAsXml(audioTracks)));
+      String audioStartsStringified = audioStartTimes.stream().map(String::valueOf).collect(Collectors.joining(","));
+      params.add(new BasicNameValuePair("audioStartTimes", audioStartsStringified));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
+    } catch (Exception e) {
+      throw new EncoderException(e);
+    }
+    HttpResponse response = null;
+    try {
+      response = getResponse(post);
+      if (response != null) {
+        Job r = JobParser.parseJob(response.getEntity().getContent());
+        logger.info("Audio Merge job {} started on a remote composer", r.getId());
+        return r;
+      }
+    } catch (Exception e) {
+      throw new EncoderException(e);
+    } finally {
+      closeConnection(response);
+    }
+    throw new EncoderException("Unable to merge audio from tracks " + audioTracks
+        + " using the remote composer service proxy");
+  }
+
   @Override
   public Job concat(String profileId, Dimension outputDimension, boolean sameCodec, Track... tracks)
           throws EncoderException, MediaPackageException {

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PartialImportWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PartialImportWorkflowOperationHandler.java
@@ -223,7 +223,7 @@ public class PartialImportWorkflowOperationHandler extends AbstractWorkflowOpera
     final Opt<String> presentationFlavor = getOptConfig(operation, SOURCE_PRESENTATION_FLAVOR);
     final MediaPackageElementFlavor smilFlavor = MediaPackageElementFlavor.parseFlavor(getConfig(operation, SOURCE_SMIL_FLAVOR));
     final String concatEncodingProfile = getConfig(operation, CONCAT_ENCODING_PROFILE);
-    final String audioMergeEncodingProfile = getConfig(operation, AUDIO_MERGE_ENCODING_PROFILE);
+    final Opt<String> audioMergeEncodingProfile = getOptConfig(operation, AUDIO_MERGE_ENCODING_PROFILE);
     final Opt<String> concatOutputFramerate = getOptConfig(operation, CONCAT_OUTPUT_FRAMERATE);
     final String trimEncodingProfile = getConfig(operation, TRIM_ENCODING_PROFILE);
     final MediaPackageElementFlavor targetPresenterFlavor = parseTargetFlavor(
@@ -254,9 +254,17 @@ public class PartialImportWorkflowOperationHandler extends AbstractWorkflowOpera
       throw new WorkflowOperationException("Concat encoding profile '" + concatEncodingProfile + "' was not found");
     }
 
-    final EncodingProfile audioMergeProfile = composerService.getProfile(audioMergeEncodingProfile);
-    if (audioMergeProfile == null)  {
-      throw new WorkflowOperationException("Audio Merge encoding profile '" + audioMergeEncodingProfile + "' was not found");
+    final String audioMergeProfileId;
+    if (audioMergeEncodingProfile.isNone()) {
+      logger.info("Workflow operation config '" + AUDIO_MERGE_ENCODING_PROFILE + "' it not set. Using default.");
+      audioMergeProfileId = "audiomerge.work";
+    } else {
+      EncodingProfile audioMergeProfile = composerService.getProfile(audioMergeEncodingProfile.get());
+      if (audioMergeProfile == null) {
+        throw new WorkflowOperationException("Audio Merge encoding profile '" + audioMergeEncodingProfile + "' was not found");
+      } else {
+        audioMergeProfileId = audioMergeProfile.getIdentifier();
+      }
     }
 
     float outputFramerate = -1.0f;
@@ -331,7 +339,7 @@ public class PartialImportWorkflowOperationHandler extends AbstractWorkflowOpera
       if (audioTracks.size() > 1) {
         if (sourceType.get().startsWith(PRESENTER_KEY) || sourceType.get().startsWith(PRESENTATION_KEY)) {
           logger.info("Merging {} audio tracks", sourceType.get());
-          Job audioMergeJob = composerService.mergeAudioTracks(audioMergeProfile.getIdentifier(), audioStartTimes, audioTracks);
+          Job audioMergeJob = composerService.mergeAudioTracks(audioMergeProfileId, audioStartTimes, audioTracks);
           jobs.put(sourceType.get(), audioMergeJob);
         } else {
           logger.warn("Can't handle unknown source type '{}'!", sourceType.get());

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PartialImportWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PartialImportWorkflowOperationHandler.java
@@ -115,10 +115,15 @@ public class PartialImportWorkflowOperationHandler extends AbstractWorkflowOpera
   private static final String TARGET_PRESENTATION_FLAVOR = "target-presentation-flavor";
 
   private static final String CONCAT_ENCODING_PROFILE = "concat-encoding-profile";
+  private static final String AUDIO_MERGE_ENCODING_PROFILE = "audio-merge-encoding-profile";
+
   private static final String CONCAT_OUTPUT_FRAMERATE = "concat-output-framerate";
   private static final String TRIM_ENCODING_PROFILE = "trim-encoding-profile";
   private static final String FORCE_ENCODING_PROFILE = "force-encoding-profile";
   private static final String PREENCODE_ENCODING_PROFILE = "preencode-encoding-profile";
+
+  /** Name of the muxing encoding profile */
+  private static final String MUX_AV_PROFILE = "mux-av.copy";
 
   private static final String FORCE_ENCODING = "force-encoding";
   private static final String REQUIRED_EXTENSIONS = "required-extensions";
@@ -218,6 +223,7 @@ public class PartialImportWorkflowOperationHandler extends AbstractWorkflowOpera
     final Opt<String> presentationFlavor = getOptConfig(operation, SOURCE_PRESENTATION_FLAVOR);
     final MediaPackageElementFlavor smilFlavor = MediaPackageElementFlavor.parseFlavor(getConfig(operation, SOURCE_SMIL_FLAVOR));
     final String concatEncodingProfile = getConfig(operation, CONCAT_ENCODING_PROFILE);
+    final String audioMergeEncodingProfile = getConfig(operation, AUDIO_MERGE_ENCODING_PROFILE);
     final Opt<String> concatOutputFramerate = getOptConfig(operation, CONCAT_OUTPUT_FRAMERATE);
     final String trimEncodingProfile = getConfig(operation, TRIM_ENCODING_PROFILE);
     final MediaPackageElementFlavor targetPresenterFlavor = parseTargetFlavor(
@@ -246,6 +252,11 @@ public class PartialImportWorkflowOperationHandler extends AbstractWorkflowOpera
     final EncodingProfile concatProfile = composerService.getProfile(concatEncodingProfile);
     if (concatProfile == null) {
       throw new WorkflowOperationException("Concat encoding profile '" + concatEncodingProfile + "' was not found");
+    }
+
+    final EncodingProfile audioMergeProfile = composerService.getProfile(audioMergeEncodingProfile);
+    if (audioMergeProfile == null)  {
+      throw new WorkflowOperationException("Audio Merge encoding profile '" + audioMergeEncodingProfile + "' was not found");
     }
 
     float outputFramerate = -1.0f;
@@ -280,9 +291,8 @@ public class PartialImportWorkflowOperationHandler extends AbstractWorkflowOpera
     }
 
     // Encode all tracks to same format to enable use of ffmpeg concat-demuxer
-    logger.info("Starting preencoding");
+    logger.info("Starting preencoding video tracks");
     originalTracks = preencode(preencodeProfile, originalTracks);
-
 
     // flavor_type -> job
     final Map<String, Job> jobs = new HashMap<String, Job>();
@@ -300,72 +310,103 @@ public class PartialImportWorkflowOperationHandler extends AbstractWorkflowOpera
     for (int i = 0; i < sequences.getLength(); i++) {
       final SMILElement item = (SMILElement) sequences.item(i);
 
-      for (final String mediaType : new String[] { NODE_TYPE_AUDIO, NODE_TYPE_VIDEO }) {
-        final List<Track> tracks = new ArrayList<Track>();
-        final VCell<String> sourceType = VCell.cell(EMPTY_VALUE);
+      List<Track> videoTracks = new ArrayList<>();
+      final List<Track> audioTracks = new ArrayList<>();
+      final List<Long> audioStartTimes = new ArrayList<>();
+      final VCell<String> sourceType = VCell.cell(EMPTY_VALUE);
 
-        final long position = processChildren(0, tracks, item.getChildNodes(), originalTracks, sourceType, mediaType,
-                elementsToClean, operationId);
+      // first process audio
+      // ----------------------------------------------------------------------------------------------
 
-        if (tracks.isEmpty()) {
-          logger.debug("The tracks list was empty.");
-          continue;
+      final long lastAudioPosition = processAudioTracks(0, audioTracks, audioStartTimes, item.getChildNodes(), originalTracks, sourceType, elementsToClean, operationId);
+      if (audioTracks.size() > 0 && lastAudioPosition < trackDurationInMs) {
+        final double extendingTime = (trackDurationInMs - lastAudioPosition) / 1000d;
+        if (extendingTime > 0) {
+          logger.info("Extending {} audio track end by {} seconds with silent audio", sourceType.get(), extendingTime);
+          audioTracks.add(getSilentAudio(extendingTime, elementsToClean, operationId));
+          audioStartTimes.add(lastAudioPosition);
         }
-        final Track lastTrack = tracks.get(tracks.size() - 1);
+      }
 
-        if (position < trackDurationInMs) {
-          final double extendingTime = (trackDurationInMs - position) / 1000d;
-          if (extendingTime > 0) {
-            if (!lastTrack.hasVideo()) {
-              logger.info("Extending {} audio track end by {} seconds with silent audio", sourceType.get(),
-                      extendingTime);
-              tracks.add(getSilentAudio(extendingTime, elementsToClean, operationId));
-            } else {
-              logger.info("Extending {} track end with last image frame by {} seconds", sourceType.get(), extendingTime);
-              Attachment tempLastImageFrame = extractLastImageFrame(lastTrack, elementsToClean);
-              tracks.add(createVideoFromImage(tempLastImageFrame, extendingTime, elementsToClean));
-            }
-          }
-        }
-
-        if (tracks.size() < 2) {
-          logger.debug("There were less than 2 tracks, copying track...");
-          if (sourceType.get().startsWith(PRESENTER_KEY)) {
-            createCopyOfTrack(mediaPackage, tracks.get(0), targetPresenterFlavor);
-          } else if (sourceType.get().startsWith(PRESENTATION_KEY)) {
-            createCopyOfTrack(mediaPackage, tracks.get(0), targetPresentationFlavor);
-          } else {
-            logger.warn("Can't handle unkown source type '{}' for unprocessed track", sourceType.get());
-          }
-          continue;
-        }
-
-        for (final Track t : tracks) {
-          if (!t.hasVideo() && !t.hasAudio()) {
-            logger.error("No audio or video stream available in the track with flavor {}! {}", t.getFlavor(), t);
-            throw new WorkflowOperationException("No audio or video stream available in the track " + t.toString());
-          }
-        }
-
-        if (sourceType.get().startsWith(PRESENTER_KEY)) {
-          logger.info("Concatenating {} track", PRESENTER_KEY);
-          jobs.put(sourceType.get(), startConcatJob(concatProfile, tracks, outputFramerate, forceDivisible));
-        } else if (sourceType.get().startsWith(PRESENTATION_KEY)) {
-          logger.info("Concatenating {} track", PRESENTATION_KEY);
-          jobs.put(sourceType.get(), startConcatJob(concatProfile, tracks, outputFramerate, forceDivisible));
+      if (audioTracks.size() > 1) {
+        if (sourceType.get().startsWith(PRESENTER_KEY) || sourceType.get().startsWith(PRESENTATION_KEY)) {
+          logger.info("Merging {} audio tracks", sourceType.get());
+          Job audioMergeJob = composerService.mergeAudioTracks(audioMergeProfile.getIdentifier(), audioStartTimes, audioTracks);
+          jobs.put(sourceType.get(), audioMergeJob);
         } else {
           logger.warn("Can't handle unknown source type '{}'!", sourceType.get());
         }
+      } else if (audioTracks.size() == 1) {
+        logger.debug("There is only one audio track, we don't have to merge something, we just copy the track...");
+        if (sourceType.get().startsWith(PRESENTER_KEY)) {
+          createCopyOfTrack(mediaPackage, audioTracks.get(0), deriveAudioFlavor(targetPresenterFlavor));
+        } else if (sourceType.get().startsWith(PRESENTATION_KEY)) {
+          createCopyOfTrack(mediaPackage, audioTracks.get(0), deriveAudioFlavor(targetPresentationFlavor));
+        } else {
+          logger.warn("Can't handle unknown source type '{}' for unprocessed track", sourceType.get());
+        }
+      }
+
+      // now process video tracks
+      // --------------------------------------------------------------------------------------
+
+      sourceType.set("");
+
+      final long lastVideoPosition = processVideoTracks(0, videoTracks, item.getChildNodes(), originalTracks, sourceType, elementsToClean, operationId);
+
+      if (videoTracks.isEmpty()) {
+        logger.debug("The video tracks list was empty.");
+        continue;
+      }
+
+      if (lastVideoPosition < trackDurationInMs) {
+        final double extendingTime = (trackDurationInMs - lastVideoPosition) / 1000d;
+        if (extendingTime > 0) {
+          logger.info("Extending {} track end with last image frame by {} seconds", sourceType.get(), extendingTime);
+          final Track lastTrack = videoTracks.get(videoTracks.size() - 1);
+          Attachment tempLastImageFrame = extractLastImageFrame(lastTrack, elementsToClean);
+          videoTracks.add(createVideoFromImage(tempLastImageFrame, extendingTime, elementsToClean));
+        }
+      }
+
+      if (videoTracks.size() < 2) {
+        logger.debug("There were less than 2 tracks, copying track...");
+        if (sourceType.get().startsWith(PRESENTER_KEY)) {
+          createCopyOfTrack(mediaPackage, videoTracks.get(0), targetPresenterFlavor);
+        } else if (sourceType.get().startsWith(PRESENTATION_KEY)) {
+          createCopyOfTrack(mediaPackage, videoTracks.get(0), targetPresentationFlavor);
+        } else {
+          logger.warn("Can't handle unknown source type '{}' for unprocessed track", sourceType.get());
+        }
+        continue;
+      }
+
+      // Now run the concat process for the video tracks
+      // -----------------------------------------------------------------------------------------
+
+      for (final Track t : videoTracks) {
+        if (!t.hasVideo() && !t.hasAudio()) {
+          logger.error("No audio or video stream available in the track with flavor {}! {}", t.getFlavor(), t);
+          throw new WorkflowOperationException("No audio or video stream available in the track " + t.toString());
+        }
+      }
+
+      if (sourceType.get().startsWith(PRESENTER_KEY) || sourceType.get().startsWith(PRESENTATION_KEY)) {
+        logger.info("Concatenating {} video tracks", sourceType.get());
+        Job concatJob = startConcatJob(concatProfile, videoTracks, outputFramerate, forceDivisible);
+        jobs.put(sourceType.get(), concatJob);
+      } else {
+        logger.warn("Can't handle unknown source type '{}'!", sourceType.get());
       }
     }
 
     // Wait for the jobs to return
     if (jobs.size() > 0) {
       if (!JobUtil.waitForJobs(serviceRegistry, jobs.values()).isSuccess()) {
-        throw new WorkflowOperationException("One of the concat jobs did not complete successfully");
+        throw new WorkflowOperationException("One of the video-concat or audio-merge jobs did not complete successfully");
       }
     } else {
-      logger.info("No concatenating needed for presenter and presentation tracks, took partial source elements");
+      logger.info("No Audio merge or video concat were neccessary. Job list was empty");
     }
 
     // All the jobs have passed, let's update the media package
@@ -850,20 +891,47 @@ public class PartialImportWorkflowOperationHandler extends AbstractWorkflowOpera
   private List<Track> preencode(EncodingProfile profile, List<Track> tracks)
           throws MediaPackageException, EncoderException, WorkflowOperationException, NotFoundException,
           ServiceRegistryException {
+
     List<Track> encodedTracks = new ArrayList<>();
+    Map<String, Job> preencodeJobMap = new HashMap<>();
+
+    // we need this maps, so we can copy some track information from the old track to the new one, when the jobs are finished
+    Map<String, Track> trackMap = new HashMap<>();
+    Map<String, Job> jobMap = new HashMap<>();
+
     for (Track track : tracks) {
-      logger.info("Preencoding track {}", track.getIdentifier());
-      Job encodeJob = composerService.encode(track, profile.getIdentifier());
-      if (!waitForStatus(encodeJob).isSuccess()) {
-        throw new WorkflowOperationException("Encoding of track " + track + " failed");
+      if (track.hasVideo()) {
+        trackMap.put(track.getIdentifier(), track);
+        logger.info("Preencoding track {}", track.getIdentifier());
+        Job encodeJob = composerService.encode(track, profile.getIdentifier());
+        preencodeJobMap.put(track.getIdentifier(), encodeJob);
+      } else {
+        // we only preencode the video tracks
+        // audio tracks will simply be copied
+        encodedTracks.add(track);
       }
-      encodeJob = serviceRegistry.getJob(encodeJob.getId());
-      Track encodedTrack = (Track) MediaPackageElementParser.getFromXml(encodeJob.getPayload());
+    }
+
+    // Wait for the jobs to finish
+    if (preencodeJobMap.size() > 0) {
+      if (!JobUtil.waitForJobs(serviceRegistry, preencodeJobMap.values()).isSuccess()) {
+        throw new WorkflowOperationException("One of the preencode jobs did not complete successfully");
+      }
+    } else {
+      logger.info("Skipping preencode, because there are no video tracks");
+    }
+
+    for (String trackIdentifier : preencodeJobMap.keySet()) {
+      Job preencodeJob = preencodeJobMap.get(trackIdentifier);
+      Track originalTrack = trackMap.get(trackIdentifier);
+
+      preencodeJob = serviceRegistry.getJob(preencodeJob.getId());
+      Track encodedTrack = (Track) MediaPackageElementParser.getFromXml(preencodeJob.getPayload());
       if (encodedTrack == null) {
-        throw new WorkflowOperationException("Encoded track " + track + " failed to produce a track");
+        throw new WorkflowOperationException("Encoded track " + encodedTrack + " failed to produce a track");
       }
-      encodedTrack.setIdentifier(track.getIdentifier());
-      encodedTrack.setFlavor(track.getFlavor());
+      encodedTrack.setIdentifier(originalTrack.getIdentifier());
+      encodedTrack.setFlavor(originalTrack.getFlavor());
       encodedTracks.add(encodedTrack);
     }
 
@@ -933,14 +1001,49 @@ public class PartialImportWorkflowOperationHandler extends AbstractWorkflowOpera
     return trimJob.getQueueTime();
   }
 
-  private long processChildren(long position, List<Track> tracks, NodeList children, List<Track> originalTracks,
-          VCell<String> type, String mediaType, List<MediaPackageElement> elementsToClean, Long operationId)
-          throws EncoderException, MediaPackageException, WorkflowOperationException, NotFoundException, IOException {
+  private long processAudioTracks(long position, List<Track> audioTracks, List<Long> audioStartTimes, NodeList children,
+      List<Track> originalTracks, VCell<String> type, List<MediaPackageElement> elementsToClean, Long operationId)
+      throws EncoderException, MediaPackageException, WorkflowOperationException, NotFoundException, IOException {
+
+    String mediaType = NODE_TYPE_AUDIO;
     for (int j = 0; j < children.getLength(); j++) {
       Node item = children.item(j);
+
       if (item.hasChildNodes()) {
-        position = processChildren(position, tracks, item.getChildNodes(), originalTracks, type, mediaType,
-                elementsToClean, operationId);
+        position = processAudioTracks(position, audioTracks, audioStartTimes, item.getChildNodes(), originalTracks,
+            type, elementsToClean, operationId);
+      } else {
+        SMILMediaElement e = (SMILMediaElement) item;
+        if (mediaType.equals(e.getNodeName())) {
+          Track audioTrack;
+          try {
+            audioTrack = getFromOriginal(e.getId(), originalTracks, type);
+          } catch (IllegalStateException exception) {
+            logger.debug("Skipping smil entry, reason: " + exception.getMessage());
+            continue;
+          }
+          double beginInSeconds = e.getBegin().item(0).getResolvedOffset();
+          long beginInMs = Math.round(beginInSeconds * 1000d);
+          audioStartTimes.add(beginInMs);
+          audioTracks.add(audioTrack);
+          position = beginInMs + Math.round(e.getDur() * 1000f);
+        }
+      }
+    }
+    return position;
+  }
+
+  private long processVideoTracks(long position, List<Track> videoTracks, NodeList children, List<Track> originalTracks,
+      VCell<String> type, List<MediaPackageElement> elementsToClean, Long operationId)
+      throws EncoderException, MediaPackageException, WorkflowOperationException, NotFoundException, IOException {
+
+    String mediaType = NODE_TYPE_VIDEO;
+    for (int j = 0; j < children.getLength(); j++) {
+      Node item = children.item(j);
+
+      if (item.hasChildNodes()) {
+        position = processVideoTracks(position, videoTracks, item.getChildNodes(), originalTracks, type,
+            elementsToClean, operationId);
       } else {
         SMILMediaElement e = (SMILMediaElement) item;
         if (mediaType.equals(e.getNodeName())) {
@@ -957,32 +1060,21 @@ public class PartialImportWorkflowOperationHandler extends AbstractWorkflowOpera
           if (beginInMs > position) {
             double positionInSeconds = position / 1000d;
             if (position == 0) {
-              if (NODE_TYPE_AUDIO.equals(e.getNodeName())) {
-                logger.info("Extending {} audio track start by {} seconds silent audio", type.get(), beginInSeconds);
-                tracks.add(getSilentAudio(beginInSeconds, elementsToClean, operationId));
-              } else {
-                logger.info("Extending {} track start image frame by {} seconds", type.get(), beginInSeconds);
-                Attachment tempFirstImageFrame = extractImage(track, 0, elementsToClean);
-                tracks.add(createVideoFromImage(tempFirstImageFrame, beginInSeconds, elementsToClean));
-              }
+              logger.info("Extending {} track start image frame by {} seconds", type.get(), beginInSeconds);
+              Attachment tempFirstImageFrame = extractImage(track, 0, elementsToClean);
+              videoTracks.add(createVideoFromImage(tempFirstImageFrame, beginInSeconds, elementsToClean));
               position += beginInMs;
             } else {
               double fillTime = (beginInMs - position) / 1000d;
-              if (NODE_TYPE_AUDIO.equals(e.getNodeName())) {
-                logger.info("Fill {} audio track gap from {} to {} with silent audio", type.get(),
-                        Double.toString(positionInSeconds), Double.toString(beginInSeconds));
-                tracks.add(getSilentAudio(fillTime, elementsToClean, operationId));
-              } else {
-                logger.info("Fill {} track gap from {} to {} with image frame",
-                        type.get(), Double.toString(positionInSeconds), Double.toString(beginInSeconds));
-                Track previousTrack = tracks.get(tracks.size() - 1);
-                Attachment tempLastImageFrame = extractLastImageFrame(previousTrack, elementsToClean);
-                tracks.add(createVideoFromImage(tempLastImageFrame, fillTime, elementsToClean));
-              }
+              logger.info("Fill {} track gap from {} to {} with image frame", type.get(),
+                  Double.toString(positionInSeconds), Double.toString(beginInSeconds));
+              Track previousTrack = videoTracks.get(videoTracks.size() - 1);
+              Attachment tempLastImageFrame = extractLastImageFrame(previousTrack, elementsToClean);
+              videoTracks.add(createVideoFromImage(tempLastImageFrame, fillTime, elementsToClean));
               position = beginInMs;
             }
           }
-          tracks.add(track);
+          videoTracks.add(track);
           position += Math.round(e.getDur() * 1000f);
         }
       }


### PR DESCRIPTION
These changes ensure, that Opencast correctly handles media where partial ingests include overlapping audio. Therefore it fixes the BigBlueButton-Opencast Integration, because BBB is using LiveKit since version 3.0, which results in multiple overlapping audio snippets.

Note: 
a) This PR adds an encoding profile.
b) The workflow operation should function like before with one benefit: Now it can handle audio that overlaps.

### How to test this patch

You have to ingest multiple audio tracks. It would be good if different combinations would be tested like: 
1. presenter has video tracks, presentation has audio tracks
2. presenter has video and audio tracks, presentation has nothing
3. ...

I created a script in the helper-scripts repository for testing purposes:
https://github.com/marwyg/helper-scripts/tree/complex-partial-ingest/ingest/complex-partial-ingest

There is also a PR for this:
https://github.com/opencast/helper-scripts/pull/82

In this repository you will find a partial-ingest.sh script, where you can configure your opencast stuff. In the directory is also a workflow you can use for the testing (partial-import-test.xml). The workflow simply runs the workflow operations and ends, so you can check the result in the assets. You can change up the encoding profiles in the workflow or use the encoding profiles provided in the same directory as the workflow. The file is named `partial-import-encoding-profiles.properties`.

I created some audio and video files. I configured the ingests in a way, that the presenter tracks will include lower pitched audios and the presentation higher pitched once.

I also added some video snippets. I am ingesting it in such a way, that the presenter tracks will start with the blue-yellow snippet and end with the purple one. The presentation tracks will be vice versa.

There is a new endpoint for the audio merge part, because the merge jobs will be offloaded to the workers. To test this locally, you can use the multi_node_setup script: https://github.com/marwyg/helper-scripts/tree/complex-partial-ingest/multi-node-test-setup: https://github.com/opencast/helper-scripts/tree/master/multi-node-test-setup It will build an admin, presentation and worker node and you can start them all locally and let them run simultaneously.

--

When I tested this I got the following results, but please feel free to add more test cases. Maybe I forgot some:

legend: v = video, a = audio, p = presenter, s = presentation (s for slides)
for example: vp - vas -> presenter with video, presentation with video and audio

- vap - vas
	- 2 Tracks, both are muxed video and audio
- ap - as
	- 2 tracks, both audio
- ap
	- 1 presenter audio track
- as
	- 1 presentation audio track
- vp - vs
	- 2 tracks, both video only
- vp
	- 1 presenter video track
- vs
	- 1 presentation video track
- vas
	- 1 presentation track, audio and video muxed
- vap
	- 1 presenter track, audio and video muxed
- ap - vs
	- 1 presentation track, audio and video muxed
- ap - vas
	- 2 tracks, presenter = audio, presentation = audio and video muxed
- vp - as
	- 1 presenter track, audio and video muxed
- vp - vas
	- 2 tracks, presenter = video, presentation = audio and video muxed
- vap - as
	- 2 tracks, presenter = video and audio muxed, presentation = audio
- vap - vs
	- 2 tracks, presenter = video and audio muxed, presentation = video
	
	
edit: 

1) I added a default encoding profile as fallback, therefore the workflow parameter is optional now.
2) The reason for this going into 17 is, that this is an important Bugfix, because the BBB-OC Integration no longer works, without these changes.
