### PR TITLE
Set proper language in YouTube publication

### DIFF
--- a/etc/org.opencastproject.publication.youtube.YouTubeV3PublicationServiceImpl.cfg
+++ b/etc/org.opencastproject.publication.youtube.YouTubeV3PublicationServiceImpl.cfg
@@ -3,6 +3,16 @@ org.opencastproject.publication.youtube.enabled=false
 org.opencastproject.publication.youtube.category=CHANGE_ME
 org.opencastproject.publication.youtube.keywords=CHANGE_ME
 
+# The following group of properties determines how to extract the audio
+# and metadata language that is transferred to YouTube from the media package.
+# `languageTarget` can be either `audio`, `metadata`, or `both` and determines whether
+# the language is set for the metadata or the video's audio track.
+# If it's unset, no language will be transferred.
+#org.opencastproject.publication.youtube.languageTarget=both
+# For each potential BCP-47 language code that you might want to set in YouTube,
+# we need a pattern to match against the language in the media package.
+#org.opencastproject.publication.youtube.languagePatterns.fr=fra
+
 # The following property corresponds to public or private status at YouTube
 org.opencastproject.publication.youtube.makeVideosPrivate=true
 org.opencastproject.publication.youtube.defaultPlaylist=CHANGE_ME

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/VideoUpload.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/VideoUpload.java
@@ -34,6 +34,8 @@ public class VideoUpload {
 
   private final String title;
   private final String description;
+  private final String metadataLanguage;
+  private final String audioLanguage;
   private final String privacyStatus;
   private final File videoFile;
   private final MediaHttpUploaderProgressListener progressListener;
@@ -42,6 +44,8 @@ public class VideoUpload {
   /**
    * @param title may not be {@code null}.
    * @param description may be {@code null}.
+   * @param metadataLanguage may be {@code null}.
+   * @param audioLanguage may be {@code null}.
    * @param privacyStatus may not be {@code null}.
    * @param videoFile may not be {@code null}.
    * @param progressListener may be {@code null}.
@@ -50,6 +54,8 @@ public class VideoUpload {
   public VideoUpload(
       final String title,
       final String description,
+      final String metadataLanguage,
+      final String audioLanguage,
       final String privacyStatus,
       final File videoFile,
       final MediaHttpUploaderProgressListener progressListener,
@@ -57,6 +63,8 @@ public class VideoUpload {
   ) {
     this.title = title;
     this.description = description;
+    this.metadataLanguage = metadataLanguage;
+    this.audioLanguage = audioLanguage;
     this.privacyStatus = privacyStatus;
     this.videoFile = videoFile;
     this.progressListener = progressListener;
@@ -77,6 +85,22 @@ public class VideoUpload {
    */
   public String getDescription() {
     return description;
+  }
+
+  /**
+   * The video's language.
+   * The value may be {@code null}.
+   */
+  public String getMetadataLanguage() {
+    return metadataLanguage;
+  }
+
+  /**
+   * The video's audio language.
+   * The value may be {@code null}.
+   */
+  public String getAudioLanguage() {
+    return audioLanguage;
   }
 
   /**

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeAPIVersion3ServiceImpl.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeAPIVersion3ServiceImpl.java
@@ -77,6 +77,8 @@ public class YouTubeAPIVersion3ServiceImpl implements YouTubeAPIVersion3Service 
     final VideoSnippet snippet = new VideoSnippet();
     snippet.setTitle(videoUpload.getTitle());
     snippet.setDescription(videoUpload.getDescription());
+    snippet.setDefaultLanguage(videoUpload.getMetadataLanguage());
+    snippet.setDefaultAudioLanguage(videoUpload.getAudioLanguage());
     final String[] tags = videoUpload.getTags();
     if (ArrayUtils.isNotEmpty(tags)) {
       snippet.setTags(Collections.list(tags));

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeKey.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeKey.java
@@ -33,6 +33,8 @@ public enum YouTubeKey {
   dataStore,
   keywords,
   defaultPlaylist,
+  languageTarget,
+  languagePatterns,
   makeVideosPrivate,
   maxFieldLength;
 }

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubePublicationAdapter.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubePublicationAdapter.java
@@ -142,6 +142,21 @@ public class YouTubePublicationAdapter {
   }
 
   /**
+   * Gets the language for the episode of the media package
+   *
+   * @return the language of the episode
+   */
+  public String getEpisodeLanguage() {
+    if (dcEpisode != null) {
+      return dcEpisode.getFirst(DublinCore.PROPERTY_LANGUAGE);
+    }
+    if (dcSeries != null) {
+      return dcSeries.getFirst(DublinCore.PROPERTY_LANGUAGE);
+    }
+    return null;
+  }
+
+  /**
    * Parse Dublincore metadata from the workspace
    *
    * @param catalog

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubePublicationAdapter.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubePublicationAdapter.java
@@ -22,6 +22,7 @@
 package org.opencastproject.publication.youtube;
 
 import org.opencastproject.mediapackage.Catalog;
+import org.opencastproject.mediapackage.EName;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElements;
 import org.opencastproject.metadata.dublincore.DublinCore;
@@ -147,11 +148,21 @@ public class YouTubePublicationAdapter {
    * @return the language of the episode
    */
   public String getEpisodeLanguage() {
-    if (dcEpisode != null) {
-      return dcEpisode.getFirst(DublinCore.PROPERTY_LANGUAGE);
-    }
+    return getEpisodeProperty(DublinCore.PROPERTY_LANGUAGE);
+  }
+
+  /**
+   * Gets a property for the episode of the media package
+   *
+   * @param property the property to get
+   * @return the property value
+   */
+  private String getEpisodeProperty(EName property) {
     if (dcSeries != null) {
-      return dcSeries.getFirst(DublinCore.PROPERTY_LANGUAGE);
+      return dcSeries.getFirst(property);
+    }
+    if (dcEpisode != null) {
+      return dcEpisode.getFirst(property);
     }
     return null;
   }

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeUtils.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeUtils.java
@@ -26,6 +26,8 @@ import org.opencastproject.util.XProperties;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Dictionary;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Supports YouTube property management.
@@ -63,6 +65,24 @@ public final class YouTubeUtils {
       throw new IllegalArgumentException("Null or blank value for YouTube-related property: " + keyPrefix + key.name());
     }
     return trimmed;
+  }
+
+  /**
+   * Disciplined way of getting a list of properties with a common prefix
+   *
+   * @param dictionary may not be {@code null}
+   * @param key  may not be {@code null}
+   * @return associated values
+   */
+  public static Map<String, String> getAll(XProperties dictionary, YouTubeKey key) {
+    final String prefix = keyPrefix + key.name() + ".";
+    return dictionary.entrySet().stream()
+        .filter(e -> e.getKey() instanceof String)
+        .filter(e -> ((String) e.getKey()).startsWith(prefix))
+        .collect(Collectors.toMap(
+            e -> ((String) e.getKey()).substring(prefix.length()),
+            e -> StringUtils.trimToNull((String) e.getValue())
+        ));
   }
 
   /**

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
@@ -66,7 +66,10 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.Dictionary;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Publishes media to a YouTube play list.
@@ -139,6 +142,11 @@ public class YouTubeV3PublicationServiceImpl
 
   private boolean enabled = false;
 
+  private boolean transferAudioLanguage;
+  private boolean transferMetadataLanguage;
+
+  private Map<String, Pattern> languagePatterns;
+
   /**
    * The default playlist to publish to, in case there is not enough information in the mediapackage to find a playlist
    */
@@ -203,6 +211,13 @@ public class YouTubeV3PublicationServiceImpl
           //
           youTubeService.initialize(clientCredentials);
           //
+          String languageTarget = YouTubeUtils.get(properties, YouTubeKey.languageTarget, false);
+          transferAudioLanguage = "audio".equals(languageTarget) || "both".equals(languageTarget);
+          transferMetadataLanguage = "metadata".equals(languageTarget) || "both".equals(languageTarget);
+          languagePatterns = YouTubeUtils.getAll(properties, YouTubeKey.languagePatterns).entrySet().stream()
+                  .collect(Collectors.toMap(
+                          Map.Entry::getKey,
+                          e -> Pattern.compile(e.getValue())));
           tags = StringUtils.split(YouTubeUtils.get(properties, YouTubeKey.keywords), ',');
           defaultPlaylist = YouTubeUtils.get(properties, YouTubeKey.defaultPlaylist);
           makeVideosPrivate = StringUtils

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
@@ -289,12 +289,20 @@ public class YouTubeV3PublicationServiceImpl
       final YouTubePublicationAdapter c = new YouTubePublicationAdapter(mediaPackage, workspace);
       final File file = workspace.get(element.getURI());
       final String episodeName = c.getEpisodeName();
+      final String episodeLanguage = c.getEpisodeLanguage();
+      final String language = episodeLanguage == null ? null : languagePatterns.entrySet().stream()
+          .filter(e -> e.getValue().matcher(c.getEpisodeLanguage()).matches())
+          .findAny()
+          .map(Map.Entry::getKey)
+          .orElse(null);
       final UploadProgressListener operationProgressListener = new UploadProgressListener(mediaPackage, file);
       final String privacyStatus = makeVideosPrivate ? "private" : "public";
       final VideoUpload videoUpload = new VideoUpload(
           truncateTitleToMaxFieldLength(episodeName, false),
-          c.getEpisodeDescription(), privacyStatus,
-          file, operationProgressListener, tags);
+          c.getEpisodeDescription(),
+          transferMetadataLanguage ? language : null,
+          transferAudioLanguage ? language : null,
+          privacyStatus, file, operationProgressListener, tags);
       final Video video = youTubeService.addVideoToMyChannel(videoUpload);
       final int timeoutMinutes = 60;
       final long startUploadMilliseconds = new Date().getTime();


### PR DESCRIPTION
Part of opencast/roadmap#17. This adds the possibility to transfer the language in the media package's metadata to YouTube during publication. To this end, a group of configuration option is added.

The first controls where the language ends up in YouTube. YouTube knows about two languages (apart from captions) per video: the language of the metadata (description, title) and the default audio language. Since Opencast only knows one language in most cases, I opted to make it configurable whether we use that for the metadata language, the audio language, both, or neither.

A possible extension of this feature would maybe allow you to configure independent metadata fields for these two languages.

The rest of the settings is a list of rules to translate whatever data people have in their language DC field to the BCP-47 codes YouTube expects. This is done using regular expressions. For every BCP-47 code you might want to upload, you provide a regex that matches whatever you want to see in the DC catalog for the language.

This is a bit roundabout, but I couldn't see any other way to deal with the fact that there are no restrictions in Opencast as to what the language field can contain.

Note that this means that videos in languages that aren't matched by any of these patterns won't have its language set in YouTube!

As in #7204 I have a few questions specifically for @ypatios:

- Is this roughly what you had in mind?
- I hope putting this towards `develop` is fine?
- Is this service level configurability enough for you or do you need this per workflow run?