### PR TITLE
Create YouTube playlists with non-public privacy status

### DIFF
--- a/etc/org.opencastproject.publication.youtube.YouTubeV3PublicationServiceImpl.cfg
+++ b/etc/org.opencastproject.publication.youtube.YouTubeV3PublicationServiceImpl.cfg
@@ -5,6 +5,9 @@ org.opencastproject.publication.youtube.keywords=CHANGE_ME
 
 # The following property corresponds to public or private status at YouTube
 org.opencastproject.publication.youtube.makeVideosPrivate=true
+# The following property corresponds to the privacy status of any newly created playlist.
+# Acceptible values are public, private and unlisted
+org.opencastproject.publication.youtube.playlistPrivacy=public
 org.opencastproject.publication.youtube.defaultPlaylist=CHANGE_ME
 
 # The next property reflects a YouTube rule concerning playlist and video titles.

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeAPIVersion3Service.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeAPIVersion3Service.java
@@ -110,9 +110,11 @@ public interface YouTubeAPIVersion3Service {
    * Creates YouTube Playlist and adds it to the authorized account.
    * @param title may not be {@code null}
    * @param description may not be {@code null}
+   * @param privacyStatus may not be {@code null}
    * @param tags zero or more tags to be applied to playlist on YouTube.
    */
-  Playlist createPlaylist(String title, String description, String... tags) throws IOException;
+  Playlist createPlaylist(String title, String description, PrivacyStatus privacyStatus, String... tags)
+          throws IOException;
 
   /**
    * Remove a previously uploaded video from YouTube.
@@ -136,4 +138,10 @@ public interface YouTubeAPIVersion3Service {
    */
   void removeMyPlaylist(String playlistId) throws IOException;
 
+  /** Valid values for YouTube privacy statuses */
+  enum PrivacyStatus {
+    PUBLIC,
+    PRIVATE,
+    UNLISTED
+  }
 }

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeAPIVersion3ServiceImpl.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeAPIVersion3ServiceImpl.java
@@ -99,17 +99,16 @@ public class YouTubeAPIVersion3ServiceImpl implements YouTubeAPIVersion3Service 
   }
 
   @Override
-  public Playlist createPlaylist(final String title, final String description, final String... tags)
-          throws IOException {
+  public Playlist createPlaylist(final String title, final String description, PrivacyStatus privacyStatus,
+          final String... tags) throws IOException {
     final PlaylistSnippet playlistSnippet = new PlaylistSnippet();
     playlistSnippet.setTitle(title);
     playlistSnippet.setDescription(description);
     if (tags.length > 0) {
       playlistSnippet.setTags(Collections.list(tags));
     }
-    // Playlists are always public. The videos therein might be private.
     final PlaylistStatus playlistStatus = new PlaylistStatus();
-    playlistStatus.setPrivacyStatus("public");
+    playlistStatus.setPrivacyStatus(privacyStatus.name().toLowerCase());
 
     // Create playlist with metadata and status.
     final Playlist youTubePlaylist = new Playlist();

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeKey.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeKey.java
@@ -34,5 +34,6 @@ public enum YouTubeKey {
   keywords,
   defaultPlaylist,
   makeVideosPrivate,
+  playlistPrivacy,
   maxFieldLength;
 }

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
@@ -66,6 +66,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.Dictionary;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -145,6 +146,7 @@ public class YouTubeV3PublicationServiceImpl
   private String defaultPlaylist;
 
   private boolean makeVideosPrivate;
+  private YouTubeAPIVersion3Service.PrivacyStatus playlistPrivacy;
 
   private String[] tags;
 
@@ -207,6 +209,8 @@ public class YouTubeV3PublicationServiceImpl
           defaultPlaylist = YouTubeUtils.get(properties, YouTubeKey.defaultPlaylist);
           makeVideosPrivate = StringUtils
                   .containsIgnoreCase(YouTubeUtils.get(properties, YouTubeKey.makeVideosPrivate), "true");
+          playlistPrivacy = YouTubeAPIVersion3Service.PrivacyStatus.valueOf(Objects.requireNonNullElse(
+                  YouTubeUtils.get(properties, YouTubeKey.playlistPrivacy, false), "public").toUpperCase());
           defaultMaxFieldLength(YouTubeUtils.get(properties, YouTubeKey.maxFieldLength, false));
         } else {
           logger.warn("Client information file does not exist: " + path);
@@ -296,7 +300,8 @@ public class YouTubeV3PublicationServiceImpl
       final Playlist playlist;
       final Playlist existingPlaylist = youTubeService.getMyPlaylistByTitle(playlistName);
       if (existingPlaylist == null) {
-        playlist = youTubeService.createPlaylist(playlistName, c.getContextDescription(), mediaPackage.getSeries());
+        playlist = youTubeService.createPlaylist(playlistName, c.getContextDescription(), playlistPrivacy,
+            mediaPackage.getSeries());
       } else {
         playlist = existingPlaylist;
       }

--- a/modules/publication-service-youtube-v3/src/test/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImplTest.java
+++ b/modules/publication-service-youtube-v3/src/test/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImplTest.java
@@ -100,7 +100,8 @@ public class YouTubeV3PublicationServiceImplTest {
         .loadFromXml(xml);
     //
     expect(youTubeService.getMyPlaylistByTitle(mediaPackage.getTitle())).andReturn(null).once();
-    expect(youTubeService.createPlaylist(mediaPackage.getSeriesTitle(), null, mediaPackage.getSeries()))
+    expect(youTubeService.createPlaylist(mediaPackage.getSeriesTitle(), null,
+      YouTubeAPIVersion3Service.PrivacyStatus.PUBLIC, mediaPackage.getSeries()))
       .andReturn(new Playlist()).once();
     expect(youTubeService.addVideoToMyChannel(anyObject(VideoUpload.class))).andReturn(new Video()).once();
     expect(youTubeService.addPlaylistItem(anyObject(String.class), anyObject(String.class)))


### PR DESCRIPTION
This is part of opencast/roadmap#17 and adds a new configuration option to the YouTube publication service which controls the privacy status of any playlists newly created by the service. It does **not** affect existing playlists!

Some questions for @ypatios, who commissioned this feature:

- Is this enough for you or do you need this for videos as well? [Here](https://github.com/opencast/roadmap/issues/17#issuecomment-3280869877) we talked only about playlists, but in your [original post](https://github.com/opencast/roadmap/issues/17#issuecomment-2797040594) you mentioned videos as well. Note that you can already create public and private videos. What's missing is “just” an option to upload unlisted videos.
- I hope putting this towards `develop` is fine?
- Is this service level configurability enough for you or do you need this per workflow run?