### PR TITLE
Update develop Editor to 19.x-2025-11-20

### DIFF
--- a/modules/editor/pom.xml
+++ b/modules/editor/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <editor.url>https://github.com/opencast/opencast-editor/releases/download/18.x-2025-10-24/oc-editor-18.x-2025-10-24.tar.gz</editor.url>
-    <editor.sha256>1a1f23297db770d0cb93ac65f5056ba451144a5a0d572922eb5a5f72bf7598ad</editor.sha256>
+    <editor.url>https://github.com/opencast/opencast-editor/releases/download/19.x-2025-11-20/oc-editor-19.x-2025-11-20.tar.gz</editor.url>
+    <editor.sha256>e5e205571a5292edb1a94c2b2be2b2032d5fe3dbe77aab5492f0c3853bba8f4d</editor.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
Updating Opencast develop Editor module to [19.x-2025-11-20](https://github.com/opencast/opencast-editor/releases/tag/19.x-2025-11-20)