### PR TITLE
Set YouTube license according to metadata

### DIFF
--- a/etc/org.opencastproject.publication.youtube.YouTubeV3PublicationServiceImpl.cfg
+++ b/etc/org.opencastproject.publication.youtube.YouTubeV3PublicationServiceImpl.cfg
@@ -3,6 +3,11 @@ org.opencastproject.publication.youtube.enabled=false
 org.opencastproject.publication.youtube.category=CHANGE_ME
 org.opencastproject.publication.youtube.keywords=CHANGE_ME
 
+# This property contains a regular expression that the license of a published
+# media package has to match in order to be given the creative commons license
+# on YouTube.
+#org.opencastproject.publication.youtube.ccLicenses=CC.*
+
 # The following property corresponds to public or private status at YouTube
 org.opencastproject.publication.youtube.makeVideosPrivate=true
 org.opencastproject.publication.youtube.defaultPlaylist=CHANGE_ME

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/VideoUpload.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/VideoUpload.java
@@ -34,7 +34,7 @@ public class VideoUpload {
 
   private final String title;
   private final String description;
-  private final String license;
+  private final License license;
   private final String privacyStatus;
   private final File videoFile;
   private final MediaHttpUploaderProgressListener progressListener;
@@ -52,7 +52,7 @@ public class VideoUpload {
   public VideoUpload(
       final String title,
       final String description,
-      final String license,
+      final License license,
       final String privacyStatus,
       final File videoFile,
       final MediaHttpUploaderProgressListener progressListener,
@@ -85,9 +85,8 @@ public class VideoUpload {
 
   /**
    * The video's license.
-   * The value may be {@code null}.
    */
-  public String getLicense() {
+  public License getLicense() {
     return license;
   }
 
@@ -121,5 +120,9 @@ public class VideoUpload {
    */
   public String[] getTags() {
     return tags;
+  }
+
+  public enum License {
+    creativeCommon, youtube
   }
 }

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/VideoUpload.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/VideoUpload.java
@@ -34,6 +34,7 @@ public class VideoUpload {
 
   private final String title;
   private final String description;
+  private final String license;
   private final String privacyStatus;
   private final File videoFile;
   private final MediaHttpUploaderProgressListener progressListener;
@@ -42,6 +43,7 @@ public class VideoUpload {
   /**
    * @param title may not be {@code null}.
    * @param description may be {@code null}.
+   * @param license may be {@code null}.
    * @param privacyStatus may not be {@code null}.
    * @param videoFile may not be {@code null}.
    * @param progressListener may be {@code null}.
@@ -50,6 +52,7 @@ public class VideoUpload {
   public VideoUpload(
       final String title,
       final String description,
+      final String license,
       final String privacyStatus,
       final File videoFile,
       final MediaHttpUploaderProgressListener progressListener,
@@ -57,6 +60,7 @@ public class VideoUpload {
   ) {
     this.title = title;
     this.description = description;
+    this.license = license;
     this.privacyStatus = privacyStatus;
     this.videoFile = videoFile;
     this.progressListener = progressListener;
@@ -77,6 +81,14 @@ public class VideoUpload {
    */
   public String getDescription() {
     return description;
+  }
+
+  /**
+   * The video's license.
+   * The value may be {@code null}.
+   */
+  public String getLicense() {
+    return license;
   }
 
   /**

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeAPIVersion3ServiceImpl.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeAPIVersion3ServiceImpl.java
@@ -71,6 +71,7 @@ public class YouTubeAPIVersion3ServiceImpl implements YouTubeAPIVersion3Service 
   public Video addVideoToMyChannel(final VideoUpload videoUpload) throws IOException {
     final Video videoObjectDefiningMetadata = new Video();
     final VideoStatus status = new VideoStatus();
+    status.setLicense(videoUpload.getLicense().name());
     status.setPrivacyStatus(videoUpload.getPrivacyStatus());
     videoObjectDefiningMetadata.setStatus(status);
     // Metadata lives in VideoSnippet

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeKey.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeKey.java
@@ -33,6 +33,7 @@ public enum YouTubeKey {
   dataStore,
   keywords,
   defaultPlaylist,
+  ccLicenses,
   makeVideosPrivate,
   maxFieldLength;
 }

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubePublicationAdapter.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubePublicationAdapter.java
@@ -133,12 +133,21 @@ public class YouTubePublicationAdapter {
       description += '\n' + episodeDescription;
     }
 
-    String episodeLicense = dcEpisode.getFirst(DublinCore.PROPERTY_LICENSE);
+    String episodeLicense = getEpisodeLicense();
     if (episodeLicense != null) {
       description += '\n' + episodeLicense;
     }
 
     return description;
+  }
+
+  /**
+   * Gets the license for the episode of the media package
+   *
+   * @return the license of the episode
+   */
+  public String getEpisodeLicense() {
+    return dcEpisode == null ? null : dcEpisode.getFirst(DublinCore.PROPERTY_LICENSE);
   }
 
   /**

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubePublicationAdapter.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubePublicationAdapter.java
@@ -22,6 +22,7 @@
 package org.opencastproject.publication.youtube;
 
 import org.opencastproject.mediapackage.Catalog;
+import org.opencastproject.mediapackage.EName;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElements;
 import org.opencastproject.metadata.dublincore.DublinCore;
@@ -147,7 +148,23 @@ public class YouTubePublicationAdapter {
    * @return the license of the episode
    */
   public String getEpisodeLicense() {
-    return dcEpisode == null ? null : dcEpisode.getFirst(DublinCore.PROPERTY_LICENSE);
+    return getEpisodeProperty(DublinCore.PROPERTY_LICENSE);
+  }
+
+  /**
+   * Gets a property for the episode of the media package
+   *
+   * @param property the property to get
+   * @return the property value
+   */
+  private String getEpisodeProperty(EName property) {
+    if (dcSeries != null) {
+      return dcSeries.getFirst(property);
+    }
+    if (dcEpisode != null) {
+      return dcEpisode.getFirst(property);
+    }
+    return null;
   }
 
   /**

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
@@ -284,9 +284,9 @@ public class YouTubeV3PublicationServiceImpl
       final UploadProgressListener operationProgressListener = new UploadProgressListener(mediaPackage, file);
       final String privacyStatus = makeVideosPrivate ? "private" : "public";
       final VideoUpload.License license = ccLicenses.map(
-         p -> p.matcher(c.getEpisodeLicense()).matches()).orElse(false)
-         ? VideoUpload.License.creativeCommon
-         : VideoUpload.License.youtube;
+          p -> p.matcher(c.getEpisodeLicense()).matches()).orElse(false)
+          ? VideoUpload.License.creativeCommon
+          : VideoUpload.License.youtube;
       final VideoUpload videoUpload = new VideoUpload(
           truncateTitleToMaxFieldLength(episodeName, false),
           c.getEpisodeDescription(), license, privacyStatus,

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
@@ -66,7 +66,9 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.Dictionary;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 /**
  * Publishes media to a YouTube play list.
@@ -144,6 +146,8 @@ public class YouTubeV3PublicationServiceImpl
    */
   private String defaultPlaylist;
 
+  private Optional<Pattern> ccLicenses;
+
   private boolean makeVideosPrivate;
 
   private String[] tags;
@@ -203,6 +207,9 @@ public class YouTubeV3PublicationServiceImpl
           //
           youTubeService.initialize(clientCredentials);
           //
+          ccLicenses = Optional.ofNullable(
+                  YouTubeUtils.get(properties, YouTubeKey.ccLicenses, false))
+                  .map(Pattern::compile);
           tags = StringUtils.split(YouTubeUtils.get(properties, YouTubeKey.keywords), ',');
           defaultPlaylist = YouTubeUtils.get(properties, YouTubeKey.defaultPlaylist);
           makeVideosPrivate = StringUtils

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
@@ -278,7 +278,7 @@ public class YouTubeV3PublicationServiceImpl
       final String privacyStatus = makeVideosPrivate ? "private" : "public";
       final VideoUpload videoUpload = new VideoUpload(
           truncateTitleToMaxFieldLength(episodeName, false),
-          c.getEpisodeDescription(), privacyStatus,
+          c.getEpisodeDescription(), c.getEpisodeLicense(), privacyStatus,
           file, operationProgressListener, tags);
       final Video video = youTubeService.addVideoToMyChannel(videoUpload);
       final int timeoutMinutes = 60;

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
@@ -283,9 +283,13 @@ public class YouTubeV3PublicationServiceImpl
       final String episodeName = c.getEpisodeName();
       final UploadProgressListener operationProgressListener = new UploadProgressListener(mediaPackage, file);
       final String privacyStatus = makeVideosPrivate ? "private" : "public";
+      final VideoUpload.License license = ccLicenses.map(
+         p -> p.matcher(c.getEpisodeLicense()).matches()).orElse(false)
+         ? VideoUpload.License.creativeCommon
+         : VideoUpload.License.youtube;
       final VideoUpload videoUpload = new VideoUpload(
           truncateTitleToMaxFieldLength(episodeName, false),
-          c.getEpisodeDescription(), c.getEpisodeLicense(), privacyStatus,
+          c.getEpisodeDescription(), license, privacyStatus,
           file, operationProgressListener, tags);
       final Video video = youTubeService.addVideoToMyChannel(videoUpload);
       final int timeoutMinutes = 60;


### PR DESCRIPTION
This is part of opencast/roadmap#17, and it allows you to set the license of a YouTube video while publishing there, according to the videos metadata in Opencast.

Since there are only two licenses on YouTube, namely YouTube Standard and Creavie Commons, and the former is the standard, all we need is a way to identify the CC licenses. Since the license field in the DC catalogs is basically just text, we provide a regex that must be matched in order for the video to have its license set to CC. This is similar to how we do languages in #7205.

As with the other YouTube PRs, some Questions for @ypatios:

- Is this what you had in mind?
- I hope putting this towards `develop` is fine?
- Is this service level configurability enough for you or do you need this per workflow run?