### PR TITLE
Update develop Admin UI to 19.x-2025-11-20

### DIFF
--- a/modules/admin-ui-interface/pom.xml
+++ b/modules/admin-ui-interface/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <interface.url>https://github.com/opencast/opencast-admin-interface/releases/download/18.x-2025-10-24/oc-admin-ui-18.x-2025-10-24.tar.gz</interface.url>
-    <interface.sha256>961ecf976bdbcff044ea23e864a6e3ca6c585a0d4a8133f07929c1e1f82c0001</interface.sha256>
+    <interface.url>https://github.com/opencast/opencast-admin-interface/releases/download/19.x-2025-11-20/oc-admin-ui-19.x-2025-11-20.tar.gz</interface.url>
+    <interface.sha256>d605dae7aab1ef6073b7d23543251025aff8e2fa23a43e40fc9bfb6294e1d261</interface.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
Updating Opencast develop Admin UI module to [19.x-2025-11-20](https://github.com/opencast/opencast-admin-interface/releases/tag/19.x-2025-11-20)