### PR TITLE
Consistent Workflow Styling

### DIFF
--- a/etc/workflows/duplicate-event.yaml
+++ b/etc/workflows/duplicate-event.yaml
@@ -9,51 +9,49 @@ state-mappings:
   - state: failing
     value: EVENTS.EVENTS.STATE_MAPPING.DUPLICATING
 configuration_panel_json: |-
-  [
-    {
-      "description": "Title of Duplicate:",
-      "fieldset": [
-        {
-          "name": "mpTitle",
-          "type": "text",
-          "value": " "
-        }
-      ]
-    },
-    {
-      "description": "Series Id:",
-      "fieldset": [
-          {
-          "name": "seriesId",
-          "type": "text",
-          "value": " "
-        }
-      ]
-    },
-    {
-      "description": "Insert the number of duplicated events",
-      "fieldset": [
-        {
-          "name": "numberOfEvents",
-          "type": "number",
-          "label": "Number of Events",
-          "min": "1",
-          "max": "25",
-          "value": "1"
-        }
-      ]
-    },
-    {
-      "fieldset": [
-        {
-          "name": "noCopySuffix",
-          "type": "checkbox",
-          "label": "Do not use copy suffix",
-          "value": false
-        }
-      ]
-    }
-  ]
+  [{
+    "description": "Title of Duplicate:",
+    "fieldset": [
+      {
+        "name": "mpTitle",
+        "type": "text",
+        "value": " "
+      }
+    ]
+  },
+  {
+    "description": "Series Id:",
+    "fieldset": [
+      {
+        "name": "seriesId",
+        "type": "text",
+        "value": " "
+      }
+    ]
+  },
+  {
+    "description": "Insert the number of duplicated events",
+    "fieldset": [
+      {
+        "name": "numberOfEvents",
+        "type": "number",
+        "label": "Number of Events",
+        "min": "1",
+        "max": "25",
+        "value": "1"
+      }
+    ]
+  },
+  {
+    "fieldset": [
+      {
+        "name": "noCopySuffix",
+        "type": "checkbox",
+        "label": "Do not use copy suffix",
+        "value": false
+      }
+    ]
+  }]
 operations:
   # Create the new events
   - id: duplicate-event

--- a/etc/workflows/fast.yaml
+++ b/etc/workflows/fast.yaml
@@ -21,110 +21,110 @@ configuration_panel_json: |-
   }]
 operations:
   - id: defaults
-    description: "Applying default configuration values"
+    description: Applying default configuration values
     configurations:
       - straightToPublishing: true
 
   - id: series
     fail-on-error: true
     exception-handler-workflow: partial-error
-    description: "Applying access control entries from series"
+    description: Applying access control entries from series
     configurations:
       - apply-acl: true
 
   - id: inspect
     fail-on-error: true
-    exception-handler-workflow: "partial-error"
-    description: "Inspecting audio and video streams"
+    exception-handler-workflow: partial-error
+    description: Inspecting audio and video streams
     configurations:
       - overwrite: false
       - accept-no-media: false
 
   - id: encode
     fail-on-error: true
-    exception-handler-workflow: "partial-error"
-    description: "Encoding video"
+    exception-handler-workflow: partial-error
+    description: Encoding video
     configurations:
-      - source-flavor: "*/source"
-      - target-flavor: "*/preview"
-      - target-tags: "engage-download,engage-streaming,rss,atom"
-      - encoding-profile: "fast.http"
+      - source-flavor: '*/source'
+      - target-flavor: '*/preview'
+      - target-tags: engage-download,engage-streaming,rss,atom
+      - encoding-profile: fast.http
 
   - id: image
-    if: "${straightToPublishing}"
+    if: ${straightToPublishing}
     fail-on-error: true
-    exception-handler-workflow: "partial-error"
-    description: "Creating Engage search result thumbnails"
+    exception-handler-workflow: partial-error
+    description: Creating Engage search result thumbnails
     configurations:
-      - source-flavor: "*/source"
-      - target-flavor: "*/search+preview"
-      - target-tags: "engage-download"
-      - encoding-profile: "search-cover.http"
+      - source-flavor: '*/source'
+      - target-flavor: '*/search+preview'
+      - target-tags: engage-download
+      - encoding-profile: search-cover.http
       - time: 1
 
   - id: image
-    if: "${straightToPublishing}"
+    if: ${straightToPublishing}
     fail-on-error: true
-    exception-handler-workflow: "partial-error"
-    description: "Creating Engage player preview image"
+    exception-handler-workflow: partial-error
+    description: Creating Engage player preview image
     configurations:
-      - source-flavor: "*/source"
-      - target-flavor: "*/player+preview"
-      - target-tags: "engage-download"
-      - encoding-profile: "player-preview.http"
+      - source-flavor: '*/source'
+      - target-flavor: '*/player+preview'
+      - target-tags: engage-download
+      - encoding-profile: player-preview.http
       - time: 1
 
   - id: segment-video
-    if: "${straightToPublishing}"
+    if: ${straightToPublishing}
     fail-on-error: false
-    exception-handler-workflow: "partial-error"
-    description: "Detecting slide transitions in presentation track"
+    exception-handler-workflow: partial-error
+    description: Detecting slide transitions in presentation track
     configurations:
-      - source-flavor: "presentation/source"
-      - target-tags: "engage-download"
+      - source-flavor: presentation/source
+      - target-tags: engage-download
 
   - id: segmentpreviews
-    if: "${straightToPublishing}"
+    if: ${straightToPublishing}
     fail-on-error: false
-    exception-handler-workflow: "partial-error"
-    description: "Creating presentation segments preview image"
+    exception-handler-workflow: partial-error
+    description: Creating presentation segments preview image
     configurations:
-      - source-flavor: "presentation/source"
-      - target-flavor: "presentation/segment+preview"
-      - reference-tags: "engage-download"
-      - target-tags: "engage-download"
-      - encoding-profile: "player-slides.http"
+      - source-flavor: presentation/source
+      - target-flavor: presentation/segment+preview
+      - reference-tags: engage-download
+      - target-tags: engage-download
+      - encoding-profile: player-slides.http
 
   - id: publish-configure
-    exception-handler-workflow: "partial-error"
-    description: "Publish to preview publication channel"
+    exception-handler-workflow: partial-error
+    description: Publish to preview publication channel
     configurations:
-      - download-source-flavors: "*/preview"
-      - channel-id: "internal"
-      - url-pattern: "${org_org_opencastproject_admin_ui_url!'http://localhost:8080'}/editor-ui/index.html?id=${event_id}"
+      - download-source-flavors: '*/preview'
+      - channel-id: internal
+      - url-pattern: ${org_org_opencastproject_admin_ui_url!'http://localhost:8080'}/editor-ui/index.html?id=${event_id}
       - check-availability: false
 
   - id: publish-engage
-    if: "${straightToPublishing}"
+    if: ${straightToPublishing}
     max-attempts: 2
     fail-on-error: true
-    exception-handler-workflow: "partial-error"
-    description: "Publishing to Engage"
+    exception-handler-workflow: partial-error
+    description: Publishing to Engage
     configurations:
-      - download-source-flavors: "dublincore/*,security/*,captions/*"
-      - download-source-tags: "engage-download"
+      - download-source-flavors: dublincore/*,security/*,captions/*
+      - download-source-tags: engage-download
       - check-availability: false
 
   - id: snapshot
     fail-on-error: true
-    exception-handler-workflow: "partial-error"
-    description: "Archiving"
+    exception-handler-workflow: partial-error
+    description: Archiving
     configurations:
-      - source-flavors: "*/source,dublincore/*,security/*"
+      - source-flavors: '*/source,dublincore/*,security/*'
 
   - id: cleanup
-    fail-on-error: "false"
-    description: "Cleaning up"
+    fail-on-error: false
+    description: Cleaning up
     configurations:
       - delete-external: true
-      - preserve-flavors: "security/*"
+      - preserve-flavors: security/*

--- a/etc/workflows/partial-preview.yaml
+++ b/etc/workflows/partial-preview.yaml
@@ -20,7 +20,7 @@ operations:
 
   # Transcode video previews
   - id: encode
-    if: ((${presenter_source_video} OR ${presentation_source_video}))
+    if: ${presenter_source_video} OR ${presentation_source_video}
     exception-handler-workflow: partial-error
     description: Create single-stream video preview
     configurations:
@@ -58,7 +58,7 @@ operations:
       - time: 50%
 
   - id: cover-image
-    if: (NOT(${presenter_source_video} OR $ ${presentation_source_video}))
+    if: NOT (${presenter_source_video} OR ${presentation_source_video})
     description: Create a cover image for audio-only files
     configurations:
       - stylesheet: file://${karaf.etc}/branding/coverimage.xsl
@@ -67,7 +67,7 @@ operations:
       - target-flavor: presenter/image+work
 
   - id: image-to-video
-    if: (NOT(${presenter_source_video} OR $ ${presentation_source_video}))
+    if: NOT (${presenter_source_video} OR ${presentation_source_video})
     description: Composite
     configurations:
       - source-flavor: presenter/image+work
@@ -76,7 +76,7 @@ operations:
       - profile: image-movie.work
 
   - id: prepare-av
-    if: (NOT(${presenter_source_video} OR $ ${presentation_source_video}))
+    if: NOT (${presenter_source_video} OR ${presentation_source_video})
     description: Preparing presenter audio and video work versions
     configurations:
       - source-flavor: presenter/video+work

--- a/etc/workflows/partial-process-uploaded-captions.yaml
+++ b/etc/workflows/partial-process-uploaded-captions.yaml
@@ -25,6 +25,7 @@ operations:
     configurations:
       - source-flavors: captions/delivery
       - target-tags: -archive,+generator:unknown,+engage-download
+
   - id: tag
     description: Don't publish captions/source
     configurations:

--- a/etc/workflows/partial-publish.yaml
+++ b/etc/workflows/partial-publish.yaml
@@ -88,7 +88,7 @@ operations:
       - time: 3
 
   - id: cover-image
-    if: NOT (${presenter_work_video} OR $ ${presentation_work_video} OR ${presentation/thumbnail_edited}) AND (${presenter_work_audio} OR ${presentation_work_audio})
+    if: NOT (${presenter_work_video} OR ${presentation_work_video} OR ${presentation/thumbnail_edited}) AND (${presenter_work_audio} OR ${presentation_work_audio})
     description: Create a cover image for audio-only files
     configurations:
       - stylesheet: file://${karaf.etc}/branding/coverimage.xsl
@@ -108,7 +108,7 @@ operations:
 
   # Generate timeline preview images
   - id: timelinepreviews
-    if: (${presenter_work_video} OR $ ${presentation_work_video})
+    if: ${presenter_work_video} OR ${presentation_work_video}
     fail-on-error: false
     exception-handler-workflow: partial-error
     description: Creating timeline preview images
@@ -124,7 +124,7 @@ operations:
   # Add trailer and bumper to the recording prior to publication.
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   - id: include
-    if: (${presenter_work_video} OR $ ${presentation_work_video})
+    if: ${presenter_work_video} OR ${presentation_work_video}
     description: Including theming operations
     configurations:
       - workflow-id: partial-theming
@@ -154,7 +154,7 @@ operations:
   # Encode presenter (camera) and presentation (screen)
   # to Engage player format
   - id: encode
-    if: (${presenter_work_video} OR $ ${presentation_work_video})
+    if: ${presenter_work_video} OR ${presentation_work_video}
     exception-handler-workflow: partial-error
     description: Encoding videos to mp4 delivery format
     configurations:
@@ -164,7 +164,7 @@ operations:
       - encoding-profile: adaptive-parallel.http
 
   - id: encode
-    if: NOT (${presenter_work_video} OR $ ${presentation_work_video}) AND (${presenter_work_audio} OR ${presentation_work_audio})
+    if: NOT (${presenter_work_video} OR ${presentation_work_video}) AND (${presenter_work_audio} OR ${presentation_work_audio})
     exception-handler-workflow: partial-error
     description: Encoding audio-only files to mp3 delivery format
     configurations:

--- a/etc/workflows/partial-theming-watermark.yaml
+++ b/etc/workflows/partial-theming-watermark.yaml
@@ -20,7 +20,7 @@ operations:
       - encoding-profile: composite.http
       - target-flavor: presenter/trimmed
       - output-resolution: lower
-      - output-background: '0x000000FF'
+      - output-background: 0x000000FF
       - layout-single: |-
           {"horizontalCoverage":1.0,"anchorOffset":{"referring":{"left":1.0,"top":0.0},"reference":{"left":1.0,"top":0.0},"offset":{"x":0,"y":0}}};
                     ${theme_watermark_layout_variable}
@@ -36,7 +36,7 @@ operations:
       - encoding-profile: composite.http
       - target-flavor: presentation/trimmed
       - output-resolution: lower
-      - output-background: '0x000000FF'
+      - output-background: 0x000000FF
       - layout-single: |-
           {"horizontalCoverage":1.0,"anchorOffset":{"referring":{"left":1.0,"top":0.0},"reference":{"left":1.0,"top":0.0},"offset":{"x":0,"y":0}}};
                     ${theme_watermark_layout_variable}

--- a/etc/workflows/partial-theming.yaml
+++ b/etc/workflows/partial-theming.yaml
@@ -26,15 +26,15 @@ operations:
       - accept-no-media: false
 
   - id: tag
-    if: NOT(${theme_active})
+    if: NOT ${theme_active}
     description: If no shifting was necessary, mark the trimmed chapters as shifted
     configurations:
-      - source-flavors: 'chapters/trimmed'
-      - target-flavor: 'chapters/shifted'
+      - source-flavors: chapters/trimmed
+      - target-flavor: chapters/shifted
       - copy: false
 
   - id: tag
-    if: NOT(${theme_active})
+    if: NOT ${theme_active}
     description: Tag elements as themed
     configurations:
       - source-flavors: '*/trimmed'

--- a/etc/workflows/publish-uploaded-assets.yaml
+++ b/etc/workflows/publish-uploaded-assets.yaml
@@ -1,6 +1,5 @@
 id: publish-uploaded-assets
 title: Publish uploaded assets
-tags: [] # Only launched from add asset in admin interface, not available for selection by end users via the Admin UI
 description: |-
   Publish uploaded assets
 state-mappings:
@@ -31,7 +30,7 @@ operations:
   # captions/delivery   engage-download
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   - id: include
-    if: NOT(${captions_source_hastag_archive})
+    if: NOT ${captions_source_hastag_archive}
     description: Include special handling for uploaded captions
     configurations:
       - workflow-id: partial-process-uploaded-captions

--- a/etc/workflows/schedule-and-upload.yaml
+++ b/etc/workflows/schedule-and-upload.yaml
@@ -23,7 +23,7 @@ operations:
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   # Apply default workflow properties
 
-  # The worklfow properties are simplified for a better
+  # The workflow properties are simplified for a better
   # user experience, please preconfigure your defaults here.
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   - id: defaults

--- a/etc/workflows/studio-upload.yaml
+++ b/etc/workflows/studio-upload.yaml
@@ -20,7 +20,7 @@ operations:
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   # Apply default workflow properties
 
-  # The worklfow properties are simplified for a better
+  # The workflow properties are simplified for a better
   # user experience, please preconfigure your defaults here.
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   - id: defaults


### PR DESCRIPTION
The styling of the yaml workflows is not in itself consistent, which does not look good. To prevent style-chaos I suggest that the community workflows are consistent in their styling. 

I would suggest the following styling (derived from how the majority of the workflows was already styled):
- only use quotes when they are necessary (always before a `*`, since they are not interpreted correctly without quotes)
- use single quotes only
- only use parenthesis when necessary
- white space after logical operators and variables in the operation condition
- empty line after each workflow operation
- for flavors and tags use comma separated lists without white spaces


This PR includes the following changes
- fixing typos
- removing unnecessary quotes
- use single quotes only
- removing unnecessary parenthesis
- using white spaces in the operation conditions
- fixing `OR $ ${variable}` typo in `partial-preview` and `partial-publish`