### PR TITLE
Fix APIs replying 302 for unauthorized requests

### DIFF
--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -525,8 +525,33 @@
   </bean>
 
   <!-- Redirects unauthenticated requests to the login form -->
-  <bean id="userEntryPoint" class="org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint">
+  <bean id="redirectingEntryPoint" class="org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint">
     <property name="loginFormUrl" value="/login.html" />
+  </bean>
+
+  <!-- Entry point that redirects to /login for certain paths, replying 403 otherwise -->
+  <bean id="userEntryPoint" class="org.opencastproject.kernel.security.UserEntryPoint">
+    <property name="redirectingEntryPoint" ref="redirectingEntryPoint" />
+    <property name="redirectingPathPatterns">
+      <list>
+        <value>**/index.html</value>
+        <value>/admin-ui/**</value>
+        <value>/admin-ng</value>
+        <value>/admin-ng/</value>
+        <value>/rest_docs.*</value>
+        <value>/rest-docs/**</value>
+        <value>/docs.*</value>
+        <value>/engage/ui/**</value>
+        <value>/studio</value>
+        <value>/studio/</value>
+        <value>/editor-ui</value>
+        <value>/editor-ui/</value>
+        <value>/engage-player</value>
+        <value>/engage-player/</value>
+        <value>/ltitools</value>
+        <value>/ltitools/</value>
+      </list>
+    </property>
   </bean>
 
   <!-- Redirect unauthenticated requests to custom login url with configurable redirect query parameter

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/UserEntryPoint.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/UserEntryPoint.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.kernel.security;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
+import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
+import org.springframework.security.web.util.AntPathRequestMatcher;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * An {@link AuthenticationEntryPoint} that delegates to either a specified redirecting AEP or to
+ * one replying with 403.
+ */
+public class UserEntryPoint implements AuthenticationEntryPoint {
+
+  private LoginUrlAuthenticationEntryPoint redirectingEntryPoint;
+  private Http403ForbiddenEntryPoint forbiddenEntryPoint = new Http403ForbiddenEntryPoint();
+  private List<AntPathRequestMatcher> redirectingPathPatterns;
+  private static final Logger logger = LoggerFactory.getLogger(UserEntryPoint.class);
+
+  public UserEntryPoint() {
+  }
+
+  @Override
+  public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+          throws IOException, ServletException {
+    var routeMatch = this.redirectingPathPatterns.stream().filter(pattern -> pattern.matches(request)).findFirst();
+    logger.debug("Match {} against routes: {}", request.getRequestURI(), routeMatch);
+
+    if (routeMatch.isPresent()) {
+      this.redirectingEntryPoint.commence(request, response, authException);
+    } else {
+      this.forbiddenEntryPoint.commence(request, response, authException);
+    }
+  }
+
+  public void setRedirectingEntryPoint(LoginUrlAuthenticationEntryPoint redirectingEntryPoint) {
+    this.redirectingEntryPoint = redirectingEntryPoint;
+  }
+
+  public void setRedirectingPathPatterns(List<String> patterns) {
+    logger.debug("Set redirectingPathPatterns to {}", patterns);
+    this.redirectingPathPatterns = patterns.stream()
+          .map(pattern -> new AntPathRequestMatcher(pattern))
+          .collect(Collectors.toList());
+  }
+}


### PR DESCRIPTION
Fixes #3244

Deciding when to reply 403 vs 302 is done purely on a path base. See the linked issue for arguments about this. The paths are configurable in the security config, so even if I missed something now, adopters can just add other paths they seem important.

The path `/` is not listed there, as it always replies 200 with a JS redirect. 

### How to test this patch

Run Opencast and just `curl` against a bunch of different paths. 

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
