### PR TITLE
Clarify encoding profile count logging

### DIFF
--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/EncodingProfileScanner.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/EncodingProfileScanner.java
@@ -327,13 +327,13 @@ public class EncodingProfileScanner implements ArtifactInstaller {
       bundleCtx.registerService(ReadinessIndicator.class.getName(), new ReadinessIndicator(), properties);
 
       if (filesInDirectory.length == sumInstalledFiles) {
-        logger.info("All {} encoding profiles installed", filesInDirectory.length);
+        logger.info("All {} encoding profiles in {} files installed", profiles.size(), filesInDirectory.length);
       } else {
-        logger.warn("{} encoding profile(s) installed, {} encoding profile(s) could not be installed",
+        logger.warn("{} encoding config files installed, {} encoding config files could not be installed",
                 sumInstalledFiles, sumUnparsableFiles);
       }
     } else {
-      logger.debug("{} of {} encoding profiles installed", sumInstalledFiles, filesInDirectory.length);
+      logger.debug("{} of {} encoding profile config files installed", sumInstalledFiles, filesInDirectory.length);
     }
   }
 


### PR DESCRIPTION
This PR clarifies the logging around encoding profiles.  Previously we reported the number of installed encoding profile *files* as the count of encoding profiles themselves.  This PR fixes that, reporting both the number of files *and* the number of profiles contained within.

Putting this into 18 since it's technically a bug, but I'm find punting this to 19 too if this is considered too low impact to warrant inclusion in 18.

### Your pull request should…

* [z] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
