### PR TITLE
Update r/19.x Admin UI to 19.x-2025-12-05

### DIFF
--- a/modules/admin-ui-interface/pom.xml
+++ b/modules/admin-ui-interface/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <interface.url>https://github.com/opencast/opencast-admin-interface/releases/download/18.x-2025-11-28/oc-admin-ui-18.x-2025-11-28.tar.gz</interface.url>
-    <interface.sha256>fbc005ad66c93c7d2d65da31006dc9e164301f9766f824103f3c1a4db4429d02</interface.sha256>
+    <interface.url>https://github.com/opencast/opencast-admin-interface/releases/download/19.x-2025-12-05/oc-admin-ui-19.x-2025-12-05.tar.gz</interface.url>
+    <interface.sha256>383060440ad7c5aaa0497831ab76f21acb505aefe7e27184bd853cd8ac50b5cd</interface.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
Updating Opencast r/19.x Admin UI module to [19.x-2025-12-05](https://github.com/opencast/opencast-admin-interface/releases/tag/19.x-2025-12-05)

Fixes #7262 