### PR TITLE
Try to read series acl from database

### DIFF
--- a/modules/authorization-xacml/pom.xml
+++ b/modules/authorization-xacml/pom.xml
@@ -28,6 +28,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-series-service-api</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.security</groupId>
       <artifactId>jboss-xacml</artifactId>
       <version>2.0.5.final</version>

--- a/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
+++ b/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
@@ -39,6 +39,8 @@ import org.opencastproject.security.api.AuthorizationService;
 import org.opencastproject.security.api.Role;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.User;
+import org.opencastproject.series.api.SeriesException;
+import org.opencastproject.series.api.SeriesService;
 import org.opencastproject.util.MimeTypes;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.data.Tuple;
@@ -90,6 +92,9 @@ public class XACMLAuthorizationService implements AuthorizationService {
 
   /** The serializer for media pacakge */
   private MediaPackageSerializer serializer;
+
+  /** The series service */
+  private SeriesService seriesService;
 
   private static final String CONFIG_MERGE_MODE = "merge.mode";
 
@@ -196,7 +201,19 @@ public class XACMLAuthorizationService implements AuthorizationService {
       } catch (URISyntaxException e) {
         logger.warn("URI {} syntax error, skip decoding", uri);
       }
-      acl = loadAcl(uri);
+      // UOM: Try to get ACLs from database else fall back to url
+      if (xacmlPolicyFlavor == XACML_POLICY_SERIES) {
+        try {
+          acl = Optional.ofNullable(seriesService.getSeriesAccessControl(mp.getSeries()));
+          if (acl.isEmpty()) {
+            throw new NotFoundException("Can't find series in database");
+          }
+        } catch (NotFoundException | SeriesException e) {
+          acl = loadAcl(uri);
+        }
+      } else {
+        acl = loadAcl(uri);
+      }
     }
     return acl;
   }
@@ -366,6 +383,17 @@ public class XACMLAuthorizationService implements AuthorizationService {
   @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
+  }
+
+  /**
+   * Declarative services callback to set the series service.
+   *
+   * @param seriesService
+   *          the series service
+   */
+  @Reference
+  public void setSeriesService(SeriesService seriesService) {
+    this.seriesService = seriesService;
   }
 
 }

--- a/modules/authorization-xacml/src/test/java/org/opencastproject/authorization/xacml/XACMLSecurityTest.java
+++ b/modules/authorization-xacml/src/test/java/org/opencastproject/authorization/xacml/XACMLSecurityTest.java
@@ -31,6 +31,7 @@ import org.opencastproject.security.api.JaxbOrganization;
 import org.opencastproject.security.api.JaxbRole;
 import org.opencastproject.security.api.JaxbUser;
 import org.opencastproject.security.api.SecurityService;
+import org.opencastproject.series.api.SeriesService;
 import org.opencastproject.workspace.api.Workspace;
 
 import org.apache.commons.io.FileUtils;
@@ -70,6 +71,8 @@ public class XACMLSecurityTest {
   // Override the behavior of the security service to use the current user and roles defined here
   protected SecurityService securityService = null;
 
+  protected SeriesService seriesService = null;
+
   protected XACMLAuthorizationService authzService = null;
 
   @Rule
@@ -83,6 +86,10 @@ public class XACMLSecurityTest {
     securityService = EasyMock.createMock(SecurityService.class);
     EasyMock.expect(securityService.getUser()).andAnswer(
             () -> new JaxbUser(currentUser, "test", organization, currentRoles)).anyTimes();
+
+    // Mock series service
+    seriesService = EasyMock.createMock(SeriesService.class);
+    EasyMock.expect(seriesService.getSeriesAccessControl(EasyMock.anyString())).andReturn(null).anyTimes();
 
     // Mock workspace
     Workspace workspace = EasyMock.createMock(Workspace.class);
@@ -114,9 +121,10 @@ public class XACMLSecurityTest {
             () -> new FileInputStream(uri.getValue().getPath())).anyTimes();
     workspace.delete(EasyMock.anyObject(URI.class));
     EasyMock.expectLastCall().anyTimes();
-    EasyMock.replay(securityService, workspace);
+    EasyMock.replay(securityService, seriesService, workspace);
     authzService.setWorkspace(workspace);
     authzService.setSecurityService(securityService);
+    authzService.setSeriesService(seriesService);
   }
 
   @Test


### PR DESCRIPTION
To improve the re-indexing of series try to read the series acl from the database instead of from file. The storage solution for the xamcl files can greatly impact the amount of time to re-index the series.


### For Discussion
This assumes that the database is the SPOT for series ACL and that the current ACL should always be applied. This could affect orgs where the series ACL has been changed over time and recordings have been published with different sets of ACLs ( depends on whether auto-publishing of new metadata is in effect? ). Should this feature be optional?

### How to test this patch

* before applying the PR use the helper-scripts to generate at least 1k series
* re-index series - note time spent
* apply patch
* re-index series - note time spent
* with the default setup of H2 and local disk ~10% improvement, this improves more with mariadb and shared/object storage

