### PR TITLE
Fix site build assets

### DIFF
--- a/.github/workflows/test-opencast-site.yml
+++ b/.github/workflows/test-opencast-site.yml
@@ -103,6 +103,21 @@ jobs:
           name: site_build
           path: target/staging
 
+      - name: Save assets build
+        uses: actions/upload-artifact@v5
+        if: >
+          github.event_name == 'push'
+          && github.repository_owner == 'opencast'
+          && github.ref == 'refs/heads/develop'
+        with:
+          name: assets
+          path: .github/assets
+
+      # Normally here we would do the uploading, but I'm deliberately breaking the upload from the build so that we can
+      # as committers check more easily if it's the *build* that's broken, or if it's just the upload.  The upload
+      # being broken can happen if there's an issue with github, for example, and it would be unfortunate if that broke
+      # our builds when *our* code is working.
+
   deploy-mvn-site:
     name: generate github pages for reports
     runs-on: ubuntu-22.04
@@ -158,10 +173,17 @@ jobs:
 
       - name: update CSS and other assets
         if: github.ref == 'refs/heads/develop'
-        working-directory: opencast
+        uses: actions/download-artifact@v6
+        with:
+          name: assets
+          path: assets_artifact
+
+      - name: commit CSS and other asset changes
+        if: github.ref == 'refs/heads/develop'
+        working-directory: coverage-reports
         run: |
           rm -rf assets
-          cp -rv ../.github/assets ./assets
+          cp -rv ../assets_artifact/ ./assets
           git add assets
           git diff --staged --quiet || git commit --amend -m "Maven site build outputs"
 

--- a/.github/workflows/test-opencast-site.yml
+++ b/.github/workflows/test-opencast-site.yml
@@ -152,7 +152,7 @@ jobs:
 
       - name: clone repository
         run: |
-          git clone -b gh-pages "git@github.com:opencast/coverage-reports.git" coverage-reports
+          git clone -b gh-pages "git@github.com:${{ github.repository_owner }}/coverage-reports.git" coverage-reports
 
       - name: store site and build index
         working-directory: coverage-reports

--- a/.github/workflows/test-opencast-site.yml
+++ b/.github/workflows/test-opencast-site.yml
@@ -137,10 +137,10 @@ jobs:
 
       - name: clone repository
         run: |
-          git clone -b gh-pages "git@github.com:opencast/coverage-reports.git" opencast
+          git clone -b gh-pages "git@github.com:opencast/coverage-reports.git" coverage-reports
 
       - name: store site and build index
-        working-directory: opencast
+        working-directory: coverage-reports
         run: |
           export TEMP=${{ github.ref_name }}
           export BRANCH="${TEMP#r\/}"
@@ -166,5 +166,5 @@ jobs:
           git diff --staged --quiet || git commit --amend -m "Maven site build outputs"
 
       - name: Push updates
-        working-directory: opencast
+        working-directory: coverage-reports
         run: git push origin gh-pages --force

--- a/.github/workflows/test-opencast-site.yml
+++ b/.github/workflows/test-opencast-site.yml
@@ -147,7 +147,7 @@ jobs:
           rm -rf $BRANCH
           mv ../site_build $BRANCH
           #Generate an index, in case anyone lands at the root of the test domain
-          echo $'<html><head><link rel=stylesheet type=text/css href=assets/index.css /></head><body><div class="head-container"><img src=assets/opencast-white.svg /></div><div class="navbar-container"></div><div class="text-container"><p>Deployment of Opencast'''s Maven Site and Code Coverage.  The branches listed here correspond to Opencast'''s own branches.</br><b>Please select a version.</b></p></div><ul>' > index.html
+          echo $'<html><head><link rel=stylesheet type=text/css href=assets/index.css /></head><body><div class="head-container"><img src=assets/opencast-white.svg /></div><div class="navbar-container"></div><div class="text-container"><p>Deployment of Opencast\'s Maven Site and Code Coverage.  The branches listed here correspond to Opencast\'s own branches.</br><b>Please select a version.</b></p></div><ul>' > index.html
           find . -mindepth 1 -maxdepth 1 -type d \
             | grep '[0-9]*.x\|develop' \
             | sort -r \


### PR DESCRIPTION
This PR fixes an issue with the GHA maven site build, where I made an assumption about how files persist which was incorrect.  This PR adds the relevant files as an uploaded artifact so that the follow on job can find and deploy them.

This really only affects `develop`, but since we're going to be maintaining `r/19.x` for quite a while at this point I figured I would put this here and then merge it forward so there are fewer opportunities for merge conflicts.


### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
