### PR TITLE
Update r/18.x Admin UI to 18.x-2025-11-28

### DIFF
--- a/modules/admin-ui-interface/pom.xml
+++ b/modules/admin-ui-interface/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <interface.url>https://github.com/opencast/opencast-admin-interface/releases/download/18.x-2025-10-24/oc-admin-ui-18.x-2025-10-24.tar.gz</interface.url>
-    <interface.sha256>961ecf976bdbcff044ea23e864a6e3ca6c585a0d4a8133f07929c1e1f82c0001</interface.sha256>
+    <interface.url>https://github.com/opencast/opencast-admin-interface/releases/download/18.x-2025-11-28/oc-admin-ui-18.x-2025-11-28.tar.gz</interface.url>
+    <interface.sha256>fbc005ad66c93c7d2d65da31006dc9e164301f9766f824103f3c1a4db4429d02</interface.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
Updating Opencast r/18.x Admin UI module to [18.x-2025-11-28](https://github.com/opencast/opencast-admin-interface/releases/tag/18.x-2025-11-28)