### PR TITLE
Add developers back to the main pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1466,7 +1466,7 @@
       <name>Opencast Committers</name>
       <email>committers@opencast.org</email>
     </developer>
-  </developers>nagement>
+  </developers>
   <!-- Site Report generation settings -->
   <reporting>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -1461,6 +1461,12 @@
     <system>GitHub</system>
     <url>https://github.com/opencast/opencast</url>
   </issueManagement>
+  <developers>
+    <developer>
+      <name>Opencast Committers</name>
+      <email>committers@opencast.org</email>
+    </developer>
+  </developers>nagement>
   <!-- Site Report generation settings -->
   <reporting>
     <plugins>


### PR DESCRIPTION
This PR adds the developers stanza back to the main pom.  We removed this previously because it was not up to date,
however this stanza is [required](https://central.sonatype.org/publish/requirements/#developer-information) to make
Sonatype publishing work.  Rather than trying to keep this list up-to-date, we put this technically correct standin
into the pom.

This needs to go into any branch that's seeking to have artifacts published.  I've targetted 18 here, but this could
go into 17 if we want to, for the very last release...

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
