### PR TITLE
Add Paella-OC-Plugins: Textboxes and Quizzes

### DIFF
--- a/docs/guides/admin/docs/configuration/player/paella.player7/plugins.md
+++ b/docs/guides/admin/docs/configuration/player/paella.player7/plugins.md
@@ -43,6 +43,7 @@ Plugin                                             | Description
 [org.opencast.paella.loginPlugin](plugins/org.opencast.paella.loginPlugin.md)                                         | Adds a button to be able to login.
 [org.opencast.paella.opencast.userTrackingDataPlugin](plugins/org.opencast.paella.opencast.userTrackingDataPlugin.md) | Allows to use Opencast usertracking service to track usage data.
 [org.opencast.paella.matomo.userTrackingDataPlugin](plugins/org.opencast.paella.matomo.userTrackingDataPlugin.md)     | Allows to use Matomo service to track usage data.
+[org.opencast.paella.quizPlugin](plugins/org.opencast.paella.matomo.quizPlugin.md) | Allows the display of quizzes
 [org.opencast.paella.textboxPlugin](plugins/org.opencast.paella.matomo.textboxPlugin.md) | Allows the display of textboxes
 [org.opencast.paella.transcriptionsPlugin](plugins/org.opencast.paella.transcriptionsPlugin.md)                       | Adds a panel to show the OCR transcriptions.
 [org.opencast.paella.versionButton](plugins/org.opencast.paella.versionButton.md)                                     | Adds a button to show the player version.

--- a/docs/guides/admin/docs/configuration/player/paella.player7/plugins.md
+++ b/docs/guides/admin/docs/configuration/player/paella.player7/plugins.md
@@ -43,5 +43,6 @@ Plugin                                             | Description
 [org.opencast.paella.loginPlugin](plugins/org.opencast.paella.loginPlugin.md)                                         | Adds a button to be able to login.
 [org.opencast.paella.opencast.userTrackingDataPlugin](plugins/org.opencast.paella.opencast.userTrackingDataPlugin.md) | Allows to use Opencast usertracking service to track usage data.
 [org.opencast.paella.matomo.userTrackingDataPlugin](plugins/org.opencast.paella.matomo.userTrackingDataPlugin.md)     | Allows to use Matomo service to track usage data.
+[org.opencast.paella.textboxPlugin](plugins/org.opencast.paella.matomo.textboxPlugin.md) | Allows the display of textboxes
 [org.opencast.paella.transcriptionsPlugin](plugins/org.opencast.paella.transcriptionsPlugin.md)                       | Adds a panel to show the OCR transcriptions.
 [org.opencast.paella.versionButton](plugins/org.opencast.paella.versionButton.md)                                     | Adds a button to show the player version.

--- a/docs/guides/admin/docs/configuration/player/paella.player7/plugins/org.opencast.paella.quizPlugin.md
+++ b/docs/guides/admin/docs/configuration/player/paella.player7/plugins/org.opencast.paella.quizPlugin.md
@@ -1,0 +1,47 @@
+Paella plugin: org.opencast.paella.quizPlugin
+=======================================================
+
+This plugin displays quizzes in the player, based on a JSON catalog in the event tracks.  
+A quiz consist of a single question which can have multiple correct answers.
+
+The expected flavor type of the catalog is "quizzes" (i.e. "quizzes/source").
+
+The file is of the form:
+```json
+{
+  "start": 2,
+  "question": "Which is a fruit?",
+  "answers": [
+    {
+      "text": "Banana",
+      "correct": true
+    },
+    {
+      "text": "Cucumber",
+      "correct": false
+    },
+    {
+      "text": "Tomato",
+      "correct": true
+    }
+  ]
+}
+
+```
+
+The configurations for this plugin are done for each tenant. So you need to modify the `plugins`
+section of the [paella config file](../configuration.md).
+
+
+Configuration
+-------------
+
+You need to enable the `org.opencast.paella.quizPlugin` plugin.
+
+```json
+{
+    "org.opencast.paella.quizPlugin": {
+        "enabled": true
+    }    
+}
+```

--- a/docs/guides/admin/docs/configuration/player/paella.player7/plugins/org.opencast.paella.quizPlugin.md
+++ b/docs/guides/admin/docs/configuration/player/paella.player7/plugins/org.opencast.paella.quizPlugin.md
@@ -9,7 +9,7 @@ The expected flavor type of the catalog is "quizzes" (i.e. "quizzes/source").
 The file is of the form:
 ```json
 {
-  "start": 2,
+  "start": 2000,
   "question": "Which is a fruit?",
   "answers": [
     {

--- a/docs/guides/admin/docs/configuration/player/paella.player7/plugins/org.opencast.paella.textboxPlugin.md
+++ b/docs/guides/admin/docs/configuration/player/paella.player7/plugins/org.opencast.paella.textboxPlugin.md
@@ -1,0 +1,39 @@
+Paella plugin: org.opencast.paella.textboxPlugin
+=======================================================
+
+This plugin displays textboxes in the player, based on a JSON catalog in the event tracks.  
+
+The expected flavor type of the catalog is "textboxes" (i.e. "textboxes/source"). 
+
+The file is of the form:
+```json
+[
+  {
+    "start": 2,
+    "end": 4,
+    "text": "My text here"
+  },
+  {
+    "start": 7,
+    "end": 14,
+    "text": "More of my text here"
+  }
+]
+```
+
+The configurations for this plugin are done for each tenant. So you need to modify the `plugins`
+section of the [paella config file](../configuration.md).
+
+
+Configuration
+-------------
+
+You need to enable the `org.opencast.paella.textboxPlugin` plugin.
+
+```json
+{
+    "org.opencast.paella.textboxPlugin": {
+        "enabled": true
+    }    
+}
+```

--- a/docs/guides/admin/docs/configuration/player/paella.player7/plugins/org.opencast.paella.textboxPlugin.md
+++ b/docs/guides/admin/docs/configuration/player/paella.player7/plugins/org.opencast.paella.textboxPlugin.md
@@ -1,22 +1,26 @@
 Paella plugin: org.opencast.paella.textboxPlugin
 =======================================================
 
-This plugin displays textboxes in the player, based on a JSON catalog in the event tracks.  
+This plugin displays textboxes in the player, based on a JSON catalog in the event tracks.
 
-The expected flavor type of the catalog is "textboxes" (i.e. "textboxes/source"). 
+The expected flavor type of the catalog is "textboxes" (i.e. "textboxes/source").
 
-The file is of the form:
+Start time is in seconds. The display duration is fixed at 10 seconds.
+Text should be kept short, or will be cut off. 20 characters max are recommended.
+Optionally, a link can be specified. Clicking on a textbox with a link will
+redirect to the specified resource.
+
+The catalog file is of the form:
 ```json
 [
   {
     "start": 2,
-    "end": 4,
     "text": "My text here"
   },
   {
     "start": 7,
-    "end": 14,
-    "text": "More of my text here"
+    "text": "More of my text here",
+    "link": "https://opencast.org",
   }
 ]
 ```
@@ -34,6 +38,6 @@ You need to enable the `org.opencast.paella.textboxPlugin` plugin.
 {
     "org.opencast.paella.textboxPlugin": {
         "enabled": true
-    }    
+    }
 }
 ```

--- a/docs/guides/admin/docs/configuration/player/paella.player7/plugins/org.opencast.paella.textboxPlugin.md
+++ b/docs/guides/admin/docs/configuration/player/paella.player7/plugins/org.opencast.paella.textboxPlugin.md
@@ -5,7 +5,7 @@ This plugin displays textboxes in the player, based on a JSON catalog in the eve
 
 The expected flavor type of the catalog is "textboxes" (i.e. "textboxes/source").
 
-Start time is in seconds. The display duration is fixed at 10 seconds.
+Start time is in milliseconds. The display duration is fixed at 10 seconds.
 Text should be kept short, or will be cut off. 20 characters max are recommended.
 Optionally, a link can be specified. Clicking on a textbox with a link will
 redirect to the specified resource.
@@ -14,11 +14,11 @@ The catalog file is of the form:
 ```json
 [
   {
-    "start": 2,
+    "start": 2000,
     "text": "My text here"
   },
   {
-    "start": 7,
+    "start": 7000,
     "text": "More of my text here",
     "link": "https://opencast.org",
   }

--- a/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/EditingData.java
+++ b/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/EditingData.java
@@ -62,14 +62,17 @@ public class EditingData {
 
   private final List<String> waveformURIs;
   private final List<Subtitle> subtitles;
+  private final InteractiveElementData textboxes;
+  private final InteractiveElementData quizzes;
   private final Boolean local;
 
   private final String metadataJSON;
 
   public EditingData(List<SegmentData> segments, List<TrackData> tracks, List<WorkflowData> workflows, Long duration,
           String title, String recordingStartDate, String seriesId, String seriesName, Boolean workflowActive,
-          List<String> waveformURIs, List<Subtitle> subtitles, Boolean local, Boolean lockingActive,
-          Integer lockRefresh, User user, String metadataJSON) {
+          List<String> waveformURIs, List<Subtitle> subtitles, InteractiveElementData textboxes,
+          InteractiveElementData quizzes, Boolean local, Boolean lockingActive, Integer lockRefresh, User user,
+          String metadataJSON) {
     this.segments = segments;
     this.tracks = tracks;
     this.workflows = workflows;
@@ -80,6 +83,8 @@ public class EditingData {
     this.workflowActive = workflowActive;
     this.waveformURIs = waveformURIs;
     this.subtitles = subtitles;
+    this.textboxes = textboxes;
+    this.quizzes = quizzes;
     this.local = local;
     this.lockingActive = lockingActive;
     this.lockRefresh = lockRefresh * 1000;
@@ -119,6 +124,14 @@ public class EditingData {
 
   public List<Subtitle> getSubtitles() {
     return subtitles;
+  }
+
+  public InteractiveElementData getTextboxes() {
+    return textboxes;
+  }
+
+  public InteractiveElementData getQuizzes() {
+    return quizzes;
   }
 
   public String getMetadataJSON() {

--- a/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/InteractiveElementData.java
+++ b/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/InteractiveElementData.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.opencastproject.editor.api;
+
+public class InteractiveElementData {
+  private final String id;
+  private final String elementsJSON;
+
+  public InteractiveElementData(String id, String elementsJSON) {
+    this.id = id;
+    this.elementsJSON = elementsJSON;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getElementsJSON() {
+    return elementsJSON;
+  }
+}

--- a/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
+++ b/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
@@ -33,6 +33,7 @@ import org.opencastproject.editor.api.EditingData;
 import org.opencastproject.editor.api.EditorService;
 import org.opencastproject.editor.api.EditorServiceException;
 import org.opencastproject.editor.api.ErrorStatus;
+import org.opencastproject.editor.api.InteractiveElementData;
 import org.opencastproject.editor.api.LockData;
 import org.opencastproject.editor.api.SegmentData;
 import org.opencastproject.editor.api.TrackData;
@@ -172,6 +173,8 @@ public class EditorServiceImpl implements EditorService {
   private MediaPackageElementFlavor smilSilenceFlavor;
   private ElasticsearchIndex searchIndex;
   private MediaPackageElementFlavor captionsFlavor;
+  private MediaPackageElementFlavor textboxesFlavor;
+  private MediaPackageElementFlavor quizzesFlavor;
   private String thumbnailWfProperty;
   private List<MediaPackageElementFlavor> thumbnailSourcePrimary;
   private String distributionDirectory;
@@ -185,6 +188,8 @@ public class EditorServiceImpl implements EditorService {
   private static final String DEFAULT_SMIL_SILENCE_FLAVOR = "*/silence";
   private static final String DEFAULT_PREVIEW_VIDEO_SUBTYPE = "video+preview";
   private static final String DEFAULT_CAPTIONS_FLAVOR = "captions/*";
+  private static final String DEFAULT_TEXTBOXES_FLAVOR = "textboxes/*";
+  private static final String DEFAULT_QUIZZES_FLAVOR = "quizzes/*";
   private static final String DEFAULT_THUMBNAIL_SUBTYPE = "player+preview";
   private static final String DEFAULT_THUMBNAIL_WF_PROPERTY = "thumbnail_edited";
   private static final List<MediaPackageElementFlavor> DEFAULT_THUMBNAIL_PRIORITY_FLAVOR = new ArrayList<>();
@@ -199,6 +204,8 @@ public class EditorServiceImpl implements EditorService {
   public static final String OPT_SMIL_SILENCE_FLAVOR = "smil.silence.flavor";
   public static final String OPT_PREVIEW_VIDEO_SUBTYPE = "preview.video.subtype";
   public static final String OPT_CAPTIONS_FLAVOR = "captions.flavor";
+  public static final String OPT_TEXTBOXES_FLAVOR = "textboxes.flavor";
+  public static final String OPT_QUIZZES_FLAVOR = "quizzes.flavor";
   public static final String OPT_THUMBNAILSUBTYPE = "thumbnail.subtype";
   public static final String OPT_THUMBNAIL_WF_PROPERTY = "thumbnail.workflow.property";
   public static final String OPT_THUMBNAIL_PRIORITY_FLAVOR = "thumbnail.priority.flavor";
@@ -339,6 +346,14 @@ public class EditorServiceImpl implements EditorService {
     captionsFlavor = MediaPackageElementFlavor.parseFlavor(
             StringUtils.defaultString((String) properties.get(OPT_CAPTIONS_FLAVOR), DEFAULT_CAPTIONS_FLAVOR));
     logger.debug("Caption flavor set to '{}'", captionsFlavor);
+
+    textboxesFlavor = MediaPackageElementFlavor.parseFlavor(
+        StringUtils.defaultString((String) properties.get(OPT_TEXTBOXES_FLAVOR), DEFAULT_TEXTBOXES_FLAVOR));
+    logger.debug("Textboxes flavor set to '{}'", textboxesFlavor);
+
+    quizzesFlavor = MediaPackageElementFlavor.parseFlavor(
+        StringUtils.defaultString((String) properties.get(OPT_QUIZZES_FLAVOR), DEFAULT_QUIZZES_FLAVOR));
+    logger.debug("Quizzes flavor set to '{}'", quizzesFlavor);
 
     thumbnailSubType =  Objects.toString(properties.get(OPT_THUMBNAILSUBTYPE), DEFAULT_THUMBNAIL_SUBTYPE);
     logger.debug("Thumbnail subtype set to '{}'", thumbnailSubType);
@@ -601,6 +616,63 @@ public class EditorServiceImpl implements EditorService {
           } catch (NotFoundException | IOException e) {
             logger.info("Could not remove track from workspace. Could be it was never there.");
           }
+        }
+      }
+    }
+
+    return mediaPackage;
+  }
+
+  private MediaPackage processInteractiveElements(
+      MediaPackage mediaPackage,
+      InteractiveElementData element,
+      String flavorType
+  ) throws IOException, IllegalArgumentException {
+
+    // Generate ID for new tracks
+    String elementId = UUID.randomUUID().toString();
+    String trackId = null;
+
+    // Check if subtitle already exists
+    for (Track t : mediaPackage.getTracks()) {
+      if (t.getIdentifier().matches(element.getId())) {
+        logger.debug("Set Identifier for interactive element to: {}", t.getIdentifier());
+        elementId = t.getIdentifier();
+        trackId = t.getIdentifier();
+        break;
+      }
+    }
+
+    Track track = mediaPackage.getTrack(trackId);
+
+    // Memorize uri of the previous track file for deletion
+    URI oldTrackURI = null;
+    if (track != null) {
+      oldTrackURI = track.getURI();
+    }
+
+    // Put updated filename in working file repository and update the track.
+    try (InputStream is = IOUtils.toInputStream(element.getElementsJSON(), "UTF-8")) {
+      URI elementUri = workspace.put(mediaPackage.getIdentifier().toString(), elementId, elementId + ".json", is);
+
+      // If not exists, create new Track
+      if (track == null) {
+        track = (Track) mediaPackage.add(elementUri, MediaPackageElement.Type.Track,
+            new MediaPackageElementFlavor(flavorType,"source"));
+        logger.info("Creating new interactive element track {}", track.getIdentifier());
+      }
+
+      track.setURI(elementUri);
+      track.setIdentifier(elementId);
+      track.setChecksum(null);
+
+      if (oldTrackURI != null && oldTrackURI != elementUri) {
+        // Delete the old files from the working file repository and workspace if they were in there
+        logger.info("Removing old track file {}", oldTrackURI);
+        try {
+          workspace.delete(oldTrackURI);
+        } catch (NotFoundException | IOException e) {
+          logger.info("Could not remove track from workspace. Could be it was never there.");
         }
       }
     }
@@ -990,6 +1062,33 @@ public class EditorServiceImpl implements EditorService {
       }
     }
 
+    // Interactive elements
+    Track[] textboxTracks = mp.getTracks(textboxesFlavor);
+    InteractiveElementData textboxes = null;
+    if (textboxTracks.length > 0) {
+      try {
+        Track t = textboxTracks[0];
+        File textboxFile = workspace.get(t.getURI());
+        String textboxString = FileUtils.readFileToString(textboxFile, StandardCharsets.UTF_8);
+        textboxes = new InteractiveElementData(t.getIdentifier(), textboxString);
+      } catch (NotFoundException | IOException e) {
+        errorExit("Could not read textboxes from file", mediaPackageId, ErrorStatus.UNKNOWN);
+      }
+    }
+
+    Track[] quizTracks = mp.getTracks(quizzesFlavor);
+    InteractiveElementData quizzes = null;
+    if (quizTracks.length > 0) {
+      try {
+        Track t = quizTracks[0];
+        File quizFile = workspace.get(t.getURI());
+        String quizString = FileUtils.readFileToString(quizFile, StandardCharsets.UTF_8);
+        quizzes = new InteractiveElementData(t.getIdentifier(), quizString);
+      } catch (NotFoundException | IOException e) {
+        errorExit("Could not read quizzes from file", mediaPackageId, ErrorStatus.UNKNOWN);
+      }
+    }
+
     // Get tracks from the internal publication because it is a lot faster than getting them from the asset manager
     // for some reason.
     final List<TrackData> tracks = trackList.stream().map(track -> {
@@ -1046,8 +1145,8 @@ public class EditorServiceImpl implements EditorService {
     User user = securityService.getUser();
 
     return new EditingData(segments, tracks, workflows, mp.getDuration(), mp.getTitle(), event.getRecordingStartDate(),
-            event.getSeriesId(), event.getSeriesName(), workflowActive, waveformList, subtitles, localPublication,
-            lockingActive, lockRefresh, user, "");
+            event.getSeriesId(), event.getSeriesName(), workflowActive, waveformList, subtitles,
+            textboxes, quizzes, localPublication, lockingActive, lockRefresh, user, "");
   }
 
 
@@ -1139,6 +1238,26 @@ public class EditorServiceImpl implements EditorService {
       errorExit("Unable to add subtitle track to archive", mediaPackageId, ErrorStatus.UNKNOWN, e);
     } catch (IllegalArgumentException e) {
       errorExit("Illegal subtitle given", mediaPackageId, ErrorStatus.UNKNOWN, e);
+    }
+
+    try {
+      if (editingData.getTextboxes() != null) {
+        mediaPackage = processInteractiveElements(mediaPackage, editingData.getTextboxes(), textboxesFlavor.getType());
+      }
+    } catch (IOException e) {
+      errorExit("Unable to add textboxes track to archive", mediaPackageId, ErrorStatus.UNKNOWN, e);
+    } catch (IllegalArgumentException e) {
+      errorExit("Illegal textbox given", mediaPackageId, ErrorStatus.UNKNOWN, e);
+    }
+
+    try {
+      if (editingData.getQuizzes() != null) {
+        mediaPackage = processInteractiveElements(mediaPackage, editingData.getQuizzes(), quizzesFlavor.getType());
+      }
+    } catch (IOException e) {
+      errorExit("Unable to add quizzes track to archive", mediaPackageId, ErrorStatus.UNKNOWN, e);
+    } catch (IllegalArgumentException e) {
+      errorExit("Illegal quiz given", mediaPackageId, ErrorStatus.UNKNOWN, e);
     }
 
     try {

--- a/modules/engage-paella-player-7/package.json
+++ b/modules/engage-paella-player-7/package.json
@@ -9,7 +9,7 @@
     "eslint": "eslint src tests",
     "html-linter": "html-linter --config ../../docs/checkstyle/html-linter.json 'src/**/*.html'",
     "html-validate": "html-validate 'public/*.html'",
-    "check": "npm run html-linter && npm run html-validate",
+    "check": "npm run eslint && npm run html-linter && npm run html-validate",
     "testenv:dev": "webpack serve --mode development --host=0.0.0.0 --env OPENCAST_SERVER_URL=https://develop.opencast.org --env OPENCAST_CONFIG_URL=/paella-opencast/config --env PUBLIC_PATH=/paella7/ui",
     "test": "playwright test"
   },

--- a/modules/engage-paella-player-7/package.json
+++ b/modules/engage-paella-player-7/package.json
@@ -9,7 +9,7 @@
     "eslint": "eslint src tests",
     "html-linter": "html-linter --config ../../docs/checkstyle/html-linter.json 'src/**/*.html'",
     "html-validate": "html-validate 'public/*.html'",
-    "check": "npm run eslint && npm run html-linter && npm run html-validate",
+    "check": "npm run html-linter && npm run html-validate",
     "testenv:dev": "webpack serve --mode development --host=0.0.0.0 --env OPENCAST_SERVER_URL=https://develop.opencast.org --env OPENCAST_CONFIG_URL=/paella-opencast/config --env PUBLIC_PATH=/paella7/ui",
     "test": "playwright test"
   },

--- a/modules/engage-paella-player-7/src/css/QuizPlugin.css
+++ b/modules/engage-paella-player-7/src/css/QuizPlugin.css
@@ -1,0 +1,41 @@
+.quiz-plugin-root {
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    width: 100%;
+    height: 100%;
+    text-align: center;
+    padding: 1% 1%;
+    z-index: 100;
+    font-size: 40px;
+    overflow-wrap: break-word;
+    background-color: rgba(30,30,30,1);
+    color: white;
+    box-sizing: border-box;
+}
+
+.quiz-plugin-question {
+  font-weight: bold;
+  margin-bottom: 1em;
+}
+
+.quiz-plugin-answers label {
+  display: block;
+  margin: 0.25em 0;
+  padding: 0.25em;
+}
+
+.quiz-plugin-correct {
+  background-color: #c8e6c9; /* light green */
+}
+.quiz-plugin-wrong {
+  background-color: #ffcdd2; /* light red */
+}
+
+.quiz-plugin-result {
+  margin-top: 1em;
+  font-weight: bold;
+}
+.quiz-plugin-correct-list {
+  margin-top: 0.5em;
+}

--- a/modules/engage-paella-player-7/src/css/QuizPlugin.css
+++ b/modules/engage-paella-player-7/src/css/QuizPlugin.css
@@ -7,10 +7,9 @@
     padding: 1% 2%;
     z-index: 100;
     font-size: 1.3em;
-    background-color: rgba(245,245,245,1);
-    color: black;
+    background-color: #1f2937;
+    color: #f9fafb;
     border-radius: 2px;
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
 
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -28,11 +27,26 @@
 
 .quiz-plugin-question {
     flex: 2;
+    display: flex;
+    align-items: center;
     font-weight: bold;
     padding: 1em 0.5em;
     font-size: clamp(12px, 3cqw, 28px);
-    background-color: rgba(180,180,180,1);
+    background-color: #263649;
     overflow: auto;
+    border-radius: 25px;
+}
+
+.quiz-plugin-result {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 5px;
+}
+
+.quiz-plugin-result-title {
+    font-size: clamp(12px, 3cqw, 28px);
 }
 
 .quiz-plugin-answers {
@@ -45,21 +59,70 @@
 }
 
 .quiz-plugin-answers label {
-    display: block;
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
     padding: 0.5em;
-    background-color: rgba(210,210,210,1);
+    background-color: #1f2937;
+    border-radius: 5px;
+    border: 3px solid #2c6fb2;
+    cursor: pointer;
 }
 
-.quiz-plugin-answers label input[type="checkbox"] {
-    width: 2em;
-    height: 1.3em;
+.quiz-plugin-answers label:has(input:checked) {
+    background-color: #2c4766;
+}
+
+.quiz-plugin-answers input[type="checkbox"] {
+    appearance: none;
+    margin: 0;
+
+    font: inherit;
+    color: currentColor;
+    width: 1.15em;
+    height: 1.15em;
+
+    border: 0.15em solid #2c6fb2;
+    border-radius: 999px;
+    transform: translateY(-0.075em);
+
+    display: grid;
+    place-content: center;
+}
+
+.quiz-plugin-answers input[type="checkbox"]:checked {
+    background-color: #2c6fb2;
+}
+
+.quiz-plugin-answers input[type="checkbox"]::before {
+    content: "";
+    width: 0.65em;
+    height: 0.65em;
+
+    transform: scale(0);
+    transition: 120ms transform ease-in-out;
+
+    box-shadow: inset 1em 1em #f9fafb;
+
+    transform-origin: bottom left;
+    clip-path: polygon(14% 44%, 0 59%, 50% 100%, 100% 20%, 85% 5%, 47% 70%);
+}
+
+.quiz-plugin-answers input[type="checkbox"]:checked::before {
+    transform: scale(1);
 }
 
 .quiz-plugin-correct {
-    background-color: #c8e6c9 !important; /* light green */
+    background-color: #2a4b48 !important;
+    border-color: #4bb07b !important;
 }
 
-.quiz-bottom-buttons {
+.quiz-plugin-wrong {
+    background-color: #5d434b !important;
+    border-color: #cd5f5c !important;
+}
+
+.quiz-plugin-bottom-buttons {
     display: flex;
     flex: 1;
     flexDirection: row;
@@ -68,12 +131,33 @@
     align-self: flex-end;
 }
 
-.quiz-submit-button {
+.quiz-plugin-button {
     padding: 0.5em;
+    color: inherit;
     background-color: rgba(180,180,180,1);
     border: none;
+    border-radius: 5px;
     font-size: inherit;
+    font-weight: bold;
     align-self: flex-end;
+}
+
+.quiz-plugin-button-primary {
+    background-color: #2d4766;
+    border: 3px solid #2c6fb2;
+}
+
+.quiz-plugin-button-primary:active {
+    background-color: #2c6fb2
+}
+
+.quiz-plugin-button-secondary {
+    background-color: #3c4653;
+    border: 3px solid #676d78;
+}
+
+.quiz-plugin-button-secondary:active {
+    background-color: #676d78
 }
 
 .quiz-plugin-right {
@@ -82,9 +166,32 @@
     justify-content: space-between;
 }
 
-.quiz-plugin-result {
-    font-weight: bold;
-}
-.quiz-plugin-correct-list {
+.quiz-plugin-missed-answers {
+    display: flex;
+    flex-direction: column;
     margin-top: 0.5em;
+}
+
+.quiz-plugin-missed-answers-item::before {
+    display: inline-block;
+    content: "";
+    width: 0.9em;
+    height: 0.9em;
+    background: #d65b5b;
+    border-radius: 50%;
+    border: 2px solid #9f3c3c;
+}
+
+.quiz-plugin-badge {
+    width: 80px;
+    aspect-ratio: 1;
+    background: #2c4766;
+    border: 2px solid #2c6fb2;
+    border-radius: 50%;
+    font-size: clamp(12px, 3cqw, 28px);
+    font-weight: bold;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }

--- a/modules/engage-paella-player-7/src/css/QuizPlugin.css
+++ b/modules/engage-paella-player-7/src/css/QuizPlugin.css
@@ -20,26 +20,32 @@
 .quiz-plugin-left {
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
-}
-
-.quiz-plugin-content {
-    display: flex;
-    flex-direction: column;
+    height: 100%;
+    flex: 1;
+    min-height: 0;       /* scrolling */
+    gap: 2vh;
 }
 
 .quiz-plugin-question {
+    flex: 2;
     font-weight: bold;
-    margin-bottom: 1em;
     padding: 1em 0.5em;
-    font-size: 2em;
-    height: 2em;
+    font-size: clamp(12px, 3cqw, 28px);
     background-color: rgba(180,180,180,1);
+    overflow: auto;
+}
+
+.quiz-plugin-answers {
+    display: flex;
+    flex-direction: column;
+    flex: 7;
+    overflow: auto;
+    min-height: 0;
+    gap: 5px;
 }
 
 .quiz-plugin-answers label {
     display: block;
-    margin: 1em 0;
     padding: 0.5em;
     background-color: rgba(210,210,210,1);
 }
@@ -54,11 +60,12 @@
 }
 
 .quiz-submit-button {
-    margin-top: 1em;
+    flex: 1;
     padding: 0.5em;
     background-color: rgba(180,180,180,1);
     border: none;
     font-size: inherit;
+    max-height: 50px;
     align-self: flex-end;
 }
 
@@ -69,7 +76,6 @@
 }
 
 .quiz-plugin-result {
-    margin-top: 1em;
     font-weight: bold;
 }
 .quiz-plugin-correct-list {

--- a/modules/engage-paella-player-7/src/css/QuizPlugin.css
+++ b/modules/engage-paella-player-7/src/css/QuizPlugin.css
@@ -59,13 +59,20 @@
     background-color: #c8e6c9 !important; /* light green */
 }
 
-.quiz-submit-button {
+.quiz-bottom-buttons {
+    display: flex;
     flex: 1;
+    flexDirection: row;
+    max-height: 50px;
+    gap: 2vh;
+    align-self: flex-end;
+}
+
+.quiz-submit-button {
     padding: 0.5em;
     background-color: rgba(180,180,180,1);
     border: none;
     font-size: inherit;
-    max-height: 50px;
     align-self: flex-end;
 }
 

--- a/modules/engage-paella-player-7/src/css/QuizPlugin.css
+++ b/modules/engage-paella-player-7/src/css/QuizPlugin.css
@@ -1,41 +1,77 @@
 .quiz-plugin-root {
     position: absolute;
-    top: 0px;
-    left: 0px;
-    width: 100%;
-    height: 100%;
-    text-align: center;
-    padding: 1% 1%;
+    top: 10%;
+    left: 10%;
+    width: 80%;
+    height: 75%;
+    padding: 1% 2%;
     z-index: 100;
-    font-size: 40px;
-    overflow-wrap: break-word;
-    background-color: rgba(30,30,30,1);
-    color: white;
-    box-sizing: border-box;
+    font-size: 1.3em;
+    background-color: rgba(245,245,245,1);
+    color: black;
+    border-radius: 2px;
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
+
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 40px;
+}
+
+.quiz-plugin-left {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+}
+
+.quiz-plugin-content {
+    display: flex;
+    flex-direction: column;
 }
 
 .quiz-plugin-question {
-  font-weight: bold;
-  margin-bottom: 1em;
+    font-weight: bold;
+    margin-bottom: 1em;
+    padding: 1em 0.5em;
+    font-size: 2em;
+    height: 2em;
+    background-color: rgba(180,180,180,1);
 }
 
 .quiz-plugin-answers label {
-  display: block;
-  margin: 0.25em 0;
-  padding: 0.25em;
+    display: block;
+    margin: 1em 0;
+    padding: 0.5em;
+    background-color: rgba(210,210,210,1);
+}
+
+.quiz-plugin-answers label input[type="checkbox"] {
+    width: 2em;
+    height: 1.3em;
 }
 
 .quiz-plugin-correct {
-  background-color: #c8e6c9; /* light green */
+    background-color: #c8e6c9 !important; /* light green */
 }
-.quiz-plugin-wrong {
-  background-color: #ffcdd2; /* light red */
+
+.quiz-submit-button {
+    margin-top: 1em;
+    padding: 0.5em;
+    background-color: rgba(180,180,180,1);
+    border: none;
+    font-size: inherit;
+    align-self: flex-end;
+}
+
+.quiz-plugin-right {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
 }
 
 .quiz-plugin-result {
-  margin-top: 1em;
-  font-weight: bold;
+    margin-top: 1em;
+    font-weight: bold;
 }
 .quiz-plugin-correct-list {
-  margin-top: 0.5em;
+    margin-top: 0.5em;
 }

--- a/modules/engage-paella-player-7/src/css/TextboxPlugin.css
+++ b/modules/engage-paella-player-7/src/css/TextboxPlugin.css
@@ -1,0 +1,15 @@
+.textbox-plugin-box {
+    position: absolute;
+    top: 0px;
+    right: 0px;
+    width: 10%;
+    height: 10%;
+    text-align: center;
+    padding: 1% 1%;
+    z-index: 100;
+    font-size: 20px;
+    overflow-wrap: break-word;
+    background-color: rgba(0,0,0,0.6);
+    color: white;
+    box-sizing: border-box;
+}

--- a/modules/engage-paella-player-7/src/css/TextboxPlugin.css
+++ b/modules/engage-paella-player-7/src/css/TextboxPlugin.css
@@ -1,15 +1,45 @@
-.textbox-plugin-box {
+.textbox-plugin-container {
     position: absolute;
-    top: 0px;
-    right: 0px;
-    width: 10%;
-    height: 10%;
+    top: 1%;
+    right: 1%;
     text-align: center;
-    padding: 1% 1%;
+    gap: 0.5vh;
     z-index: 100;
-    font-size: 20px;
-    overflow-wrap: break-word;
-    background-color: rgba(0,0,0,0.6);
+
+    display: flex;
+    flex-direction: column;
+}
+
+.textbox-plugin-box {
+    width: 12vw;
+    height: 1.5vh;
+    padding: 0.5vw;
+    gap: 0.5vw;
+    border-radius: 0.5vw;
+    font-size: min(1vw, 1vh);
+
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+
     color: white;
-    box-sizing: border-box;
+    fill: white;
+    background-color: rgba(0,0,0,0.7);
+
+    text-decoration: none;
+}
+
+.textbox-plugin-box-text {
+    flex: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.textbox-plugin-box-icon {
+    flex-shrink: 0;
+    width: 1em;
+    height: 1.1em;
+    font-size: 1em;
 }

--- a/modules/engage-paella-player-7/src/css/TextboxPlugin.css
+++ b/modules/engage-paella-player-7/src/css/TextboxPlugin.css
@@ -10,77 +10,107 @@
     flex-direction: column;
 }
 
-/* .textbox-plugin-box {
-    width: 12vw;
-    height: 1.5vh;
-    padding: 0.5vw;
-    gap: 0.5vw;
-    border-radius: 0.5vw;
-    font-size: min(1vw, 1vh);
-
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: center;
-
-    color: white;
-    fill: white;
-    background-color: rgba(0,0,0,0.7);
-
-    text-decoration: none;
-} */
-
-.textbox-plugin-box-details {
+.textbox-plugin-details {
     width: clamp(100px, 14vw, 220px);
-    padding: clamp(5px, 0.5vw, 10px);
     border-radius: clamp(5px, 0.5vw, 10px);
     font-size: clamp(14px, min(1vw, 1vh), 20px);
 
     color: white;
-    fill: white;
-    background-color: rgba(0,0,0,0.7);
+    background: #e5e7eb;
 
     text-decoration: none;
 }
 
-.textbox-plugin-box-summary {
-    display: flex;
+/* remove default arrow */
+.textbox-plugin-summary {
+    list-style: none;
+}
+.textbox-plugin-summary::-webkit-details-marker {
+    display: none;
 }
 
-.textbox-plugin-box-summary-link {
-    display: flex;
-    align-items: center;
-    gap: 0.5em;
-    flex: 1;
-    min-width: 0;
-
-    color: white;
-    text-decoration: none;
+/* header layout */
+.textbox-plugin-summary {
+    display: grid;
+    grid-template-columns: 2em 1fr 2em;
+    cursor: pointer;
 }
 
-/* Right-side dropdown arrow */
-.textbox-plugin-box-summary::-webkit-details-marker {
-  display: none;
-}
-.textbox-plugin-box-summary .right::after {
-  content: "◂";
-  padding: 0.5vw;
-}
-details[open] .textbox-plugin-box-summary .right::after {
-  content: "▾";
-  padding: 0.5vw;
+/* left white icon area */
+.textbox-plugin-icon {
+    background: #e5e7eb;
+    color: #1f2937;
+    display: grid;
+    place-items: center;
+    justify-self: center;
+    align-self: center;
+    font-weight: bold;
+
+    /* circle */
+    width: 1.4em;
+    height: 1.4em;
+    border: 0.12em solid #1f2937;
+    border-radius: 50%;
 }
 
-.textbox-plugin-box-text {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    min-width: 0;
+/* center dark blue title area */
+.textbox-plugin-title {
+  background: #4b5563;
+  color: #e5e7eb;
+  display: flex;
+  align-items: center;
+  padding: 0.6em 0.35em;
+
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.textbox-plugin-box-icon {
-    flex-shrink: 0;
-    width: 1em;
-    height: 1.1em;
-    display: block;
+/* right arrow area */
+.textbox-plugin-toggle {
+    display: grid;
+    place-items: center;
+}
+
+/* arrow */
+.textbox-plugin-toggle::before {
+    content: "▽";
+    font-size: 1.2em;
+    color: #374151;
+    transition: transform 0.2s;
+}
+
+/* rotate arrow when open */
+.textbox-plugin[open] .textbox-plugin-toggle::before {
+    transform: rotate(180deg);
+}
+
+/* content layout (same column structure) */
+.textbox-plugin-content {
+    display: grid;
+    grid-template-columns: 2em 1fr 2em;
+}
+
+/* keep white side bars */
+.textbox-plugin-content::before,
+.textbox-plugin-content::after {
+    content: "";
+}
+
+.textbox-plugin-content > * {
+    grid-column: 2;
+}
+
+/* center content background */
+.textbox-plugin-content {
+    color: #e5e7eb;
+
+    background: linear-gradient(
+      to right,
+      #e5e7eb 2em,
+      #4b5563 2em,
+      #4b5563 calc(100% - 2em),
+      #e5e7eb calc(100% - 2em)
+    );
+    padding: 0.5em 0.35em;
 }

--- a/modules/engage-paella-player-7/src/css/TextboxPlugin.css
+++ b/modules/engage-paella-player-7/src/css/TextboxPlugin.css
@@ -30,6 +30,51 @@
     text-decoration: none;
 }
 
+.textbox-plugin-box-details {
+    width: 12vw;
+    min-height: 1.5vh;
+    padding: 0.5vw;
+    gap: 0.5vw;
+    border-radius: 0.5vw;
+    font-size: min(1vw, 1vh);
+
+    color: white;
+    fill: white;
+    background-color: rgba(0,0,0,0.7);
+
+    text-decoration: none;
+}
+
+.textbox-plugin-box-summary {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 0.5vw;
+
+    width: 100%;
+    cursor: pointer;
+}
+
+/* Right-side dropdown arrow */
+.textbox-plugin-box-summary::-webkit-details-marker {
+  display: none;
+}
+.textbox-plugin-box-summary .right::after {
+  content: "◂";
+  font-size: 1em;
+}
+details[open] .textbox-plugin-box-summary .right::after {
+  content: "▾";
+  font-size: 1em;
+}
+
+/* Optional left icon */
+.textbox-plugin-box-summary .left svg {
+  width: 1em;
+  height: 1em;
+  object-fit: contain;
+}
+
 .textbox-plugin-box-text {
     flex: 1;
     white-space: nowrap;

--- a/modules/engage-paella-player-7/src/css/TextboxPlugin.css
+++ b/modules/engage-paella-player-7/src/css/TextboxPlugin.css
@@ -31,13 +31,10 @@
 } */
 
 .textbox-plugin-box-details {
-    width: 14vw;
-    min-height: 1.5vh;
-    padding: 0.5vw 0;
-    padding-left: 0.5vw;
-    gap: 0.5vw;
-    border-radius: 0.5vw;
-    font-size: min(1vw, 1vh);
+    width: clamp(100px, 14vw, 220px);
+    padding: clamp(5px, 0.5vw, 10px);
+    border-radius: clamp(5px, 0.5vw, 10px);
+    font-size: clamp(14px, min(1vw, 1vh), 20px);
 
     color: white;
     fill: white;
@@ -67,12 +64,10 @@
 }
 .textbox-plugin-box-summary .right::after {
   content: "◂";
-  font-size: 1em;
   padding: 0.5vw;
 }
 details[open] .textbox-plugin-box-summary .right::after {
   content: "▾";
-  font-size: 1em;
   padding: 0.5vw;
 }
 
@@ -87,6 +82,5 @@ details[open] .textbox-plugin-box-summary .right::after {
     flex-shrink: 0;
     width: 1em;
     height: 1.1em;
-    font-size: 1em;
     display: block;
 }

--- a/modules/engage-paella-player-7/src/css/TextboxPlugin.css
+++ b/modules/engage-paella-player-7/src/css/TextboxPlugin.css
@@ -10,7 +10,7 @@
     flex-direction: column;
 }
 
-.textbox-plugin-box {
+/* .textbox-plugin-box {
     width: 12vw;
     height: 1.5vh;
     padding: 0.5vw;
@@ -28,12 +28,13 @@
     background-color: rgba(0,0,0,0.7);
 
     text-decoration: none;
-}
+} */
 
 .textbox-plugin-box-details {
-    width: 12vw;
+    width: 14vw;
     min-height: 1.5vh;
-    padding: 0.5vw;
+    padding: 0.5vw 0;
+    padding-left: 0.5vw;
     gap: 0.5vw;
     border-radius: 0.5vw;
     font-size: min(1vw, 1vh);
@@ -46,13 +47,18 @@
 }
 
 .textbox-plugin-box-summary {
-    display: grid;
-    grid-template-columns: auto 1fr auto;
-    align-items: center;
-    gap: 0.5vw;
+    display: flex;
+}
 
-    width: 100%;
-    cursor: pointer;
+.textbox-plugin-box-summary-link {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+    flex: 1;
+    min-width: 0;
+
+    color: white;
+    text-decoration: none;
 }
 
 /* Right-side dropdown arrow */
@@ -62,24 +68,19 @@
 .textbox-plugin-box-summary .right::after {
   content: "◂";
   font-size: 1em;
+  padding: 0.5vw;
 }
 details[open] .textbox-plugin-box-summary .right::after {
   content: "▾";
   font-size: 1em;
-}
-
-/* Optional left icon */
-.textbox-plugin-box-summary .left svg {
-  width: 1em;
-  height: 1em;
-  object-fit: contain;
+  padding: 0.5vw;
 }
 
 .textbox-plugin-box-text {
-    flex: 1;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    min-width: 0;
 }
 
 .textbox-plugin-box-icon {
@@ -87,4 +88,5 @@ details[open] .textbox-plugin-box-summary .right::after {
     width: 1em;
     height: 1.1em;
     font-size: 1em;
+    display: block;
 }

--- a/modules/engage-paella-player-7/src/i18n/en-US.json
+++ b/modules/engage-paella-player-7/src/i18n/en-US.json
@@ -151,5 +151,12 @@
 
     "Undefined caption": "Unknown language",
     "Unknown language": "Unknown language",
-    "automatically generated": "automatically generated"
+    "automatically generated": "automatically generated",
+
+    "Quiz Skip": "Skip",
+    "Quiz Submit": "Submit",
+    "Quiz Try Again": "Try Again",
+    "Quiz Continue": "Continue",
+    "Quiz Correct Answers": "You got $1 out of $2 correct.",
+    "Quiz Correct Answers Missed": "Correct answers you missed: $1"
 }

--- a/modules/engage-paella-player-7/src/i18n/en-US.json
+++ b/modules/engage-paella-player-7/src/i18n/en-US.json
@@ -157,6 +157,6 @@
     "Quiz Submit": "Submit",
     "Quiz Try Again": "Try Again",
     "Quiz Continue": "Continue",
-    "Quiz Correct Answers": "You got $1 out of $2 correct.",
-    "Quiz Correct Answers Missed": "Correct answers you missed: $1"
+    "Quiz Correct Answers": "Correct answers",
+    "Quiz Correct Answers Missed": "Answers you missed"
 }

--- a/modules/engage-paella-player-7/src/icons/external-link.svg
+++ b/modules/engage-paella-player-7/src/icons/external-link.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-external-link-icon lucide-external-link"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>

--- a/modules/engage-paella-player-7/src/js/EpisodeConversor.js
+++ b/modules/engage-paella-player-7/src/js/EpisodeConversor.js
@@ -487,6 +487,32 @@ function getTextboxes(episode) {
   return textboxes;
 }
 
+function readQuizzes(potentialNewQuizzes, quizzes) {
+  potentialNewQuizzes.forEach((potentialQuiz) => {
+    try {
+      let quizzes_regex = /^quizzes\/([^+]+)(\+(.+))?/g;
+      let quizzes_match = quizzes_regex.exec(potentialQuiz.type);
+
+      if (quizzes_match) {
+        quizzes.push(potentialQuiz);
+      }
+    }
+    catch (err) {/**/}
+  });
+}
+
+function getQuizzes(episode) {
+  var quizzes = [];
+
+  var tracks = episode.mediapackage.media.track;
+  if (!(tracks instanceof Array)) { tracks = tracks ? [tracks] : []; }
+
+  // Read the quizzes from the tracks
+  readQuizzes(tracks, quizzes);
+
+  return quizzes;
+}
+
 function processTranscriptions(episode, manifest) {
   var catalog = episode.mediapackage.metadata.catalog;
   if (!(catalog instanceof Array)) { catalog = catalog ? [catalog] : []; }
@@ -550,13 +576,14 @@ export function episodeToManifest(ocResponse, config) {
     const streams = getStreams(episode, config);
     const captions = getCaptions(episode, config);
     const textboxes = getTextboxes(episode, config);
+    const quizzes = getQuizzes(episode, config);
 
     const result = {
       metadata,
       streams,
-      captions
       captions,
       textboxes,
+      quizzes
     };
 
     processAttachments(episode, result, config);

--- a/modules/engage-paella-player-7/src/js/EpisodeConversor.js
+++ b/modules/engage-paella-player-7/src/js/EpisodeConversor.js
@@ -461,6 +461,32 @@ function getCaptions(episode) {
   return captions;
 }
 
+function readTextboxes(potentialNewTextboxes, textboxes) {
+  potentialNewTextboxes.forEach((potentialTextbox) => {
+    try {
+      let textboxes_regex = /^textboxes\/([^+]+)(\+(.+))?/g;
+      let textboxes_match = textboxes_regex.exec(potentialTextbox.type);
+
+      if (textboxes_match) {
+        textboxes.push(potentialTextbox);
+      }
+    }
+    catch (err) {/**/}
+  });
+}
+
+function getTextboxes(episode) {
+  var textboxes = [];
+
+  var tracks = episode.mediapackage.media.track;
+  if (!(tracks instanceof Array)) { tracks = tracks ? [tracks] : []; }
+
+  // Read the textboxes from the tracks
+  readTextboxes(tracks, textboxes);
+
+  return textboxes;
+}
+
 function processTranscriptions(episode, manifest) {
   var catalog = episode.mediapackage.metadata.catalog;
   if (!(catalog instanceof Array)) { catalog = catalog ? [catalog] : []; }
@@ -523,11 +549,14 @@ export function episodeToManifest(ocResponse, config) {
     const metadata = getMetadata(episode, config);
     const streams = getStreams(episode, config);
     const captions = getCaptions(episode, config);
+    const textboxes = getTextboxes(episode, config);
 
     const result = {
       metadata,
       streams,
       captions
+      captions,
+      textboxes,
     };
 
     processAttachments(episode, result, config);

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.quizPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.quizPlugin.js
@@ -122,17 +122,13 @@ export default class QuizPlugin extends EventLogPlugin {
         <div class="quiz-plugin-left"> </div>
       `, quiz);
 
-      const quizContent = createElementWithHtmlText(`
-        <div class="quiz-plugin-content"> </div>
-      `, quizLeft);
-
       createElementWithHtmlText(`
-        <h2 class="quiz-plugin-question">${info.question}</h2>
-      `, quizContent);
+        <div class="quiz-plugin-question">${info.question}</div>
+      `, quizLeft);
 
       const answers = createElementWithHtmlText(`
         <div class="quiz-plugin-answers"> </div>
-      `, quizContent);
+      `, quizLeft);
 
       info.answers?.map((answer) => {
         createElementWithHtmlText(`

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.quizPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.quizPlugin.js
@@ -137,15 +137,15 @@ export default class QuizPlugin extends EventLogPlugin {
       });
 
       const bottomButtons = createElementWithHtmlText(`
-        <div class="quiz-bottom-buttons"></div>
+        <div class="quiz-plugin-bottom-buttons"></div>
       `, quizLeft);
 
       const skipButton = createElementWithHtmlText(`
-        <button class="quiz-submit-button">${translate('Quiz Skip')}</button>
+        <button class="quiz-plugin-button quiz-plugin-button-secondary">${translate('Quiz Skip')}</button>
       `, bottomButtons);
 
       const submit = createElementWithHtmlText(`
-        <button class="quiz-submit-button">${translate('Quiz Submit')}</button>
+        <button class="quiz-plugin-button quiz-plugin-button-primary">${translate('Quiz Submit')}</button>
       `, bottomButtons);
 
       const quizRight = createElementWithHtmlText(`
@@ -159,18 +159,35 @@ export default class QuizPlugin extends EventLogPlugin {
       const result = createElementWithHtmlText(`
         <div class="quiz-plugin-result"></div>
       `, quizRight);
+      result.style.display = 'none';
+
+      createElementWithHtmlText(`
+        <div class="quiz-plugin-result-title">${translate('Quiz Correct Answers')}</div>
+      `, result);
+
+      const quizBadge = createElementWithHtmlText(`
+        <div class="quiz-plugin-badge">0/2</div>
+      `, result);
+
+      createElementWithHtmlText(`
+        <div>${translate('Quiz Correct Answers Missed')}</div>
+      `, result);
+
+      const missedAnswers = createElementWithHtmlText(`
+        <div class="quiz-plugin-missed-answers"></div>
+      `, result);
 
       const bottomButtonsRight = createElementWithHtmlText(`
-        <div class="quiz-bottom-buttons"></div>
+        <div class="quiz-plugin-bottom-buttons"></div>
       `, quizRight);
 
       const tryAgainButton = createElementWithHtmlText(`
-        <button class="quiz-submit-button">${translate('Quiz Try Again')}</button>
+        <button class="quiz-plugin-button quiz-plugin-button-secondary">${translate('Quiz Try Again')}</button>
       `, bottomButtonsRight);
       tryAgainButton.style.display = 'none';
 
       const continueButton = createElementWithHtmlText(`
-        <button class="quiz-submit-button">${translate('Quiz Continue')}</button>
+        <button class="quiz-plugin-button quiz-plugin-button-secondary">${translate('Quiz Continue')}</button>
       `, bottomButtonsRight);
       continueButton.style.display = 'none';
 
@@ -188,6 +205,7 @@ export default class QuizPlugin extends EventLogPlugin {
         checkboxes.forEach(checkbox => {
           const label = checkbox.parentElement;
           label.classList.remove('quiz-plugin-correct');
+          label.classList.remove('quiz-plugin-wrong');
         });
 
         // Evaluate answers
@@ -201,23 +219,27 @@ export default class QuizPlugin extends EventLogPlugin {
             if (isCorrect) {
               label.classList.add('quiz-plugin-correct');
               correctCount++;
+            } else {
+              label.classList.add('quiz-plugin-wrong');
             }
           }
         });
 
         // Build result message
         const totalCorrect = correctAnswers.length;
-        let resultMsg = `${translate('Quiz Correct Answers', [correctCount, totalCorrect])}`;
+        quizBadge.innerHTML = `${correctCount}/${totalCorrect}`;
 
         // Show missed answers
-        const missed = correctAnswers.filter(answer => !selected.includes(answer));
-        if (missed.length > 0) {
-          const names = missed.map(a => a[0].toUpperCase() + a.slice(1)).join(', ');
-          resultMsg += `<br>
-            <span class="quiz-plugin-correct-list">${translate('Quiz Correct Answers Missed', [names])}</span>`;
-        }
+        let missedAnswersMsg = '';
 
-        result.innerHTML = resultMsg;
+        const missedAnswersList = correctAnswers.filter(answer => !selected.includes(answer));
+        missedAnswersList.forEach(missedAnswer => {
+          const name = missedAnswer[0].toUpperCase() + missedAnswer.slice(1);
+          missedAnswersMsg += `<span class="quiz-plugin-missed-answers-item"> ${name}</span>`;
+        });
+
+        missedAnswers.innerHTML = missedAnswersMsg;
+        result.style.display = 'flex';
         continueButton.style.display = 'block';
         tryAgainButton.style.display = 'block';
       });
@@ -230,10 +252,12 @@ export default class QuizPlugin extends EventLogPlugin {
           checkbox.checked = false;
           const label = checkbox.parentElement;
           label.classList.remove('quiz-plugin-correct');
+          label.classList.remove('quiz-plugin-wrong');
         });
 
 
-        result.innerHTML = '';
+        // result.innerHTML = '';
+        result.style.display = 'none';
         continueButton.style.display = 'none';
         tryAgainButton.style.display = 'none';
       });

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.quizPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.quizPlugin.js
@@ -32,7 +32,7 @@ export default class QuizPlugin extends EventLogPlugin {
     /* Demo json for quick developing purposes */
     // const myTestJson = [
     //   {
-    //     start: 2,
+    //     start: 2000,
     //     type: 'multipleChoice',
     //     question: 'Which is a fruit?',
     //     answers: [
@@ -54,12 +54,6 @@ export default class QuizPlugin extends EventLogPlugin {
     //       }
     //     ],
     //   },
-    //   {
-    //     start: 8,
-    //     type: 'text',
-    //     question: 'Can we have free form questions as well?',
-    //     correctAnswers: ['Yes', 'Y', 'If I have to']
-    //   }
     // ];
     // this._quizJSON = myTestJson;
   }
@@ -94,13 +88,14 @@ export default class QuizPlugin extends EventLogPlugin {
       }
 
       // TODO: Avoid quizzes overlapping
-      if (!info.shown && params.currentTime >= info.start && !this._quiz) {
+      const start = (info.start / 1000);
+      if (!info.shown && params.currentTime >= start && !this._quiz) {
         this.player.pause();
         this.createQuiz(info, index);
         info.shown = true;
       }
 
-      if (params.currentTime < info.start) {
+      if (params.currentTime < start) {
         info.shown = false; // Reset flag
       }
     });

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.quizPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.quizPlugin.js
@@ -1,0 +1,230 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+import { Events, EventLogPlugin, createElementWithHtmlText } from 'paella-core';
+import '../css/QuizPlugin.css';
+
+export default class QuizPlugin extends EventLogPlugin {
+
+  // Initialize
+  async load() {
+    this._quiz = null; // DOM element
+    this._quizJSON = []; // Infos from the Opencast mediapackage
+
+    const myTestJson = [
+      {
+        start: 2,
+        type: 'multipleChoice',
+        question: 'Which is a fruit?',
+        answers: [
+          {
+            text: 'Banana',
+            correct: true
+          },
+          {
+            text: 'Cucumber',
+            correct: false
+          },
+          {
+            text: 'Tomato',
+            correct: true
+          },
+          {
+            text: 'Adjustable side table, walnut',
+            correct: false
+          }
+        ],
+      },
+      {
+        start: 8,
+        type: 'text',
+        question: 'Can we have free form questions as well?',
+        correctAnswers: ['Yes', 'Y', 'If I have to']
+      }
+    ];
+
+    this._quizJSON = myTestJson;
+  }
+
+  // Define which events we subscribe too
+  get events() {
+    return [
+      Events.PLAYER_LOADED,
+      Events.TIMEUPDATE,
+      Events.FULLSCREEN_CHANGED
+    ];
+  }
+
+  async onEvent(event, params) {
+    // Load info from Opencast
+    if (event === Events.PLAYER_LOADED) {
+      // TODO: Handle multiple quiz files
+      const quiz = this.player?._videoManifest?.quizzes?.[0];
+      this._quizJSON = await this.loadQuizzesFromOpencast(quiz.url);
+    }
+
+    // Display/Hide quiz
+    this._quizJSON.forEach((info, index) => {
+      if (info.shown === undefined) {
+        info.shown = false;
+      }
+
+      // TODO: Avoid quizzes overlapping
+      if (!info.shown && params.currentTime >= info.start && !this._quiz) {
+        this.player.pause();
+        this.createQuiz(info, index);
+        info.shown = true;
+      }
+
+      if (params.currentTime < info.start) {
+        info.shown = false; // Reset flag
+      }
+    });
+
+    // // Old code for manually fixing fullscreen issue
+    // // Requires Events.FULLSCREEN_CHANGED in the get events() method
+    // if (event === Events.FULLSCREEN_CHANGED) {
+    //   const fsElement = document.fullscreenElement;
+    //   const quiz = document.querySelector('.quiz-plugin-root');
+    //   if (fsElement && quiz && !fsElement.contains(quiz)) {
+    //     fsElement.appendChild(quiz);
+    //   }
+    // }
+
+  }
+
+  // Add a textbox to the DOM
+  createQuiz(info) {
+    if (!this._quiz) {
+      /* HTML */
+      const quiz = createElementWithHtmlText('<div class="quiz-plugin-root"> </div>');
+
+      createElementWithHtmlText(`
+        <div class="quiz-plugin-question">${info.question}</div>
+      `, quiz);
+
+      const answers = createElementWithHtmlText(`
+        <div class="quiz-plugin-answers"> </div>
+      `, quiz);
+
+      info.answers?.map((answer) => {
+        createElementWithHtmlText(`
+          <label><input type="checkbox" value="${answer.text}">${answer.text}</label>
+        `, answers);
+      });
+
+      const submit = createElementWithHtmlText(`
+        <button>Submit</button>
+      `, quiz);
+
+      const result = createElementWithHtmlText(`
+        <div class="quiz-plugin-result"></div>
+      `, quiz);
+
+      const continueButton = createElementWithHtmlText(`
+        <button>Continue</button>
+      `, quiz);
+
+      /* Script */
+      const correctAnswers = info.answers
+        .filter(answer => answer.correct)
+        .map(answer => answer.text);
+
+      submit.addEventListener('click', () => {
+        const checkboxes = answers.querySelectorAll('.quiz-plugin-answers input[type="checkbox"]');
+        const selected = [];
+        let correctCount = 0;
+
+        // Reset styles
+        checkboxes.forEach(checkbox => {
+          const label = checkbox.parentElement;
+          label.classList.remove('quiz-plugin-correct', 'quiz-plugin-wrong');
+        });
+
+        // Evaluate answers
+        checkboxes.forEach(box => {
+          const label = box.parentElement;
+          const isChecked = box.checked;
+          const isCorrect = correctAnswers.includes(box.value);
+
+          if (isChecked) {
+            selected.push(box.value);
+            if (isCorrect) {
+              label.classList.add('quiz-plugin-correct');
+              correctCount++;
+            } else {
+              label.classList.add('quiz-plugin-wrong');
+            }
+          } else if (!isChecked && isCorrect) {
+            // Missed a correct answer
+            label.classList.add('quiz-plugin-wrong');
+          }
+        });
+
+        // Build result message
+        const totalCorrect = correctAnswers.length;
+        let resultMsg = `You got ${correctCount} out of ${totalCorrect} correct.`;
+
+        // Show missed answers
+        const missed = correctAnswers.filter(answer => !selected.includes(answer));
+        if (missed.length > 0) {
+          const names = missed.map(a => a[0].toUpperCase() + a.slice(1)).join(', ');
+          resultMsg += `<br><span class="quiz-plugin-correct-list">Correct answers you missed: ${names}</span>`;
+        }
+
+        result.innerHTML = resultMsg;
+      });
+
+      continueButton.addEventListener('click', () => {
+        this.removeQuiz();
+      });
+
+
+      this._quiz = quiz;
+      // Append to player-container to not dissappear during fullscreen
+      document.querySelector('.player-container').appendChild(this._quiz);
+    }
+  }
+
+  // Remove a textbox from the DOM
+  removeQuiz() {
+    if (this._quiz) {
+      document.querySelector('.player-container').removeChild(this._quiz);
+      this._quiz = null;
+      this.player.play();
+    }
+  }
+
+  // Query Opencast for a json with info about textboxes
+  loadQuizzesFromOpencast = async (url) => {
+    let quizzes = [];
+    const response = await fetch(url);
+    if (response.ok) {
+      try {
+        quizzes = response.json();
+      }
+      catch (e) {
+        this.player.log.warn('Error loading quizzes');
+      }
+    }
+    return quizzes;
+  };
+}

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.quizPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.quizPlugin.js
@@ -30,32 +30,32 @@ export default class QuizPlugin extends EventLogPlugin {
     this._quizJSON = []; // Infos from the Opencast mediapackage
 
     /* Demo json for quick developing purposes */
-    // const myTestJson = [
-    //   {
-    //     start: 2000,
-    //     type: 'multipleChoice',
-    //     question: 'Which is a fruit?',
-    //     answers: [
-    //       {
-    //         text: 'Banana',
-    //         correct: true
-    //       },
-    //       {
-    //         text: 'Cucumber',
-    //         correct: false
-    //       },
-    //       {
-    //         text: 'Tomato',
-    //         correct: true
-    //       },
-    //       {
-    //         text: 'Adjustable side table, walnut',
-    //         correct: false
-    //       }
-    //     ],
-    //   },
-    // ];
-    // this._quizJSON = myTestJson;
+    const myTestJson = [
+      {
+        start: 2000,
+        type: 'multipleChoice',
+        question: 'Which is a fruit?',
+        answers: [
+          {
+            text: 'Banana',
+            correct: true
+          },
+          {
+            text: 'Cucumber',
+            correct: false
+          },
+          {
+            text: 'Tomato',
+            correct: true
+          },
+          {
+            text: 'Adjustable side table, walnut',
+            correct: false
+          }
+        ],
+      },
+    ];
+    this._quizJSON = myTestJson;
   }
 
   // Define which events we subscribe too
@@ -136,9 +136,18 @@ export default class QuizPlugin extends EventLogPlugin {
         `, answers);
       });
 
+      const bottomButtons = createElementWithHtmlText(`
+        <div class="quiz-bottom-buttons"></div>
+      `, quizLeft);
+
+      // eslint-disable-next-line no-unused-vars
+      const skipButton = createElementWithHtmlText(`
+        <button class="quiz-submit-button">Skip</button>
+      `, bottomButtons);
+
       const submit = createElementWithHtmlText(`
         <button class="quiz-submit-button">Submit</button>
-      `, quizLeft);
+      `, bottomButtons);
 
       const quizRight = createElementWithHtmlText(`
         <div class="quiz-plugin-right"> </div>
@@ -201,6 +210,10 @@ export default class QuizPlugin extends EventLogPlugin {
 
         result.innerHTML = resultMsg;
         continueButton.style.display = 'block';
+      });
+
+      skipButton.addEventListener('click', () => {
+        this.removeQuiz();
       });
 
       continueButton.addEventListener('click', () => {

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.quizPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.quizPlugin.js
@@ -140,7 +140,6 @@ export default class QuizPlugin extends EventLogPlugin {
         <div class="quiz-bottom-buttons"></div>
       `, quizLeft);
 
-      // eslint-disable-next-line no-unused-vars
       const skipButton = createElementWithHtmlText(`
         <button class="quiz-submit-button">Skip</button>
       `, bottomButtons);
@@ -161,9 +160,18 @@ export default class QuizPlugin extends EventLogPlugin {
         <div class="quiz-plugin-result"></div>
       `, quizRight);
 
+      const bottomButtonsRight = createElementWithHtmlText(`
+        <div class="quiz-bottom-buttons"></div>
+      `, quizRight);
+
+      const tryAgainButton = createElementWithHtmlText(`
+        <button class="quiz-submit-button">Try again</button>
+      `, bottomButtonsRight);
+      tryAgainButton.style.display = 'none';
+
       const continueButton = createElementWithHtmlText(`
         <button class="quiz-submit-button">Continue</button>
-      `, quizRight);
+      `, bottomButtonsRight);
       continueButton.style.display = 'none';
 
       /* Script */
@@ -210,6 +218,23 @@ export default class QuizPlugin extends EventLogPlugin {
 
         result.innerHTML = resultMsg;
         continueButton.style.display = 'block';
+        tryAgainButton.style.display = 'block';
+      });
+
+      tryAgainButton.addEventListener('click', () => {
+        const checkboxes = answers.querySelectorAll('.quiz-plugin-answers input[type="checkbox"]');
+
+        // Reset
+        checkboxes.forEach(checkbox => {
+          checkbox.checked = false;
+          const label = checkbox.parentElement;
+          label.classList.remove('quiz-plugin-correct');
+        });
+
+
+        result.innerHTML = '';
+        continueButton.style.display = 'none';
+        tryAgainButton.style.display = 'none';
       });
 
       skipButton.addEventListener('click', () => {

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.quizPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.quizPlugin.js
@@ -29,39 +29,39 @@ export default class QuizPlugin extends EventLogPlugin {
     this._quiz = null; // DOM element
     this._quizJSON = []; // Infos from the Opencast mediapackage
 
-    const myTestJson = [
-      {
-        start: 2,
-        type: 'multipleChoice',
-        question: 'Which is a fruit?',
-        answers: [
-          {
-            text: 'Banana',
-            correct: true
-          },
-          {
-            text: 'Cucumber',
-            correct: false
-          },
-          {
-            text: 'Tomato',
-            correct: true
-          },
-          {
-            text: 'Adjustable side table, walnut',
-            correct: false
-          }
-        ],
-      },
-      {
-        start: 8,
-        type: 'text',
-        question: 'Can we have free form questions as well?',
-        correctAnswers: ['Yes', 'Y', 'If I have to']
-      }
-    ];
-
-    this._quizJSON = myTestJson;
+    /* Demo json for quick developing purposes */
+    // const myTestJson = [
+    //   {
+    //     start: 2,
+    //     type: 'multipleChoice',
+    //     question: 'Which is a fruit?',
+    //     answers: [
+    //       {
+    //         text: 'Banana',
+    //         correct: true
+    //       },
+    //       {
+    //         text: 'Cucumber',
+    //         correct: false
+    //       },
+    //       {
+    //         text: 'Tomato',
+    //         correct: true
+    //       },
+    //       {
+    //         text: 'Adjustable side table, walnut',
+    //         correct: false
+    //       }
+    //     ],
+    //   },
+    //   {
+    //     start: 8,
+    //     type: 'text',
+    //     question: 'Can we have free form questions as well?',
+    //     correctAnswers: ['Yes', 'Y', 'If I have to']
+    //   }
+    // ];
+    // this._quizJSON = myTestJson;
   }
 
   // Define which events we subscribe too

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.quizPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.quizPlugin.js
@@ -19,7 +19,7 @@
  *
  */
 
-import { Events, EventLogPlugin, createElementWithHtmlText } from 'paella-core';
+import { Events, EventLogPlugin, createElementWithHtmlText, translate } from 'paella-core';
 import '../css/QuizPlugin.css';
 
 export default class QuizPlugin extends EventLogPlugin {
@@ -30,32 +30,32 @@ export default class QuizPlugin extends EventLogPlugin {
     this._quizJSON = []; // Infos from the Opencast mediapackage
 
     /* Demo json for quick developing purposes */
-    const myTestJson = [
-      {
-        start: 2000,
-        type: 'multipleChoice',
-        question: 'Which is a fruit?',
-        answers: [
-          {
-            text: 'Banana',
-            correct: true
-          },
-          {
-            text: 'Cucumber',
-            correct: false
-          },
-          {
-            text: 'Tomato',
-            correct: true
-          },
-          {
-            text: 'Adjustable side table, walnut',
-            correct: false
-          }
-        ],
-      },
-    ];
-    this._quizJSON = myTestJson;
+    // const myTestJson = [
+    //   {
+    //     start: 2000,
+    //     type: 'multipleChoice',
+    //     question: 'Which is a fruit?',
+    //     answers: [
+    //       {
+    //         text: 'Banana',
+    //         correct: true
+    //       },
+    //       {
+    //         text: 'Cucumber',
+    //         correct: false
+    //       },
+    //       {
+    //         text: 'Tomato',
+    //         correct: true
+    //       },
+    //       {
+    //         text: 'Adjustable side table, walnut',
+    //         correct: false
+    //       }
+    //     ],
+    //   },
+    // ];
+    // this._quizJSON = myTestJson;
   }
 
   // Define which events we subscribe too
@@ -141,11 +141,11 @@ export default class QuizPlugin extends EventLogPlugin {
       `, quizLeft);
 
       const skipButton = createElementWithHtmlText(`
-        <button class="quiz-submit-button">Skip</button>
+        <button class="quiz-submit-button">${translate('Quiz Skip')}</button>
       `, bottomButtons);
 
       const submit = createElementWithHtmlText(`
-        <button class="quiz-submit-button">Submit</button>
+        <button class="quiz-submit-button">${translate('Quiz Submit')}</button>
       `, bottomButtons);
 
       const quizRight = createElementWithHtmlText(`
@@ -165,12 +165,12 @@ export default class QuizPlugin extends EventLogPlugin {
       `, quizRight);
 
       const tryAgainButton = createElementWithHtmlText(`
-        <button class="quiz-submit-button">Try again</button>
+        <button class="quiz-submit-button">${translate('Quiz Try Again')}</button>
       `, bottomButtonsRight);
       tryAgainButton.style.display = 'none';
 
       const continueButton = createElementWithHtmlText(`
-        <button class="quiz-submit-button">Continue</button>
+        <button class="quiz-submit-button">${translate('Quiz Continue')}</button>
       `, bottomButtonsRight);
       continueButton.style.display = 'none';
 
@@ -207,13 +207,14 @@ export default class QuizPlugin extends EventLogPlugin {
 
         // Build result message
         const totalCorrect = correctAnswers.length;
-        let resultMsg = `You got ${correctCount} out of ${totalCorrect} correct.`;
+        let resultMsg = `${translate('Quiz Correct Answers', [correctCount, totalCorrect])}`;
 
         // Show missed answers
         const missed = correctAnswers.filter(answer => !selected.includes(answer));
         if (missed.length > 0) {
           const names = missed.map(a => a[0].toUpperCase() + a.slice(1)).join(', ');
-          resultMsg += `<br><span class="quiz-plugin-correct-list">Correct answers you missed: ${names}</span>`;
+          resultMsg += `<br>
+            <span class="quiz-plugin-correct-list">${translate('Quiz Correct Answers Missed', [names])}</span>`;
         }
 
         result.innerHTML = resultMsg;

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.quizPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.quizPlugin.js
@@ -69,7 +69,8 @@ export default class QuizPlugin extends EventLogPlugin {
     return [
       Events.PLAYER_LOADED,
       Events.TIMEUPDATE,
-      Events.FULLSCREEN_CHANGED
+      Events.PLAY,
+      Events.SEEK
     ];
   }
 
@@ -79,6 +80,11 @@ export default class QuizPlugin extends EventLogPlugin {
       // TODO: Handle multiple quiz files
       const quiz = this.player?._videoManifest?.quizzes?.[0];
       this._quizJSON = await this.loadQuizzesFromOpencast(quiz.url);
+    }
+
+    // Hide Quiz if user is trying to play the video again
+    if (this._quiz && (event === Events.PLAY || event === Events.SEEK)) {
+      this.removeQuiz();
     }
 
     // Display/Hide quiz
@@ -117,13 +123,21 @@ export default class QuizPlugin extends EventLogPlugin {
       /* HTML */
       const quiz = createElementWithHtmlText('<div class="quiz-plugin-root"> </div>');
 
-      createElementWithHtmlText(`
-        <div class="quiz-plugin-question">${info.question}</div>
+      const quizLeft = createElementWithHtmlText(`
+        <div class="quiz-plugin-left"> </div>
       `, quiz);
+
+      const quizContent = createElementWithHtmlText(`
+        <div class="quiz-plugin-content"> </div>
+      `, quizLeft);
+
+      createElementWithHtmlText(`
+        <h2 class="quiz-plugin-question">${info.question}</h2>
+      `, quizContent);
 
       const answers = createElementWithHtmlText(`
         <div class="quiz-plugin-answers"> </div>
-      `, quiz);
+      `, quizContent);
 
       info.answers?.map((answer) => {
         createElementWithHtmlText(`
@@ -132,16 +146,25 @@ export default class QuizPlugin extends EventLogPlugin {
       });
 
       const submit = createElementWithHtmlText(`
-        <button>Submit</button>
+        <button class="quiz-submit-button">Submit</button>
+      `, quizLeft);
+
+      const quizRight = createElementWithHtmlText(`
+        <div class="quiz-plugin-right"> </div>
       `, quiz);
+
+      createElementWithHtmlText(`
+        <div></div>
+      `, quizRight);
 
       const result = createElementWithHtmlText(`
         <div class="quiz-plugin-result"></div>
-      `, quiz);
+      `, quizRight);
 
       const continueButton = createElementWithHtmlText(`
-        <button>Continue</button>
-      `, quiz);
+        <button class="quiz-submit-button">Continue</button>
+      `, quizRight);
+      continueButton.style.display = 'none';
 
       /* Script */
       const correctAnswers = info.answers
@@ -156,7 +179,7 @@ export default class QuizPlugin extends EventLogPlugin {
         // Reset styles
         checkboxes.forEach(checkbox => {
           const label = checkbox.parentElement;
-          label.classList.remove('quiz-plugin-correct', 'quiz-plugin-wrong');
+          label.classList.remove('quiz-plugin-correct');
         });
 
         // Evaluate answers
@@ -170,12 +193,7 @@ export default class QuizPlugin extends EventLogPlugin {
             if (isCorrect) {
               label.classList.add('quiz-plugin-correct');
               correctCount++;
-            } else {
-              label.classList.add('quiz-plugin-wrong');
             }
-          } else if (!isChecked && isCorrect) {
-            // Missed a correct answer
-            label.classList.add('quiz-plugin-wrong');
           }
         });
 
@@ -191,6 +209,7 @@ export default class QuizPlugin extends EventLogPlugin {
         }
 
         result.innerHTML = resultMsg;
+        continueButton.style.display = 'block';
       });
 
       continueButton.addEventListener('click', () => {

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.textboxPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.textboxPlugin.js
@@ -116,7 +116,12 @@ export default class TextBoxPlugin extends EventLogPlugin {
       let summaryBox;
       if (info.link) {
         summaryBox = createElementWithHtmlText(`
-            <a href=${ info.link } class="textbox-plugin-box-summary-link"> </a>
+            <a
+              href=${ info.link }
+              class="textbox-plugin-box-summary-link"
+              target="_blank"
+              rel="noopener noreferrer"
+            > </a>
         `, summary);
       } else {
         summaryBox = createElementWithHtmlText(`

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.textboxPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.textboxPlugin.js
@@ -19,8 +19,9 @@
  *
  */
 
-import { Events, EventLogPlugin } from 'paella-core';
+import { Events, EventLogPlugin, createElementWithHtmlText } from 'paella-core';
 import '../css/TextboxPlugin.css';
+import infoIcon from '../icons/info.svg';
 
 export default class TextBoxPlugin extends EventLogPlugin {
 
@@ -29,16 +30,21 @@ export default class TextBoxPlugin extends EventLogPlugin {
     this._textboxes = new Map(); // DOM elements
     this._textboxJSON = []; // Infos from the Opencast mediapackage
 
+    // Create textbox container
+    this._container = document.createElement('div');
+    this._container.className = 'textbox-plugin-container';
+    // Append to player-container to not dissappear during fullscreen
+    document.querySelector('.player-container').appendChild(this._container);
+
     const myTestJson = [
       {
         start: 2,
-        end: 4,
         text: 'Samalamadingdong',
       },
       {
         start: 3,
-        end: 6,
         text: 'Get in the comments',
+        link: 'https://opencast.org',
       }
     ];
     this._textboxJSON = myTestJson;
@@ -57,15 +63,18 @@ export default class TextBoxPlugin extends EventLogPlugin {
     if (event === Events.PLAYER_LOADED) {
       // TODO: Handle multiple textbox files
       const box = this.player?._videoManifest?.textboxes?.[0];
-      this._textboxJSON = await this.loadTextboxesFromOpencast(box.url);
+      if (box) {
+        this._textboxJSON = await this.loadTextboxesFromOpencast(box.url);
+      }
     }
 
     // Display/Hide textboxes
     this._textboxJSON.forEach((boxInfo, index) => {
-      if (params.currentTime > boxInfo.start && params.currentTime < boxInfo.end && !this._textboxes.get(index)) {
+      const end = boxInfo.start + 10;
+      if (params.currentTime > boxInfo.start && params.currentTime < end && !this._textboxes.get(index)) {
         this.createBox(boxInfo, index);
       }
-      if (params.currentTime > boxInfo.end && this._textboxes.get(index)) {
+      if ((params.currentTime < boxInfo.start || params.currentTime > end) && this._textboxes.get(index)) {
         this.removeBox(boxInfo, index);
       }
     });
@@ -75,20 +84,33 @@ export default class TextBoxPlugin extends EventLogPlugin {
   // Add a textbox to the DOM
   createBox(info, index) {
     if (!this._textboxes.get(index)) {
-      const textbox = document.createElement('div');
-      textbox.className = 'textbox-plugin-box';
-      textbox.textContent = info.text;
+      let textbox = undefined;
+      if (info.link) {
+        textbox = createElementWithHtmlText(`
+          <a class="textbox-plugin-box" href=${ info.link }></a>
+        `, this._container);
+      } else {
+        textbox = createElementWithHtmlText(`
+          <div class="textbox-plugin-box" href=${ info.link }></div>
+        `, this._container);
+      }
+
+      createElementWithHtmlText(`
+        <i class="textbox-plugin-box-icon">${ infoIcon }</i>
+      `, textbox);
+
+      createElementWithHtmlText(`
+        <span class="textbox-plugin-box-text">${ info.text }</span>
+      `, textbox);
 
       this._textboxes.set(index, textbox);
-      // Append to player-container to not dissappear during fullscreen
-      document.querySelector('.player-container').appendChild(this._textboxes.get(index));
     }
   }
 
   // Remove a textbox from the DOM
   removeBox(info, index) {
     if (this._textboxes.get(index)) {
-      document.querySelector('.player-container').removeChild(this._textboxes.get(index));
+      this._container.removeChild(this._textboxes.get(index));
       this._textboxes.set(index, null);
     }
   }

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.textboxPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.textboxPlugin.js
@@ -1,0 +1,110 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+import { Events, EventLogPlugin } from 'paella-core';
+import '../css/TextboxPlugin.css';
+
+export default class TextBoxPlugin extends EventLogPlugin {
+
+  // Initialize
+  async load() {
+    this._textboxes = new Map(); // DOM elements
+    this._textboxJSON = []; // Infos from the Opencast mediapackage
+
+    const myTestJson = [
+      {
+        start: 2,
+        end: 4,
+        text: 'Samalamadingdong',
+      },
+      {
+        start: 3,
+        end: 6,
+        text: 'Get in the comments',
+      }
+    ];
+    this._textboxJSON = myTestJson;
+  }
+
+  // Define which events we subscribe too
+  get events() {
+    return [
+      Events.PLAYER_LOADED,
+      Events.TIMEUPDATE
+    ];
+  }
+
+  async onEvent(event, params) {
+    // Load textbox info from Opencast
+    if (event === Events.PLAYER_LOADED) {
+      // TODO: Handle multiple textbox files
+      const box = this.player?._videoManifest?.textboxes?.[0];
+      this._textboxJSON = await this.loadTextboxesFromOpencast(box.url);
+    }
+
+    // Display/Hide textboxes
+    this._textboxJSON.forEach((boxInfo, index) => {
+      if (params.currentTime > boxInfo.start && params.currentTime < boxInfo.end && !this._textboxes.get(index)) {
+        this.createBox(boxInfo, index);
+      }
+      if (params.currentTime > boxInfo.end && this._textboxes.get(index)) {
+        this.removeBox(boxInfo, index);
+      }
+    });
+
+  }
+
+  // Add a textbox to the DOM
+  createBox(info, index) {
+    if (!this._textboxes.get(index)) {
+      const textbox = document.createElement('div');
+      textbox.className = 'textbox-plugin-box';
+      textbox.textContent = info.text;
+
+      this._textboxes.set(index, textbox);
+      // Append to player-container to not dissappear during fullscreen
+      document.querySelector('.player-container').appendChild(this._textboxes.get(index));
+    }
+  }
+
+  // Remove a textbox from the DOM
+  removeBox(info, index) {
+    if (this._textboxes.get(index)) {
+      document.querySelector('.player-container').removeChild(this._textboxes.get(index));
+      this._textboxes.set(index, null);
+    }
+  }
+
+  // Query Opencast for a json with info about textboxes
+  loadTextboxesFromOpencast = async (url) => {
+    let boxes = [];
+    const response = await fetch(url);
+    if (response.ok) {
+      try {
+        boxes = response.json();
+      }
+      catch (e) {
+        this.player.log.warn('Error loading boxes');
+      }
+    }
+    return boxes;
+  };
+}

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.textboxPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.textboxPlugin.js
@@ -39,11 +39,11 @@ export default class TextBoxPlugin extends EventLogPlugin {
     /* Demo json for quick developing purposes */
     // const myTestJson = [
     //   {
-    //     start: 2,
+    //     start: 2000,
     //     text: 'Samalamadingdong',
     //   },
     //   {
-    //     start: 3,
+    //     start: 3000,
     //     text: 'Get in the comments',
     //     link: 'https://opencast.org',
     //   }
@@ -71,11 +71,12 @@ export default class TextBoxPlugin extends EventLogPlugin {
 
     // Display/Hide textboxes
     this._textboxJSON.forEach((boxInfo, index) => {
-      const end = boxInfo.start + 10;
-      if (params.currentTime > boxInfo.start && params.currentTime < end && !this._textboxes.get(index)) {
+      const start = (boxInfo.start / 1000);
+      const end = (boxInfo.start / 1000) + 10;
+      if (params.currentTime > start && params.currentTime < end && !this._textboxes.get(index)) {
         this.createBox(boxInfo, index);
       }
-      if ((params.currentTime < boxInfo.start || params.currentTime > end) && this._textboxes.get(index)) {
+      if ((params.currentTime < start || params.currentTime > end) && this._textboxes.get(index)) {
         this.removeBox(boxInfo, index);
       }
     });

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.textboxPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.textboxPlugin.js
@@ -22,6 +22,7 @@
 import { Events, EventLogPlugin, createElementWithHtmlText } from 'paella-core';
 import '../css/TextboxPlugin.css';
 import infoIcon from '../icons/info.svg';
+import externalLinkIcon from '../icons/external-link.svg';
 
 export default class TextBoxPlugin extends EventLogPlugin {
 
@@ -86,6 +87,7 @@ export default class TextBoxPlugin extends EventLogPlugin {
   // Add a textbox to the DOM
   createBox(info, index) {
     if (!this._textboxes.get(index)) {
+      const icon = info.link ? externalLinkIcon : infoIcon;
       let textbox = undefined;
 
       // textbox = createElementWithHtmlText(`
@@ -130,7 +132,7 @@ export default class TextBoxPlugin extends EventLogPlugin {
       }
 
       createElementWithHtmlText(`
-        <i class="textbox-plugin-box-icon">${ infoIcon }</i>
+        <i class="textbox-plugin-box-icon">${ icon }</i>
       `, summaryBox);
 
       createElementWithHtmlText(`

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.textboxPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.textboxPlugin.js
@@ -21,8 +21,6 @@
 
 import { Events, EventLogPlugin, createElementWithHtmlText } from 'paella-core';
 import '../css/TextboxPlugin.css';
-import infoIcon from '../icons/info.svg';
-import externalLinkIcon from '../icons/external-link.svg';
 
 export default class TextBoxPlugin extends EventLogPlugin {
 
@@ -87,60 +85,34 @@ export default class TextBoxPlugin extends EventLogPlugin {
   // Add a textbox to the DOM
   createBox(info, index) {
     if (!this._textboxes.get(index)) {
-      const icon = info.link ? externalLinkIcon : infoIcon;
       let textbox = undefined;
 
-      // textbox = createElementWithHtmlText(`
-      //   <details class="textbox-plugin-box-details">
-      //     <summary class="textbox-plugin-box-summary">
-      //       <a href=${ info.link } class="textbox-plugin-box-summary-link">
-      //         <i class="textbox-plugin-box-icon">${ infoIcon }</i>
-      //         <span class="textbox-plugin-box-text">${ info.text }</span>
-      //       </a>
-      //       <span class="right" aria-hidden="true"></span>
-      //     </summary>
-      //     ${ info.text }
-      //   </details>
-      //   `, this._container);
-
       textbox = createElementWithHtmlText(`
-        <details class="textbox-plugin-box-details"> </details>
+        <details class="textbox-plugin-details"> </details>
       `, this._container);
 
       let summary = createElementWithHtmlText(`
-          <summary class="textbox-plugin-box-summary"> </summary>
+        <summary class="textbox-plugin-summary"> </summary>
       `, textbox);
 
       createElementWithHtmlText(`
-          <div>${ info.text }</div>
+        <div class="textbox-plugin-content">
+          ${ info.text }
+          </br>
+          <a href=${ info.link } target="_blank" rel="noopener noreferrer">${ info.link }</a>
+        </div>
       `, textbox);
 
-      let summaryBox;
-      if (info.link) {
-        summaryBox = createElementWithHtmlText(`
-            <a
-              href=${ info.link }
-              class="textbox-plugin-box-summary-link"
-              target="_blank"
-              rel="noopener noreferrer"
-            > </a>
-        `, summary);
-      } else {
-        summaryBox = createElementWithHtmlText(`
-            <div class="textbox-plugin-box-summary-link"> </div>
-        `, summary);
-      }
+      createElementWithHtmlText(`
+        <div class="textbox-plugin-icon">i</div>
+      `, summary);
 
       createElementWithHtmlText(`
-        <i class="textbox-plugin-box-icon">${ icon }</i>
-      `, summaryBox);
+        <span class="textbox-plugin-title">${ info.text }</span>
+      `, summary);
 
       createElementWithHtmlText(`
-        <span class="textbox-plugin-box-text">${ info.text }</span>
-      `, summaryBox);
-
-      createElementWithHtmlText(`
-        <span class="right" aria-hidden="true"></span>
+        <span class="textbox-plugin-toggle" aria-hidden="true"></span>
       `, summary);
 
       this._textboxes.set(index, textbox);

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.textboxPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.textboxPlugin.js
@@ -36,18 +36,19 @@ export default class TextBoxPlugin extends EventLogPlugin {
     // Append to player-container to not dissappear during fullscreen
     document.querySelector('.player-container').appendChild(this._container);
 
-    const myTestJson = [
-      {
-        start: 2,
-        text: 'Samalamadingdong',
-      },
-      {
-        start: 3,
-        text: 'Get in the comments',
-        link: 'https://opencast.org',
-      }
-    ];
-    this._textboxJSON = myTestJson;
+    /* Demo json for quick developing purposes */
+    // const myTestJson = [
+    //   {
+    //     start: 2,
+    //     text: 'Samalamadingdong',
+    //   },
+    //   {
+    //     start: 3,
+    //     text: 'Get in the comments',
+    //     link: 'https://opencast.org',
+    //   }
+    // ];
+    // this._textboxJSON = myTestJson;
   }
 
   // Define which events we subscribe too

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.textboxPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.textboxPlugin.js
@@ -87,23 +87,42 @@ export default class TextBoxPlugin extends EventLogPlugin {
   createBox(info, index) {
     if (!this._textboxes.get(index)) {
       let textbox = undefined;
-      if (info.link) {
-        textbox = createElementWithHtmlText(`
-          <a class="textbox-plugin-box" href=${ info.link }></a>
+      // if (info.link) {
+      //   textbox = createElementWithHtmlText(`
+      //     <a class="textbox-plugin-box" href=${ info.link }></a>
+      //   `, this._container);
+      // } else {
+      textbox = createElementWithHtmlText(`
+        <details class="textbox-plugin-box-details">
+          <summary class="textbox-plugin-box-summary">
+            <span class="left">
+              <a href=${ info.link }>${ infoIcon }</a>
+            </span>
+            <span class="middle">${ info.text }</span>
+            <span class="right"></span>
+          </summary>
+          ${ info.text }
+        </details>
         `, this._container);
-      } else {
-        textbox = createElementWithHtmlText(`
-          <div class="textbox-plugin-box" href=${ info.link }></div>
-        `, this._container);
-      }
+      // }
 
-      createElementWithHtmlText(`
-        <i class="textbox-plugin-box-icon">${ infoIcon }</i>
-      `, textbox);
+      // createElementWithHtmlText(`
+      //   <details class="textbox-plugin-box">${ infoIcon }
+      //     <summary class="textbox-plugin-box-text">
+      //       <i class="textbox-plugin-box-icon">${ infoIcon }</i>
+      //       ${ info.text }
+      //     </summary>
+      //     ${ info.text }
+      //   </details>
+      // `, textbox);
 
-      createElementWithHtmlText(`
-        <span class="textbox-plugin-box-text">${ info.text }</span>
-      `, textbox);
+      // createElementWithHtmlText(`
+      //   <i class="textbox-plugin-box-icon">${ infoIcon }</i>
+      // `, textbox);
+
+      // createElementWithHtmlText(`
+      //   <span class="textbox-plugin-box-text">${ info.text }</span>
+      // `, textbox);
 
       this._textboxes.set(index, textbox);
     }

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.textboxPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.textboxPlugin.js
@@ -87,42 +87,54 @@ export default class TextBoxPlugin extends EventLogPlugin {
   createBox(info, index) {
     if (!this._textboxes.get(index)) {
       let textbox = undefined;
-      // if (info.link) {
-      //   textbox = createElementWithHtmlText(`
-      //     <a class="textbox-plugin-box" href=${ info.link }></a>
-      //   `, this._container);
-      // } else {
-      textbox = createElementWithHtmlText(`
-        <details class="textbox-plugin-box-details">
-          <summary class="textbox-plugin-box-summary">
-            <span class="left">
-              <a href=${ info.link }>${ infoIcon }</a>
-            </span>
-            <span class="middle">${ info.text }</span>
-            <span class="right"></span>
-          </summary>
-          ${ info.text }
-        </details>
-        `, this._container);
-      // }
 
-      // createElementWithHtmlText(`
-      //   <details class="textbox-plugin-box">${ infoIcon }
-      //     <summary class="textbox-plugin-box-text">
-      //       <i class="textbox-plugin-box-icon">${ infoIcon }</i>
-      //       ${ info.text }
+      // textbox = createElementWithHtmlText(`
+      //   <details class="textbox-plugin-box-details">
+      //     <summary class="textbox-plugin-box-summary">
+      //       <a href=${ info.link } class="textbox-plugin-box-summary-link">
+      //         <i class="textbox-plugin-box-icon">${ infoIcon }</i>
+      //         <span class="textbox-plugin-box-text">${ info.text }</span>
+      //       </a>
+      //       <span class="right" aria-hidden="true"></span>
       //     </summary>
       //     ${ info.text }
       //   </details>
-      // `, textbox);
+      //   `, this._container);
 
-      // createElementWithHtmlText(`
-      //   <i class="textbox-plugin-box-icon">${ infoIcon }</i>
-      // `, textbox);
+      textbox = createElementWithHtmlText(`
+        <details class="textbox-plugin-box-details"> </details>
+      `, this._container);
 
-      // createElementWithHtmlText(`
-      //   <span class="textbox-plugin-box-text">${ info.text }</span>
-      // `, textbox);
+      let summary = createElementWithHtmlText(`
+          <summary class="textbox-plugin-box-summary"> </summary>
+      `, textbox);
+
+      createElementWithHtmlText(`
+          <div>${ info.text }</div>
+      `, textbox);
+
+      let summaryBox;
+      if (info.link) {
+        summaryBox = createElementWithHtmlText(`
+            <a href=${ info.link } class="textbox-plugin-box-summary-link"> </a>
+        `, summary);
+      } else {
+        summaryBox = createElementWithHtmlText(`
+            <div class="textbox-plugin-box-summary-link"> </div>
+        `, summary);
+      }
+
+      createElementWithHtmlText(`
+        <i class="textbox-plugin-box-icon">${ infoIcon }</i>
+      `, summaryBox);
+
+      createElementWithHtmlText(`
+        <span class="textbox-plugin-box-text">${ info.text }</span>
+      `, summaryBox);
+
+      createElementWithHtmlText(`
+        <span class="right" aria-hidden="true"></span>
+      `, summary);
 
       this._textboxes.set(index, textbox);
     }

--- a/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/impl/VideoEditorProperties.java
+++ b/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/impl/VideoEditorProperties.java
@@ -41,5 +41,6 @@ public interface VideoEditorProperties {
   String VIDEO_FADE = "video.fade";
   String DEFAULT_EXTENSION = ".mp4";
   String WEBVTT_EXTENSION = "vtt";
+  String INTERACTIVE_ELEMENT_EXTENSION = "json";
   long SUBTITLE_GRACE_PERIOD = 500; //ms
 }

--- a/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/impl/VideoEditorServiceImpl.java
+++ b/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/impl/VideoEditorServiceImpl.java
@@ -59,6 +59,11 @@ import org.opencastproject.videoeditor.api.VideoEditorService;
 import org.opencastproject.videoeditor.ffmpeg.FFmpegEdit;
 import org.opencastproject.workspace.api.Workspace;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
@@ -75,8 +80,10 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -312,6 +319,9 @@ public class VideoEditorServiceImpl extends AbstractJobProducer implements Video
         if (VideoEditorProperties.WEBVTT_EXTENSION.equals(extension)) {
           outputFileExtension = properties.getProperty(VideoEditorProperties.WEBVTT_EXTENSION, ".vtt");
         }
+        if (VideoEditorProperties.INTERACTIVE_ELEMENT_EXTENSION.equals(extension)) {
+          outputFileExtension = properties.getProperty(VideoEditorProperties.INTERACTIVE_ELEMENT_EXTENSION, ".json");
+        }
       }
       outputFileExtension = properties.getProperty(VideoEditorProperties.OUTPUT_FILE_EXTENSION, outputFileExtension);
 
@@ -353,6 +363,7 @@ public class VideoEditorServiceImpl extends AbstractJobProducer implements Video
         // remove very short cuts that will look bad
         List<VideoClip> cleanclips = sortSegments(refElements, segmentsMinDuration, segmentsMinCutDuration);
         String extension = FilenameUtils.getExtension(sourceTrackUri);
+        // Cut subtitles
         if (VideoEditorProperties.WEBVTT_EXTENSION.equals(extension)) {
           // Parse
           WebVTTParser parser = new WebVTTParser();
@@ -389,6 +400,42 @@ public class VideoEditorServiceImpl extends AbstractJobProducer implements Video
             WebVTTWriter writer = new WebVTTWriter();
             writer.write(subtitle, fos);
           }
+        // Cut interactive elements
+        } else if (VideoEditorProperties.INTERACTIVE_ELEMENT_EXTENSION.equals(extension)) {
+          Gson gson = new Gson();
+          FileInputStream fis = new FileInputStream(sourceFile);
+          InputStreamReader reader = new InputStreamReader(fis, "UTF-8");
+          JsonArray array = JsonParser.parseReader(reader).getAsJsonArray();
+
+          // Edit
+          JsonArray cutArray = new JsonArray();
+          double removedTime = 0;
+          for (int i = 0; i < cleanclips.size(); i++) {
+            if (i == 0) {
+              removedTime = removedTime
+                  + cleanclips.get(i).getStartInMilliseconds();
+            } else {
+              removedTime = removedTime
+                  + cleanclips.get(i).getStartInMilliseconds()
+                  - cleanclips.get(i - 1).getEndInMilliseconds();
+            }
+            for (int j = 0; j < array.size(); j++) {
+              JsonObject obj = array.get(j).getAsJsonObject();
+              if (obj.has("start")) {
+                long oldStart = obj.get("start").getAsLong();
+                if ((cleanclips.get(i).getStartInMilliseconds()) <= oldStart
+                    && (cleanclips.get(i).getEndInMilliseconds()) >= oldStart) {
+                  obj.addProperty("start", oldStart + removedTime);
+                  cutArray.add(obj);
+                }
+              }
+            }
+          }
+
+          // Write
+          FileWriter writer = new FileWriter(outputPath);
+          gson.toJson(cutArray, writer);
+          writer.close();
         } else {
           throw new ProcessFailedException("The video editor does not support the following file: " + sourceTrackUri);
         }
@@ -423,6 +470,10 @@ public class VideoEditorServiceImpl extends AbstractJobProducer implements Video
       if (refElements.size() > 0) {
         String extension = FilenameUtils.getExtension(sourceTrackUri);
         if (VideoEditorProperties.WEBVTT_EXTENSION.equals(extension)) {
+          editedTrack.setFlavor(new MediaPackageElementFlavor(sourceTrackFlavor.getType(),
+              sourceTrackFlavor.getSubtype() + "+" + SINK_FLAVOR_SUBTYPE));
+        }
+        if (VideoEditorProperties.INTERACTIVE_ELEMENT_EXTENSION.equals(extension)) {
           editedTrack.setFlavor(new MediaPackageElementFlavor(sourceTrackFlavor.getType(),
               sourceTrackFlavor.getSubtype() + "+" + SINK_FLAVOR_SUBTYPE));
         }


### PR DESCRIPTION
Adds two small Paella-Opencast-Plugins. 

The textbox plugin should allow users to display a bit of user-defined text and possibly links on top of the videos. Textboxes will appear in the top-right corner of the player and display at user-defined point in time for a set duration.

The quiz plugin should allow users to pose a simple multiple choice quiz to the users. Quizzes will also appear at user-defined points in the time, pausing the video though playback can be resumed any time. Answers by users are not stored.

<img width="1200" height="1146" alt="Bildschirmfoto vom 2025-12-01 09-33-22" src="https://github.com/user-attachments/assets/cc791cbc-908a-4c0f-85c8-e866d9c081fc" />


Development started before the 19.x branch cut, so this is still based on 19.x. Will rebase at a later date.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
