### PR TITLE
Change default `mediapackage-element-type` to `Track` for WebVttCaptionConverter

### DIFF
--- a/etc/org.opencastproject.caption.converters.WebVttCaptionConverter.cfg
+++ b/etc/org.opencastproject.caption.converters.WebVttCaptionConverter.cfg
@@ -1,5 +1,5 @@
 
 # defines the mediapackage element type of the subtitle files
 # possible values: Attachment, Track
-# default: Attachment
-#mediapackage-element-type=Attachment
+# default: Track
+#mediapackage-element-type=Track

--- a/modules/caption-impl/src/main/java/org/opencastproject/caption/converters/WebVttCaptionConverter.java
+++ b/modules/caption-impl/src/main/java/org/opencastproject/caption/converters/WebVttCaptionConverter.java
@@ -60,7 +60,7 @@ public class WebVttCaptionConverter implements CaptionConverter {
 
   /** This configuration key defines the mediapackage element type of the captions file (Attachment, Track) */
   static final String MEDIAPACKAGE_ELEMENT_TYPE_CONFIG_KEY = "mediapackage-element-type";
-  static final Type DEFAULT_MEDIAPACKAGE_ELEMENT_TYPE = Type.Attachment;
+  static final Type DEFAULT_MEDIAPACKAGE_ELEMENT_TYPE = Type.Track;
   private static Type mediapackageElementType = DEFAULT_MEDIAPACKAGE_ELEMENT_TYPE;
 
 


### PR DESCRIPTION
We decided a while ago that we want subtitles as tracks instead of attachments.
### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
