### PR TITLE
Fix incorrect escaping in site GHA build

### DIFF
--- a/.github/workflows/test-opencast-site.yml
+++ b/.github/workflows/test-opencast-site.yml
@@ -147,7 +147,7 @@ jobs:
           rm -rf $BRANCH
           mv ../site_build $BRANCH
           #Generate an index, in case anyone lands at the root of the test domain
-          echo $'<html><head><link rel=stylesheet type=text/css href=assets/index.css /></head><body><div class="head-container"><img src=assets/opencast-white.svg /></div><div class="navbar-container"></div><div class="text-container"><p>Deployment of Opencast's Maven Site and Code Coverage.  The branches listed here correspond to Opencast\'s own branches.</br><b>Please select a version.</b></p></div><ul>' > index.html
+          echo $'<html><head><link rel=stylesheet type=text/css href=assets/index.css /></head><body><div class="head-container"><img src=assets/opencast-white.svg /></div><div class="navbar-container"></div><div class="text-container"><p>Deployment of Opencast'''s Maven Site and Code Coverage.  The branches listed here correspond to Opencast'''s own branches.</br><b>Please select a version.</b></p></div><ul>' > index.html
           find . -mindepth 1 -maxdepth 1 -type d \
             | grep '[0-9]*.x\|develop' \
             | sort -r \


### PR DESCRIPTION
This PR fixes some escaping in the site index generation. 

### How to test this patch

Copy the modified echo statement, and run it locally

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] ~explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch~
