### PR TITLE
Deactivate heartbeat on non-dispatching nodes

### DIFF
--- a/docs/guides/admin/docs/releasenotes/deactive-heartbeat-on-non-dispatching-nodes.txt
+++ b/docs/guides/admin/docs/releasenotes/deactive-heartbeat-on-non-dispatching-nodes.txt
@@ -1,8 +1,4 @@
-The configuration option "heartbeat.interval" was moved from
-
-etc/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg
-
-to
+The configuration option "heartbeat.interval" was removed from
 
 etc/org.opencastproject.serviceregistry.impl.JobDispatcher.cfg
 

--- a/docs/guides/admin/docs/releasenotes/deactive-heartbeat-on-non-dispatching-nodes.txt
+++ b/docs/guides/admin/docs/releasenotes/deactive-heartbeat-on-non-dispatching-nodes.txt
@@ -1,0 +1,9 @@
+The configuration option "heartbeat.interval" was moved from
+
+etc/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg
+
+to
+
+etc/org.opencastproject.serviceregistry.impl.JobDispatcher.cfg
+
+Furthermore, only dispatching nodes will have a heartbeat from now on.

--- a/etc/org.opencastproject.serviceregistry.impl.JobDispatcher.cfg
+++ b/etc/org.opencastproject.serviceregistry.impl.JobDispatcher.cfg
@@ -6,3 +6,10 @@
 # usually not be activated on these nodes to avoid concurrency problems.
 # Default: 0
 #dispatch.interval=0
+
+# The interval in seconds between checking if the hosts in the service registry hosts are still alive.
+# Only effective on dispatching nodes, meaning nodes with a dispatch.interval higher than 0. Non-dispatching nodes
+# do not have a heartbeat and changing the interval will have no effect on them.
+# Set to 0 to disable checking if hosts are still alive and able to be dispatched to.
+# Default: 60
+#heartbeat.interval=60

--- a/etc/org.opencastproject.serviceregistry.impl.JobDispatcher.cfg
+++ b/etc/org.opencastproject.serviceregistry.impl.JobDispatcher.cfg
@@ -6,10 +6,3 @@
 # usually not be activated on these nodes to avoid concurrency problems.
 # Default: 0
 #dispatch.interval=0
-
-# The interval in seconds between checking if the hosts in the service registry hosts are still alive.
-# Only effective on dispatching nodes, meaning nodes with a dispatch.interval higher than 0. Non-dispatching nodes
-# do not have a heartbeat and changing the interval will have no effect on them.
-# Set to 0 to disable checking if hosts are still alive and able to be dispatched to.
-# Default: 60
-#heartbeat.interval=60

--- a/etc/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg
+++ b/etc/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg
@@ -8,11 +8,6 @@
 # Default: None
 #no.error.state.service.types=
 
-# The interval in seconds between checking if the hosts in the service registry hosts are still alive.
-# Set to 0 to disable checking if hosts are still alive and able to be dispatched to.
-# Default: 60
-#heartbeat.interval=60
-
 # Whether to collect detailed job statistics information. This can cause excessive database load (see MH-10034)!
 # Default: false
 #jobstats.collect=false

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/JobDispatcher.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/JobDispatcher.java
@@ -110,10 +110,6 @@ public class JobDispatcher {
   /** Multiplicative factor to transform dispatch interval captured in seconds to milliseconds */
   static final long DISPATCH_INTERVAL_MS_FACTOR = 1000;
 
-  /** Configuration key for the interval to check whether the hosts in the service registry are still alive,
-   * in seconds */
-  protected static final String OPT_HEARTBEATINTERVAL = "heartbeat.interval";
-
   /** Default delay between checking if hosts are still alive in seconds * */
   static final long DEFAULT_HEART_BEAT = 60;
 
@@ -232,25 +228,6 @@ public class JobDispatcher {
       }
     }
 
-    long heartbeatInterval = DEFAULT_HEART_BEAT;
-    String heartbeatIntervalString = StringUtils.trimToNull((String) properties.get(OPT_HEARTBEATINTERVAL));
-    if (StringUtils.isNotBlank(heartbeatIntervalString)) {
-      try {
-        heartbeatInterval = Long.parseLong(heartbeatIntervalString);
-      } catch (Exception e) {
-        logger.warn("Heartbeat interval '{}' is malformed, setting to {}", heartbeatIntervalString, DEFAULT_HEART_BEAT);
-        heartbeatInterval = DEFAULT_HEART_BEAT;
-      }
-      if (heartbeatInterval == 0) {
-        logger.info("Heartbeat disabled");
-      } else if (heartbeatInterval < 0) {
-        logger.warn("Heartbeat interval {} seconds too low, adjusting to {}", heartbeatInterval, DEFAULT_HEART_BEAT);
-        heartbeatInterval = DEFAULT_HEART_BEAT;
-      } else {
-        logger.info("Heartbeat interval set to {} seconds", heartbeatInterval);
-      }
-    }
-
     // Stop the current dispatch thread so we can configure a new one
     if (jdfuture != null) {
       jdfuture.cancel(true);
@@ -264,7 +241,7 @@ public class JobDispatcher {
       jdfuture = scheduledExecutor.scheduleWithFixedDelay(getJobDispatcherRunnable(), dispatchIntervalMs,
           dispatchIntervalMs, TimeUnit.MILLISECONDS);
       // Schedule heartbeat for dispatching nodes
-      serviceRegistry.startHeartbeat(heartbeatInterval);
+      serviceRegistry.startHeartbeat(DEFAULT_HEART_BEAT);
     } else {
       logger.info("Job dispatching is disabled");
     }

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/JobDispatcher.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/JobDispatcher.java
@@ -110,6 +110,13 @@ public class JobDispatcher {
   /** Multiplicative factor to transform dispatch interval captured in seconds to milliseconds */
   static final long DISPATCH_INTERVAL_MS_FACTOR = 1000;
 
+  /** Configuration key for the interval to check whether the hosts in the service registry are still alive,
+   * in seconds */
+  protected static final String OPT_HEARTBEATINTERVAL = "heartbeat.interval";
+
+  /** Default delay between checking if hosts are still alive in seconds * */
+  static final long DEFAULT_HEART_BEAT = 60;
+
   private static final Logger logger = LoggerFactory.getLogger(JobDispatcher.class);
 
   private ServiceRegistryJpaImpl serviceRegistry;
@@ -225,6 +232,25 @@ public class JobDispatcher {
       }
     }
 
+    long heartbeatInterval = DEFAULT_HEART_BEAT;
+    String heartbeatIntervalString = StringUtils.trimToNull((String) properties.get(OPT_HEARTBEATINTERVAL));
+    if (StringUtils.isNotBlank(heartbeatIntervalString)) {
+      try {
+        heartbeatInterval = Long.parseLong(heartbeatIntervalString);
+      } catch (Exception e) {
+        logger.warn("Heartbeat interval '{}' is malformed, setting to {}", heartbeatIntervalString, DEFAULT_HEART_BEAT);
+        heartbeatInterval = DEFAULT_HEART_BEAT;
+      }
+      if (heartbeatInterval == 0) {
+        logger.info("Heartbeat disabled");
+      } else if (heartbeatInterval < 0) {
+        logger.warn("Heartbeat interval {} seconds too low, adjusting to {}", heartbeatInterval, DEFAULT_HEART_BEAT);
+        heartbeatInterval = DEFAULT_HEART_BEAT;
+      } else {
+        logger.info("Heartbeat interval set to {} seconds", heartbeatInterval);
+      }
+    }
+
     // Stop the current dispatch thread so we can configure a new one
     if (jdfuture != null) {
       jdfuture.cancel(true);
@@ -237,6 +263,8 @@ public class JobDispatcher {
       logger.debug("Starting job dispatching at a custom interval of {}s", dispatchInterval);
       jdfuture = scheduledExecutor.scheduleWithFixedDelay(getJobDispatcherRunnable(), dispatchIntervalMs,
           dispatchIntervalMs, TimeUnit.MILLISECONDS);
+      // Schedule heartbeat for dispatching nodes
+      serviceRegistry.startHeartbeat(heartbeatInterval);
     } else {
       logger.info("Job dispatching is disabled");
     }

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -99,7 +99,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -169,10 +170,6 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
   /** Configuration key for the maximum load */
   protected static final String OPT_MAXLOAD = "org.opencastproject.server.maxload";
 
-  /** Configuration key for the interval to check whether the hosts in the service registry are still alive,
-   * in seconds */
-  protected static final String OPT_HEARTBEATINTERVAL = "heartbeat.interval";
-
   /** Configuration key for the collection of job statistics */
   protected static final String OPT_JOBSTATISTICS = "jobstats.collect";
 
@@ -223,9 +220,6 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
   /** Services for which error state is disabled */
   private List<String> noErrorStateServiceTypes = new ArrayList<>();
 
-  /** Default delay between checking if hosts are still alive in seconds * */
-  static final long DEFAULT_HEART_BEAT = 60;
-
   /** Default job load when not passed by service creating the job * */
   static final float DEFAULT_JOB_LOAD = 0.1f;
 
@@ -252,7 +246,8 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
   protected DBSession db;
 
   /** The thread pool to use for dispatching queued jobs and checking on phantom services. */
-  protected ScheduledExecutorService scheduledExecutor = null;
+  protected ScheduledThreadPoolExecutor scheduledExecutor = null;
+  private ScheduledFuture hbfuture = null;
 
   /** The security service */
   protected SecurityService securityService = null;
@@ -706,25 +701,6 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
       }
     }
 
-    long heartbeatInterval = DEFAULT_HEART_BEAT;
-    String heartbeatIntervalString = StringUtils.trimToNull((String) properties.get(OPT_HEARTBEATINTERVAL));
-    if (StringUtils.isNotBlank(heartbeatIntervalString)) {
-      try {
-        heartbeatInterval = Long.parseLong(heartbeatIntervalString);
-      } catch (Exception e) {
-        logger.warn("Heartbeat interval '{}' is malformed, setting to {}", heartbeatIntervalString, DEFAULT_HEART_BEAT);
-        heartbeatInterval = DEFAULT_HEART_BEAT;
-      }
-      if (heartbeatInterval == 0) {
-        logger.info("Heartbeat disabled");
-      } else if (heartbeatInterval < 0) {
-        logger.warn("Heartbeat interval {} seconds too low, adjusting to {}", heartbeatInterval, DEFAULT_HEART_BEAT);
-        heartbeatInterval = DEFAULT_HEART_BEAT;
-      } else {
-        logger.info("Heartbeat interval set to {} seconds", heartbeatInterval);
-      }
-    }
-
     String jobStatsString = StringUtils.trimToNull((String) properties.get(OPT_JOBSTATISTICS));
     if (StringUtils.isNotBlank(jobStatsString)) {
       try {
@@ -773,14 +749,28 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
                 OPT_SERVICE_STATISTICS_MAX_JOB_AGE);
       }
     }
+  }
 
-    scheduledExecutor = Executors.newScheduledThreadPool(1);
+  private void setupScheduledExecutor() {
+    if (scheduledExecutor == null) {
+      scheduledExecutor = (ScheduledThreadPoolExecutor) Executors.newScheduledThreadPool(1);
+      scheduledExecutor.setRemoveOnCancelPolicy(true);
+    }
+  }
+
+  protected void startHeartbeat(long heartbeatInterval) {
+    setupScheduledExecutor();
 
     // Schedule the service heartbeat if the interval is > 0
     if (heartbeatInterval > 0) {
+      // Stop the current dispatch thread so we can configure a new one
+      if (hbfuture != null) {
+        hbfuture.cancel(true);
+      }
+
       logger.debug("Starting service heartbeat at a custom interval of {}s", heartbeatInterval);
-      scheduledExecutor.scheduleWithFixedDelay(new JobProducerHeartbeat(), heartbeatInterval, heartbeatInterval,
-              TimeUnit.SECONDS);
+      hbfuture = scheduledExecutor.scheduleWithFixedDelay(new JobProducerHeartbeat(), heartbeatInterval,
+          heartbeatInterval, TimeUnit.SECONDS);
     }
   }
 

--- a/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
+++ b/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
@@ -84,6 +84,7 @@ import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import javax.management.ObjectInstance;
@@ -316,7 +317,7 @@ public class ServiceRegistryJpaImplTest {
     if (serviceRegistryJpaImpl.scheduledExecutor != null) {
       serviceRegistryJpaImpl.scheduledExecutor.shutdown();
     }
-    serviceRegistryJpaImpl.scheduledExecutor = Executors.newScheduledThreadPool(1);
+    serviceRegistryJpaImpl.scheduledExecutor = (ScheduledThreadPoolExecutor) Executors.newScheduledThreadPool(1);
     jobDispatcher.scheduledExecutor.schedule(jobDispatcher.getJobDispatcherRunnable(), DISPATCH_START_DELAY,
         TimeUnit.MILLISECONDS);
 


### PR DESCRIPTION
Fixes #6706.

With this patch, only dispatching nodes (usually admin or allinone) will have a heartbeat. Conversely non-dispatching nodes will not have a heartbeat anymore and cannot be configured to have one either.

Reasons:
- There is no use case for checking for heartbeat on non-dispatching nodes.
- A non-dispatching node could bring down the whole cluster if it could not talk to every other node, by repeatedly marking the unreachable nodes as offline. This is undesirable.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
