### PR TITLE
Silence unconfigured Matomo stats provider

### DIFF
--- a/modules/statistics-provider-matomo/src/main/java/org/opencastproject/statistics/provider/matomo/StatisticsProviderMatomoService.java
+++ b/modules/statistics-provider-matomo/src/main/java/org/opencastproject/statistics/provider/matomo/StatisticsProviderMatomoService.java
@@ -150,6 +150,8 @@ public class StatisticsProviderMatomoService implements ArtifactInstaller {
   @Modified
   public void modified(Map<String, Object> properties) {
     if (properties == null) {
+      logger.info("Configuration file not found. Not connecting to Matomo API.");
+    } else if (!(properties.containsKey(KEY_MATOMO_API_TOKEN) || properties.containsKey(KEY_MATOMO_API_URL))) {
       logger.info("No configuration available. Not connecting to Matomo API.");
     } else {
       final Object matomoApiUrlValue = properties.get(KEY_MATOMO_API_URL);


### PR DESCRIPTION
The new Matomo stats provider (#7134) throws exceptions on startup when you have not configured anything at all (ie, the default state).  This is obviously undesireable, so we introduce a check here that if the config object passed in is empty then we disable and log as such.

### How to test this patch

Start Opencast without this patch, and observe

```
2025-11-19T15:42:21,375 | ERROR | (ScrLogManager$ScrLoggerFacade:206) - bundle opencast-statistics-provider-matomo:19.0.0.SNAPSHOT (182)[org.o
pencastproject.statistics.provider.matomo.StatisticsProviderMatomoService(112)] : The activate method has thrown an exception
org.opencastproject.util.ConfigurationException: Matomo API URL is missing in config file.
        at org.opencastproject.statistics.provider.matomo.StatisticsProviderMatomoService.modified(StatisticsProviderMatomoService.java:159) ~
[?:?]
        at org.opencastproject.statistics.provider.matomo.StatisticsProviderMatomoService.activate(StatisticsProviderMatomoService.java:97) ~[
?:?]
        at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[?:?]
[...]
```

With it you get
```
2025-11-19 16:07:53,370 | INFO  | (StatisticsProviderMatomoService:155) - No configuration available. Not connecting to Matomo API.
```


### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] ~explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch~
