### PR TITLE
Fix AssetManager snapshot with empty or missing acl

### DIFF
--- a/modules/asset-manager-impl/pom.xml
+++ b/modules/asset-manager-impl/pom.xml
@@ -66,6 +66,11 @@
       <artifactId>opencast-authorization-manager</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-userdirectory</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <!-- -->
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
@@ -80,6 +80,7 @@ import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.security.api.User;
 import org.opencastproject.security.util.SecurityUtil;
+import org.opencastproject.userdirectory.UserIdRoleProvider;
 import org.opencastproject.util.Checksum;
 import org.opencastproject.util.ChecksumType;
 import org.opencastproject.util.MimeTypes;
@@ -427,6 +428,12 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
       }
 
       final AccessControlList acl = authorizationService.getActiveAcl(mp).getA();
+      if (acl.getEntries().isEmpty()) {
+        // mediapackage does not contain any ACL, let's put users role to the list
+        final String userRole = UserIdRoleProvider.getUserIdRole(securityService.getUser().getUsername());
+        acl.getEntries().add(new AccessControlEntry(userRole, WRITE_ACTION, true));
+        acl.getEntries().add(new AccessControlEntry(userRole, READ_ACTION, true));
+      }
       // store acl as properties
       // Drop old ACL rules
       deleteProperties(mediaPackageId, SECURITY_NAMESPACE);

--- a/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AssetManagerBasicTest.java
+++ b/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AssetManagerBasicTest.java
@@ -144,14 +144,14 @@ public class AssetManagerBasicTest extends AssetManagerTestBase {
     assertTrue("The property should be set", am.setProperty(p.start(mpId, d1)));
     logger.info("Select all properties of the media package");
     {
-      List<Property> properties = am.selectProperties(mpId, null);
+      List<Property> properties = nonSecurityProperties(am.selectProperties(mpId, null));
       assertEquals("One property should be found", 1, properties.size());
       assertEquals("Value check", d1, properties.stream().findFirst().get().getValue().get(Value.DATE));
     }
     logger.info("Update the property");
     assertTrue("The property should be updated", am.setProperty(p.start(mpId, d2)));
     {
-      List<Property> properties = am.selectProperties(mpId, null);
+      List<Property> properties = nonSecurityProperties(am.selectProperties(mpId, null));
       assertEquals("One property should be found", 1, properties.size());
       assertEquals("Value check", d2, properties.stream().findFirst().get().getValue().get(Value.DATE));
     }
@@ -162,7 +162,7 @@ public class AssetManagerBasicTest extends AssetManagerTestBase {
     assertTrue("The property should be updated", am.setProperty(p.start(mpId, d3)));
     {
       List<Snapshot> snapshots = am.getSnapshotsById(mpId);
-      List<Property> properties = am.selectProperties(mpId, null);
+      List<Property> properties = nonSecurityProperties(am.selectProperties(mpId, null));
       assertEquals("Two records should be found since there are now two versions of the media package and no"
                   + "version restriction has been applied",
                    2, snapshots.size());

--- a/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AssetManagerDeletePropertyTest.java
+++ b/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AssetManagerDeletePropertyTest.java
@@ -35,19 +35,19 @@ public class AssetManagerDeletePropertyTest extends AssetManagerDeleteTestBase {
     am.setProperty(p.agent(mp[0], "agent-1"));
     am.setProperty(p.agent(mp[1], "agent-2"));
     am.setProperty(p.agent(mp[2], "agent-5"));
-    assertTotals(6, 6, 3);
+    assertTotals(6, 6, 9);
     assertEquals(
-        "One property should be deleted",
-        1,
+        "Three properties should be deleted",
+        3,
         am.deleteProperties(mp[0])
     );
-    assertTotals(6, 6, 2);
+    assertTotals(6, 6, 6);
     assertEquals(
-        "One property should be deleted",
-        1,
+        "Three properties should be deleted",
+        3,
         am.deleteProperties(mp[1])
     );
-    assertTotals(6, 6, 1);
+    assertTotals(6, 6, 3);
     assertEquals(Value.mk("agent-5"),
         am.selectProperties(mp[2], p.getNamespace()).get(0).getValue());
   }
@@ -59,19 +59,19 @@ public class AssetManagerDeletePropertyTest extends AssetManagerDeleteTestBase {
     am.setProperty(p.agent(mp[1], "agent-2"));
     am.setProperty(p2.agent(mp[1], "agent-12"));
     am.setProperty(p.agent(mp[2], "agent-5"));
-    assertTotals(6, 6, 4);
+    assertTotals(6, 6, 10);
     assertEquals(
         "One property should be deleted",
         1,
         am.deleteProperties(mp[0], p.getNamespace())
     );
-    assertTotals(6, 6, 3);
+    assertTotals(6, 6, 9);
     assertEquals(
         "One property should be deleted",
         1,
         am.deleteProperties(mp[1], p.getNamespace())
     );
-    assertTotals(6, 6, 2);
+    assertTotals(6, 6, 8);
     assertEquals(Value.mk("agent-12"),
         am.selectProperties(mp[1], p2.getNamespace()).get(0).getValue());
     assertEquals(Value.mk("agent-5"),
@@ -98,8 +98,7 @@ public class AssetManagerDeletePropertyTest extends AssetManagerDeleteTestBase {
     assertEquals(3L, Properties.removeProperties(
         am, mp[0], p.getNamespace()
     ));
-    assertEquals(1L, am.selectProperties(mp[0], null).size());
-//    assertEquals(1L, enrich(q.select(q.properties()).where(q.mediaPackageId(mp[0])).run()).countProperties());
+    assertEquals(3L, am.selectProperties(mp[0], null).size());
     assertEquals(1L, Properties.removeProperties(
         am, mp[0], p2.getNamespace()
     ));

--- a/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AssetManagerDeleteSnapshotTest.java
+++ b/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AssetManagerDeleteSnapshotTest.java
@@ -39,10 +39,10 @@ public class AssetManagerDeleteSnapshotTest extends AssetManagerDeleteTestBase {
     am.setProperty(p.agent(mp[0], "agent-1"));
     am.setProperty(p.agent(mp[1], "agent-2"));
     am.setProperty(p.agent(mp[2], "agent-2"));
-    assertTotals(mpCount * versionCount, mpCount * versionCount, 3);
+    assertTotals(mpCount * versionCount, mpCount * versionCount, 9);
     assertStoreSize(mpCount * versionCount * 2);
     assertEquals(versionCount, am.deleteSnapshots(mp[0]));
-    assertTotals((mpCount - 1) * versionCount, (mpCount - 1) * versionCount, 3);
+    assertTotals((mpCount - 1) * versionCount, (mpCount - 1) * versionCount, 9);
     assertStoreSize((mpCount - 1) * versionCount * 2);
   }
 
@@ -55,14 +55,14 @@ public class AssetManagerDeleteSnapshotTest extends AssetManagerDeleteTestBase {
     am.setProperty(p.agent(mp[0], "agent-1"));
     am.setProperty(p.agent(mp[1], "agent-2"));
     am.setProperty(p.agent(mp[2], "agent-2"));
-    assertTotals(6, 6, 3);
+    assertTotals(6, 6, 9);
     assertStoreSize(6 * 2);
     assertEquals(
         "Two snapshots should be deleted",
         2,
         am.deleteSnapshots(mp[0])
     );
-    assertTotals(4, 4, 3);
+    assertTotals(4, 4, 9);
     assertStoreSize(4 * 2);
   }
 
@@ -78,10 +78,10 @@ public class AssetManagerDeleteSnapshotTest extends AssetManagerDeleteTestBase {
     am.setProperty(p.agent(mp[0], "agent-1"));
     am.setProperty(p.agent(mp[1], "agent-2"));
     am.setProperty(p.agent(mp[2], "agent-2"));
-    assertTotals(mpCount * versionCount, mpCount * versionCount, 3);
+    assertTotals(mpCount * versionCount, mpCount * versionCount, 9);
     assertStoreSize(mpCount * versionCount * 2);
     assertEquals(versionCount - 1, am.deleteAllButLatestSnapshot(mp[0]));
-    assertTotals((mpCount - 1) * versionCount + 1, 11, 3);
+    assertTotals((mpCount - 1) * versionCount + 1, 11, 9);
     assertStoreSize(((mpCount - 1) * versionCount * 2) + 2);
   }
 }

--- a/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AssetManagerSelectTest.java
+++ b/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AssetManagerSelectTest.java
@@ -79,13 +79,13 @@ public class AssetManagerSelectTest extends AssetManagerTestBase {
     mp1.add(mpe);
     am.takeSnapshot(OWNER, mp1);
     assertEquals("No properties should be found",
-        0, am.selectProperties(mp1.getIdentifier().toString(), null).size());
+        0, nonSecurityProperties(am.selectProperties(mp1.getIdentifier().toString(), null)).size());
 
     logger.info("Set property on first episode");
     am.setProperty(Property.mk(PropertyId.mk(mp1.getIdentifier().toString(), "org.opencastproject.service", "count"),
         Value.mk(10L)));
     assertEquals("One property should be found",
-        1, am.selectProperties(mp1.getIdentifier().toString(), null).size());
+        1, nonSecurityProperties(am.selectProperties(mp1.getIdentifier().toString(), null)).size());
 
     logger.info("Add another media package with some properties of the same namespace");
     final MediaPackage mp2 = mkMediaPackage(mkCatalog());
@@ -98,9 +98,9 @@ public class AssetManagerSelectTest extends AssetManagerTestBase {
 
 
     assertEquals("One property should be found",
-        1, am.selectProperties(mp1.getIdentifier().toString(), null).size());
+        1, nonSecurityProperties(am.selectProperties(mp1.getIdentifier().toString(), null)).size());
     assertEquals("Three properties should be found",
-        3, am.selectProperties(mp2.getIdentifier().toString(), null).size());
+        3, nonSecurityProperties(am.selectProperties(mp2.getIdentifier().toString(), null)).size());
 
     assertEquals("One property should be found",
         1, am.selectProperties(mp1.getIdentifier().toString(), "org.opencastproject.service").size());
@@ -131,7 +131,7 @@ public class AssetManagerSelectTest extends AssetManagerTestBase {
     am.takeSnapshot(OWNER, mp1);
 
     List<Snapshot> snapshots = am.getSnapshotsById(mp1.getIdentifier().toString());
-    List<Property> properties = am.selectProperties(mp1.getIdentifier().toString(), null);
+    List<Property> properties = nonSecurityProperties(am.selectProperties(mp1.getIdentifier().toString(), null));
     assertEquals("One snapshot should be found", 1, snapshots.size());
     assertEquals("No properties should be found", 0, properties.size());
 

--- a/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AssetManagerTestBase.java
+++ b/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AssetManagerTestBase.java
@@ -332,6 +332,19 @@ public abstract class AssetManagerTestBase {
   }
 
   /**
+   * Filter list of properties by namespace. All properties with the namespace
+   * {@link AssetManagerImpl#SECURITY_NAMESPACE} will not be part of the resulting list.
+   *
+   * @param properties properties list to filter
+   * @return properties list without properties with namespace {@link AssetManagerImpl#SECURITY_NAMESPACE}
+   */
+  public List<Property> nonSecurityProperties(List<Property> properties) {
+    return properties.stream()
+        .filter(property -> !AssetManagerImpl.SECURITY_NAMESPACE.equals(property.getId().getNamespace()))
+        .toList();
+  }
+
+  /**
    * Create a test asset store.
    */
   protected AssetStore mkAssetStore(String storeType) {


### PR DESCRIPTION
An unprivileged user with `ROLE_STUDIO` cannot upload and process a media package if no ACLs are set or are missing. In this case, the snapshot operation fails. The snapshot operation checks the user's rights based on the AssetManager properties that were generated from the ACL during the previous run. However, there is one exception: the check is not performed when the first snapshot of a media package is taken. This is why processing can be started in the first place. We should guarantee that a snapshot does not fail if no ACLs have been set previously and the user is authorized.

You can test this behavior like this:
1. Create a user with `ROLE_STUDIO`
2. Run this curl command to ingest a video
    - `curl -i -u user http://localhost:8080/ingest/addMediaPackage/fast -F title="Test" -F 'flavor=presenter/source' -F 'BODY=@test.mp4'`
    - replace `user` with the username of the user you've created before
    - an Admin UI will always create and upload an ACL file, therefor you can't use it for this test

An other test case (running Tobira instance is needed):
- Create a series in Opencast and give some unprivileged user write permissions to this series
- Go to Tobira > My series view and select this series
- In the Tobira series details view there is a option to upload a video to this series
- Upload a video to this series
    - Internally Tobira will generate a JWT and pass it to the ingest request. This JWT grant the user `ROLE_STUDIO` but also the read and write role specific for this media package. This will allow start processing but also give the user rights to write this media package
- During the processing upload an other video
    - The JWT of the second upload will overwrite the media package specific read and write user permission from first upload
- The second upload will be processed as it should
- But the first upload will fail during snapshot operation due to missing write permissions