### PR TITLE
Fix HEAD requests to static files returning wrong status codes

### DIFF
--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -312,7 +312,9 @@
     <sec:intercept-url pattern="/search/**" method="GET" access="ROLE_ANONYMOUS" />
     <sec:intercept-url pattern="/usertracking/**" method="GET" access="ROLE_ANONYMOUS" />
     <sec:intercept-url pattern="/usertracking/**" method="PUT" access="ROLE_ANONYMOUS" />
+    <!-- The `/static` route is separately protected, see `StaticResoruceServlet` -->
     <sec:intercept-url pattern="/static/**" method="GET" access="ROLE_ANONYMOUS" />
+    <sec:intercept-url pattern="/static/**" method="HEAD" access="ROLE_ANONYMOUS" />
     <sec:intercept-url pattern="/export/**" method="GET" access="ROLE_ANONYMOUS" />
 
     <!-- Enable access to Opencast Studio -->

--- a/modules/static/src/main/java/org/opencastproject/fsresources/StaticResourceServlet.java
+++ b/modules/static/src/main/java/org/opencastproject/fsresources/StaticResourceServlet.java
@@ -178,6 +178,16 @@ public class StaticResourceServlet extends HttpServlet {
   @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
     logger.debug("Looking for static resource '{}'", req.getRequestURI());
+    impl(req, resp, true);
+  }
+
+  @Override
+  protected void doHead(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    logger.trace("HEAD request '{}'", req.getRequestURI());
+    impl(req, resp, false);
+  }
+
+  private void impl(HttpServletRequest req, HttpServletResponse resp, boolean withBody) throws IOException {
     String path = req.getPathInfo();
     if (path == null || path.contains("..")) {
       resp.sendError(HttpServletResponse.SC_FORBIDDEN);
@@ -221,14 +231,16 @@ public class StaticResourceServlet extends HttpServlet {
     ArrayList<Range> ranges = parseRange(req, resp, eTag, file.lastModified(), file.length());
 
     if ((((ranges == null) || (ranges.isEmpty())) && (req.getHeader("Range") == null)) || (ranges == FULL_RANGE)) {
-      IOException e = copyRange(new FileInputStream(file), resp.getOutputStream(), 0, file.length());
-      if (e != null) {
-        try {
-          resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-        } catch (IOException e1) {
-          logger.warn("unable to send http 500 error", e1);
-        } catch (IllegalStateException e2) {
-          logger.trace("unable to send http 500 error. Client side was probably closed during file copy.", e2);
+      if (withBody) {
+        IOException e = copyRange(new FileInputStream(file), resp.getOutputStream(), 0, file.length());
+        if (e != null) {
+          try {
+            resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+          } catch (IOException e1) {
+            logger.warn("unable to send http 500 error", e1);
+          } catch (IllegalStateException e2) {
+            logger.trace("unable to send http 500 error. Client side was probably closed during file copy.", e2);
+          }
         }
       }
       return;
@@ -246,20 +258,22 @@ public class StaticResourceServlet extends HttpServlet {
         // Set the content-length as String to be able to use a long
         resp.setHeader("content-length", "" + length);
       }
-      try {
-        resp.setBufferSize(2048);
-      } catch (IllegalStateException e) {
-        logger.debug(e.getMessage(), e);
-      }
       resp.setStatus(HttpServletResponse.SC_PARTIAL_CONTENT);
-      IOException e = copyRange(new FileInputStream(file), resp.getOutputStream(), range.start, range.end);
-      if (e != null) {
+      if (withBody) {
         try {
-          resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-        } catch (IOException e1) {
-          logger.warn("unable to send http 500 error", e1);
-        } catch (IllegalStateException e2) {
-          logger.trace("unable to send http 500 error. Client side was probably closed during file copy.", e2);
+          resp.setBufferSize(2048);
+        } catch (IllegalStateException e) {
+          logger.debug(e.getMessage(), e);
+        }
+        IOException e = copyRange(new FileInputStream(file), resp.getOutputStream(), range.start, range.end);
+        if (e != null) {
+          try {
+            resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+          } catch (IOException e1) {
+            logger.warn("unable to send http 500 error", e1);
+          } catch (IllegalStateException e2) {
+            logger.trace("unable to send http 500 error. Client side was probably closed during file copy.", e2);
+          }
         }
       }
       return;
@@ -267,12 +281,14 @@ public class StaticResourceServlet extends HttpServlet {
 
     resp.setStatus(HttpServletResponse.SC_PARTIAL_CONTENT);
     resp.setContentType("multipart/byteranges; boundary=" + mimeSeparation);
-    try {
-      resp.setBufferSize(2048);
-    } catch (IllegalStateException e) {
-      logger.debug(e.getMessage(), e);
+    if (withBody) {
+      try {
+        resp.setBufferSize(2048);
+      } catch (IllegalStateException e) {
+        logger.debug(e.getMessage(), e);
+      }
+      copy(file, resp.getOutputStream(), ranges.iterator(), contentType);
     }
-    copy(file, resp.getOutputStream(), ranges.iterator(), contentType);
   }
 
   /**


### PR DESCRIPTION
I'm not sure if this is the best way to do it, but I just overwrite `doHead` and do everything that `doGet` would do, except add a body. This still opens the file and does some other logic, but it is required to correctly set status code and headers.

Fixes #7179

It is targeting a legacy branch as this is a bug fix, that `octoka` will rely on. Without this being backported to 17, it's harder for people to use octoka.

### How to test this patch

Upload some test videos in different visibilities and then send HEAD requests to static file routes. 

To review the code, enable "hide whitespace", which makes the diff considerably smaller.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
