### PR TITLE
Add new cutting "mode" to editor for vtt files

### DIFF
--- a/etc/org.opencastproject.videoeditor.impl.VideoEditorServiceImpl.cfg
+++ b/etc/org.opencastproject.videoeditor.impl.VideoEditorServiceImpl.cfg
@@ -13,6 +13,14 @@ video.fade = 0.2
 # Default: 2000 milliseconds
 #segments.min.cut.duration = 2000
 
+# The main flavor of the vtt files which should be cut in "Shorten" mode.
+# The default mode will remove cues from vtt files if they overlap too much with a cut segment. This is not desirable
+# for e.g. chapters. "Shorten" mode will instead keep the cue, but reduce its duration by the overlap amount. A cue that
+# overlaps a cut segment completely is still removed.
+# Multiple type can be provided as a comma separated list, e.g. chapters, captions
+# Default: chapters
+#vtt.shorten.flavor.types = chapters
+
 # if not specified, default codec is same as input file
 audio.codec = aac
 video.codec = libx264

--- a/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/impl/VideoEditorServiceImpl.java
+++ b/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/impl/VideoEditorServiceImpl.java
@@ -86,7 +86,9 @@ import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 import javax.xml.bind.JAXBException;
 
@@ -119,6 +121,10 @@ public class VideoEditorServiceImpl extends AbstractJobProducer implements Video
   private static final int DEFAULT_SEGMENTS_MIN_CUT_DURATION = 2000;
 
   private int segmentsMinCutDuration = DEFAULT_SEGMENTS_MIN_CUT_DURATION;
+
+  private static final String VTT_SHORTEN_FLAVOR_TYPES = "vtt.shorten.flavor.types";
+  private static final String DEFAULT_VTT_SHORTEN_FLAVOR_TYPES = "chapters";
+  private List<String> shortenFlavorTypes = new ArrayList<>();
 
   /**
    * The logging instance
@@ -361,28 +367,43 @@ public class VideoEditorServiceImpl extends AbstractJobProducer implements Video
             subtitle = parser.parse(fin);
           }
 
-          // Edit
-          List<WebVTTSubtitleCue> cutCues = new ArrayList<>();
-          double removedTime = 0;
-          for (int i = 0; i < cleanclips.size(); i++) {
-            if (i == 0) {
-              removedTime = removedTime
-                  + cleanclips.get(i).getStartInMilliseconds();
-            } else {
-              removedTime = removedTime
-                  + cleanclips.get(i).getStartInMilliseconds()
-                  - cleanclips.get(i - 1).getEndInMilliseconds();
-            }
-            for (WebVTTSubtitleCue cue : subtitle.getCues()) {
-              if ((cleanclips.get(i).getStartInMilliseconds() - SUBTITLE_GRACE_PERIOD) <= cue.getStartTime()
-                      && (cleanclips.get(i).getEndInMilliseconds() + SUBTITLE_GRACE_PERIOD) >= cue.getEndTime()) {
-                cue.setStartTime((long) (cue.getStartTime() - removedTime));
-                cue.setEndTime((long) (cue.getEndTime() - removedTime));
-                cutCues.add(cue);
+          if (shortenFlavorTypes.contains(sourceTrackFlavor.getType())) {
+            // Edit - Shorten
+            List<WebVTTSubtitleCue> result = new ArrayList<>();
+            for (WebVTTSubtitleCue ch :  subtitle.getCues()) {
+              long newStart = totalKeptBefore(ch.getStartTime(), cleanclips);
+              long newEnd   = totalKeptBefore(ch.getEndTime(), cleanclips);
+              if (newEnd > newStart) {
+                ch.setStartTime(newStart);
+                ch.setEndTime(newEnd);
+                result.add(ch);
               }
             }
+            subtitle.setCues(result);
+          } else {
+            // Edit - Remove (Default)
+            List<WebVTTSubtitleCue> cutCues = new ArrayList<>();
+            double removedTime = 0;
+            for (int i = 0; i < cleanclips.size(); i++) {
+              if (i == 0) {
+                removedTime = removedTime
+                    + cleanclips.get(i).getStartInMilliseconds();
+              } else {
+                removedTime = removedTime
+                    + cleanclips.get(i).getStartInMilliseconds()
+                    - cleanclips.get(i - 1).getEndInMilliseconds();
+              }
+              for (WebVTTSubtitleCue cue : subtitle.getCues()) {
+                if ((cleanclips.get(i).getStartInMilliseconds() - SUBTITLE_GRACE_PERIOD) <= cue.getStartTime()
+                    && (cleanclips.get(i).getEndInMilliseconds() + SUBTITLE_GRACE_PERIOD) >= cue.getEndTime()) {
+                  cue.setStartTime((long) (cue.getStartTime() - removedTime));
+                  cue.setEndTime((long) (cue.getEndTime() - removedTime));
+                  cutCues.add(cue);
+                }
+              }
+            }
+            subtitle.setCues(cutCues);
           }
-          subtitle.setCues(cutCues);
 
           // Write
           try (FileOutputStream fos = new FileOutputStream(outputPath)) {
@@ -493,6 +514,27 @@ public class VideoEditorServiceImpl extends AbstractJobProducer implements Video
     return clips;
   }
 
+  /*
+   * Compute removed time from segments for cue time
+   */
+  private long totalKeptBefore(long t, List<VideoClip> keepSegments) {
+    long kept = 0;
+    for (VideoClip s : keepSegments) {
+      if (s.getEndInMilliseconds() <= 0) {
+        continue;
+      }
+      if (s.getStartInMilliseconds() >= t) {
+        break; // this and all further segments are after t
+      }
+      long overlapStart = Math.max(s.getStartInMilliseconds(), 0);
+      long overlapEnd = Math.min(s.getEndInMilliseconds(), t);
+      if (overlapEnd > overlapStart) {
+        kept += (overlapEnd - overlapStart);
+      }
+    }
+    return kept;
+  }
+
   /**
    * {@inheritDoc}
    *
@@ -593,6 +635,11 @@ public class VideoEditorServiceImpl extends AbstractJobProducer implements Video
         String.valueOf(DEFAULT_SEGMENTS_MIN_DURATION)));
     segmentsMinCutDuration = Integer.parseInt(this.properties.getProperty(SEGMENTS_MIN_CUT_DURATION_KEY,
         String.valueOf(DEFAULT_SEGMENTS_MIN_CUT_DURATION)));
+    String tmp = Objects.toString(properties.get(VTT_SHORTEN_FLAVOR_TYPES),
+        DEFAULT_VTT_SHORTEN_FLAVOR_TYPES);
+    shortenFlavorTypes = Arrays.stream(tmp.split(","))
+        .map(String::trim)
+        .collect(Collectors.toList());
   }
 
   @Reference


### PR DESCRIPTION
Addresses #7241.

Currently, the editor removes cues from vtt files when the cue overlaps with a cut segment. For example, if there is a cue that goes from 10 to 16, and there is a cut from 13 to 20, that cue would be removed. This patch adds an alternative "Shorten" mode to the editor. With this active, cues are not removed but their duration is reduced if possible. If the above example was processed in shorten mode, the cue would remain and go from 10 to 13 instead. "Shorten" mode is intended to be used with chapters, which have slightly different semantics from normal subtitles.

### How to test this patch

You could use the new chapter editor in the editor to generate and cut chapters with the new mode. Or you could configure "captions" as a flavor for Shorten mode and test cutting subtitles with it (which you could also provide through the editor).


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
