### PR TITLE
docs: Download npm packages to common folder

### DIFF
--- a/docs/guides/developer/docs/develop/setup-opencast-for-develop.md
+++ b/docs/guides/developer/docs/develop/setup-opencast-for-develop.md
@@ -174,6 +174,22 @@ To fix a NPM access error ([example](https://stackoverflow.com/questions/1615101
 
     $ sudo chown -R $USER:$(id -gn $USER) ~/.config && sudo chown -R $USER:$(id -gn $USER) ~/.npm
 
+### NPM Timeout
+
+To avoid timeout and connection errors when downloading npm packages used in UI modules that are not maintained as dedicated
+projects (`engage-paella-player-7`, `engage-paella-player-8`, `engage-ui`, `graphql-ui`, `lti` and `runtime-info-ui`), you can
+configure an npm cache by setting an environment variable before running Maven. For example: `NPM_CONFIG_CACHE=~/.npm`.
+
+This is especially useful when building inside a container:
+
+```sh
+% docker run -v /path/to/opencast:/opencast -v npm-cache:/root/.npm ...
+
+% cd /opencast
+% export NPM_CONFIG_CACHE=/root/.npm
+% ./mvnv clean install ...
+```
+
 ### JDK Version
 
 Some IDEs attempt to use the most recent version of the JDK. Make sure that your IDE uses JDK 11.


### PR DESCRIPTION
When building Opencast maven stores downloaded artifacts for all modules in `~/.m2` - saving time and bandwidth when building again. That's especially useful if using containers for builds:

`podman run -v maven-cache:/root/.m2 ...`

The goal of this PR is to do the same for npm packages, that are downloaded (`npm ci`) for building the "embedded" UIs (`engage-paella-player-7`, `engage-ui`, `graphql-ui`, `lti` and `runtime-info-ui`) by configuring _cache_ in `.npmrc`, so you can do something like:

`podman run -v maven-cache:/root/.m2 -v npm-cache:/root/.npm ...`

Futhermore this eases the problem of stuck builds of these modules - after initial population of the npm-cache builds work reliably.

### How to test this patch
1) Build Opencast on your local machine
2) Verify if npm packages are stored in ~/.npm, the size should be approx. ~170MB
3) Build Opencast again... no npm packages should be downloaded and the build time should decrease.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
