### PR TITLE
Add `?download=1` support for static files

### DIFF
--- a/modules/static/src/main/java/org/opencastproject/fsresources/StaticResourceServlet.java
+++ b/modules/static/src/main/java/org/opencastproject/fsresources/StaticResourceServlet.java
@@ -227,6 +227,13 @@ public class StaticResourceServlet extends HttpServlet {
     resp.setHeader("Content-Length", Long.toString(file.length()));
     resp.setDateHeader("Last-Modified", file.lastModified());
 
+    // Set Content-Disposition header based on query parameter (`?download=1`).
+    // With this, passing that parameter will allow download links to trigger the download directly
+    // instead of opening files in the browser.
+    if ("1".equals(req.getParameter("download"))) {
+      resp.setHeader("Content-Disposition", "attachment");
+    }
+
     resp.setHeader("Accept-Ranges", "bytes");
     ArrayList<Range> ranges = parseRange(req, resp, eTag, file.lastModified(), file.length());
 


### PR DESCRIPTION
Closes #7208

This will set the `Content-Disposition` header based on the query parameter `?download=1`.
Passing that parameter will allow download links to trigger the download directly instead of opening files in the browser.

Should be safe to go into `r/18.x`. It's a very small change and won't break anything.


You can test this by appending `?download=1` to the url of an image or videofile in Opencast. An easy way to get at that is to open the engage pulication link, inspect the video with dev-tools and copy that link from there.


https://github.com/user-attachments/assets/70102fce-2fbf-4d3c-af54-a3f1901da102



### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
