### PR TITLE
Add JWT support to `/paella7/ui` (with token refresh via iframe host)

### DIFF
--- a/modules/engage-paella-player-7/package-lock.json
+++ b/modules/engage-paella-player-7/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "paella-7-opencast",
       "dependencies": {
+        "@opencast/jwtify": "^0.1.3",
         "paella-basic-plugins": "^1.50.3",
         "paella-core": "^1.50.4",
         "paella-mp4multiquality-plugin": "^1.47.1",
@@ -1977,6 +1978,12 @@
       "dependencies": {
         "eslint-scope": "5.1.1"
       }
+    },
+    "node_modules/@opencast/jwtify": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@opencast/jwtify/-/jwtify-0.1.3.tgz",
+      "integrity": "sha512-aC2Z/3lRR5OPGG1FldpNlXE/cKJIeCzlsFNOSUfAKWQ62glil9fO15BaHkGb2uBtiR7VI17q7M5dtDZVpShoFw==",
+      "license": "MIT"
     },
     "node_modules/@playwright/test": {
       "version": "1.55.1",

--- a/modules/engage-paella-player-7/package.json
+++ b/modules/engage-paella-player-7/package.json
@@ -36,6 +36,7 @@
     "xml-loader": "^1.2.1"
   },
   "dependencies": {
+    "@opencast/jwtify": "^0.1.3",
     "paella-basic-plugins": "^1.50.3",
     "paella-core": "^1.50.4",
     "paella-mp4multiquality-plugin": "^1.47.1",

--- a/modules/engage-paella-player-7/src/index.js
+++ b/modules/engage-paella-player-7/src/index.js
@@ -52,3 +52,21 @@ window.onload = async () => {
     paella.log.error(error);
   }
 };
+
+
+// Setup service worker to enable static file auth via JWT. We pass JWT and
+// video ID via query parameters in order to have them available in the SW
+// immediately. I know that typically, you want an unchanging URL for your SWs,
+// but that only applies to service workers that want to have a persistent state
+// as far as I can tell. This query parameter passing method is known and used.
+// Also, the SW is super tiny, so the additional fetches don't really matter.
+const params = new URLSearchParams(window.location.search);
+const swUrl = `sw.js?${new URLSearchParams({
+  jwt: params.get('jwt'),
+  videoId: params.get('id'),
+})}`;
+
+navigator.serviceWorker
+  .register(swUrl, { updateViaCache: 'none' })
+  // eslint-disable-next-line no-console
+  .catch(e => console.error('Failed to register service worker', e));

--- a/modules/engage-paella-player-7/src/index.js
+++ b/modules/engage-paella-player-7/src/index.js
@@ -61,12 +61,47 @@ window.onload = async () => {
 // as far as I can tell. This query parameter passing method is known and used.
 // Also, the SW is super tiny, so the additional fetches don't really matter.
 const params = new URLSearchParams(window.location.search);
+let refreshEnabled = params.get('jwtRefresh') === 'true';
+if (refreshEnabled && window.self === window.top) {
+  // eslint-disable-next-line no-console
+  console.warn('jwtRefresh=true given, but not running in iframe');
+  refreshEnabled = false;
+}
 const swUrl = `sw.js?${new URLSearchParams({
   jwt: params.get('jwt'),
   videoId: params.get('id'),
+  refresh: refreshEnabled,
 })}`;
 
 navigator.serviceWorker
   .register(swUrl, { updateViaCache: 'none' })
   // eslint-disable-next-line no-console
   .catch(e => console.error('Failed to register service worker', e));
+
+
+
+// If JWT refresh is enabled, we need to forward messages between the host of
+// this iframe and the SW (as they cannot communicate directly).
+if (refreshEnabled) {
+  // Forward messages coming from the iframe host to the SW.
+  window.addEventListener('message', ev => {
+    if (ev.source !== window.parent) {
+      return;
+    }
+
+    const d = ev.data;
+    if (typeof d === 'object' && d?.type === 'oc-event-jwt' && typeof d?.jwt === 'string') {
+      const { type, jwt } = d;
+      navigator.serviceWorker.controller?.postMessage({ type, jwt });
+    }
+  });
+
+  // Forward messages coming from the SW to the iframe host.
+  navigator.serviceWorker.addEventListener('message', ev => {
+    const d = ev.data;
+    if (typeof d === 'object' && d?.type === 'oc-event-jwt-request' && typeof d?.event === 'string') {
+      const { type, event } = d;
+      window.parent.postMessage({ type, event }, '*');
+    }
+  });
+}

--- a/modules/engage-paella-player-7/src/js/PaellaOpencast.js
+++ b/modules/engage-paella-player-7/src/js/PaellaOpencast.js
@@ -105,7 +105,12 @@ const initParams = {
   repositoryUrl: getUrlFromOpencastServer('/search/episode.json'),
 
   getManifestUrl: (repoUrl, videoId) => {
-    return `${repoUrl}?id=${videoId}`;
+    let out =  `${repoUrl}?id=${videoId}`;
+    const jwt = new URLSearchParams(location.search).get('jwt');
+    if (jwt) {
+      out += `&jwt=${jwt}`;
+    }
+    return out;
   },
 
   getManifestFileUrl: (manifestUrl) => {

--- a/modules/engage-paella-player-7/src/js/PaellaOpencast.js
+++ b/modules/engage-paella-player-7/src/js/PaellaOpencast.js
@@ -163,7 +163,7 @@ const initParams = {
       const data = await fetch(getUrlFromOpencastServer('/info/me.json'));
       const me = await data.json();
 
-      if (!me.roles.includes('ROLE_USER')) {
+      if (!me.roles.includes('ROLE_USER') && !new URLSearchParams(location.search).get('jwt')) {
         player.log.info('Video not found and user is not authenticated. Try to log in.');
         await redirectToAuthPage();
         // This Error should not happen, as the user is redirected to the auth page.

--- a/modules/engage-paella-player-7/src/js/sw/index.js
+++ b/modules/engage-paella-player-7/src/js/sw/index.js
@@ -21,20 +21,73 @@
 
 import { setUpServiceWorker } from '@opencast/jwtify';
 
-// Get initial parameters (containing video ID and JWT)
+// Get initial parameters
 const params = new URLSearchParams(self.location.search);
 const jwt = params.get('jwt');
 const videoId = params.get('videoId');
+const refreshEnabled = params.get('refresh') === 'true';
 
 // Only of those are set do we actually register anything.
 if (jwt && videoId) {
-  const fetchJwts = async (eventIds) => {
-    return new Map(eventIds.has(videoId) ? [[videoId, jwt]] : []);
+  let lastClientId = null;
+  let resolveRefresh = () => {};
+  if (refreshEnabled) {
+    // Remember the last client that sent a request. We will always ask it for
+    // fresh JWTs.
+    self.addEventListener('fetch', event => {
+      lastClientId = event.clientId;
+    });
+
+    // Receive messages from clients, which will send JWTs back.
+    self.addEventListener('message', e => {
+      const d = e.data;
+      if (typeof d === 'object' && d?.type === 'oc-event-jwt' && typeof d?.jwt === 'string') {
+        resolveRefresh(d.jwt);
+      }
+    });
+  }
+
+  const fetchJwts =  async (eventIds) => {
+    if (eventIds.size !== 1 || !eventIds.has(videoId)) {
+      // eslint-disable-next-line no-console
+      console.warn('event IDs requested by jwtify do not match video ID');
+      return new Map();
+    }
+
+    if (!refreshEnabled) {
+      // eslint-disable-next-line no-console
+      console.warn('JWT refresh is not enabled, but jwtify asked for a new JWT, meaning the old one is expired');
+      return new Map();
+    }
+
+    const client = await self.clients.get(lastClientId) ?? self.clients.matchAll()[0];
+    if (!client) {
+      // eslint-disable-next-line no-console
+      console.warn('No client connected to SW, but a JWT is needed for a request... weird');
+      return new Map();
+    }
+
+    // Get fresh JWT by asking the host frame (by first asking the client).
+    const jwt = await new Promise(resolve => {
+      resolveRefresh = resolve;
+      client.postMessage({
+        type: 'oc-event-jwt-request',
+        event: videoId,
+      });
+
+      // After some timeout we give up, as there might not be anyone answering.
+      setTimeout(() => resolve(null), 3000);
+    });
+
+    return new Map(jwt ? [[videoId, jwt]] : []);
   };
 
-  setUpServiceWorker({
+  const handle = setUpServiceWorker({
     getJwts: fetchJwts,
     trustedOcOrigins: ['https://stable.opencast.org', 'http://localhost:8080', 'http://localhost:8081'], // TODO
     debugLog: true, // TODO: remove
   });
+
+  // Add our initial JWT to the cache so that it can be used for immediate requests.
+  handle.cache.add(videoId, jwt);
 }

--- a/modules/engage-paella-player-7/src/js/sw/index.js
+++ b/modules/engage-paella-player-7/src/js/sw/index.js
@@ -1,0 +1,40 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+import { setUpServiceWorker } from '@opencast/jwtify';
+
+// Get initial parameters (containing video ID and JWT)
+const params = new URLSearchParams(self.location.search);
+const jwt = params.get('jwt');
+const videoId = params.get('videoId');
+
+// Only of those are set do we actually register anything.
+if (jwt && videoId) {
+  const fetchJwts = async (eventIds) => {
+    return new Map(eventIds.has(videoId) ? [[videoId, jwt]] : []);
+  };
+
+  setUpServiceWorker({
+    getJwts: fetchJwts,
+    trustedOcOrigins: ['https://stable.opencast.org', 'http://localhost:8080', 'http://localhost:8081'], // TODO
+    debugLog: true, // TODO: remove
+  });
+}

--- a/modules/engage-paella-player-7/webpack.config.js
+++ b/modules/engage-paella-player-7/webpack.config.js
@@ -33,7 +33,13 @@ module.exports = function (env) {
   };
 
   return {
-    entry: './src/index.js',
+    entry: {
+      main: './src/index.js',
+      sw: {
+        import: './src/js/sw/index.js',
+        filename: 'sw.js',
+      },
+    },
     output: {
       path: path.join(__dirname,'target/paella-build'),
       filename: 'paella-player.js',


### PR DESCRIPTION
This makes the built-in player capable of authorizing requests via JWT. Well, it is a "first viable product", see todo-list below. 
- The `jwt` query parameter can be passed (i.e. `/paella7/ui/watch.html?id=...&jwt=...`)
- That given JWT is used when requesting the search API to get event information.
- A service worker is installed, which uses [`jwtify`](https://github.com/opencast/jwtify) to intercept all requests to static files (e.g. thumbnail, video, ...) and authenticate them.
- If the `jwtRefresh=true` parameter is given, the service worker can request fresh JWTs by posting a message to the iframe host, which can then reply with a fresh JWT. 
- If refresh is not enabled, it is assumed that the initial JWT is valid for a long time and that is used for all requests. Once it expires, static file requests will start returning 403, breaking the page.

## Documentation for integration developer

... ok let's be real, I am talking about @ferishili here :P

**Note**: this is a draft PR and thus, this "protocol" might still change a bit. So don't release/ship any code implementing this yet, until we decided on this.

The iframe route accepts two new query parameters:
- `jwt`: an initial JWT which is used to load data from the search API, and potentially for other early requests like the thumbnail or the first video request. 
- `jwtRefresh`: if `true`, refresh is enabled.

If token refresh is enabled, the iframe will send the following message:

```js
{
    type: "oc-event-jwt-request", // this is always this exact string
    event: "19be2fb4-0241-4947-a6e0-28873e857a7d", // the event ID
}
```

You (the host of the iframe) are then supposed to answer with this message:

```js
{
    type: "oc-event-jwt", // always this exact string
    event: "19be2fb4-0241-4947-a6e0-28873e857a7d", // event ID, the same that was passed to you
    jwt: "ey...", // the JWT 
}
```

The JWT needs to give read access to the event in question, and do it in a way that `octoka` understands, which basically means: via the `"oc": { "e:<id>": ["read"] }` claim.

Here is an example for dealing with reacting to messages:

<details>

It is assumed that `fetchJwt` is `async (eventId: string) => string`.

```js
  window.addEventListener("message", ev => {
    // TODO: make sure it's from the expected iframe! Excercise for the reader.
    if (typeof ev.data === "object" && ev.data?.type === "oc-event-jwt-request" && typeof ev.data?.event === "string") {
      fetchJwt(ev.data.event).then(jwt => {
        ev.source.postMessage({
          type: "oc-event-jwt",
          event: ev.data.event,
          jwt,
        }, '*');
      });
    }
  });
```

</details>


## TODO

While the central logic already works, there is still lots to do before we can merge it:
- [ ] Make whole thing depend on config variable: I assume we probably don't want to enable this outright for everyone, but make it opt-in first. 
  - This might be a bit tricky, as fetching this config value must happen before registering the service workers, which must happen before the first static file request is sent.
  - In Tobira, I also made sure that when this is disabled, all current service workers are uninstalled, as otherwise it might stay in a broken state.
- [ ] Disable all of this new stuff when no JWT is given as query parameter
  - Or is this enough as a "guard" and the previous point about configuring this can be ignored?
- [ ] Maybe make "protocol" immediately able to deal with multiple event IDs? 
  - `jwtify` already uses "request batches" in its API, and it might be useful to also have that for this iframe<->host protocol so that the host can reduce the number of fetches it needs to do. On the other hand, I cannot currently imagine when that would ever happen? When would an iframe feature content from multiple videos?
- [ ] Implement for Paella 8 as well
- [ ] Correctly set `trustedHosts`
  - This is a protection by jwtify to not send JWTs to random hosts, which might have been injected into the media package by an attacker. 
  - Decide: is that really an attack worth protecting against? In the worst case, the attacker gets a JWT that grants access to a single event, but the attacker must have already manipulated said event for that to work. Soooo maybe not a big deal? We could also say that "being able to put non-Opencast URLs into media packages" is the core problem and that everyone else should be able to trust media packages.
  - If we decide to protect against it: get a list of trusted hosts in the code and pass it to jwtify. Again, might be tricky timing wise. Maybe jwtify needs to be adjusted.
  - If we decide to ignore this, we need to adjust jwtify to not require this trustedHosts list.
- [ ] Check if other non-static-file requests need to be authenticated. I just dealed with the search API requests, but haven't gone through the code to see if there are other cases.

## Open Problems & Questions
- The search endpoint is requested with the JWT. But unlike static files, which will be served by octoka, Opencast currently still requires a username and name. Typically, static file JWTs do not include them, as they are useless for the task. Either the host site (e.g. LMS) needs to pass these two values in the JWT, or Opencast needs to be able to accept the JWT even without that info. For local testing, 
  - I configured the `usernameMapping` in the security config to `['sub'] ?: 'unknown-jwt-user'`. I wonder: is that safe for production systems? The problem with the username is, that it is (sometimes?) used to look up additional permissions?! Someone needs to look into that.


### How to test this patch

(This is still draft and no one should do a full test yet. This is mostly for Farbod to play around with now.) 

Build it, configure JWT (luckily much easier now :>), upload videos, and well... start experimenting with the `/paella7/ui/watch.html` URL. Pass a valid JWT to it and you should see the thumbnail loading even if you are not logged in. And then you probably have to build your own iframe stuff to check the refresh code.
