### PR TITLE
Add @Deactivate method to JobDispatcher.java

### DIFF
--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/JobDispatcher.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/JobDispatcher.java
@@ -57,6 +57,7 @@ import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
@@ -239,6 +240,24 @@ public class JobDispatcher {
           dispatchIntervalMs, TimeUnit.MILLISECONDS);
     } else {
       logger.info("Job dispatching is disabled");
+    }
+  }
+
+  @Deactivate
+  public void deactivate() {
+    logger.info("Deactivate Job Dispatcher");
+
+    // Wait for runnable to stop before stopping
+    if (scheduledExecutor != null) {
+      try {
+        scheduledExecutor.shutdownNow();
+        if (!scheduledExecutor.isShutdown()) {
+          logger.info("Waiting for Job Dispatcher to terminate");
+          scheduledExecutor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+      } catch (InterruptedException e) {
+        logger.error("Error shutting down the Job Dispatcher", e);
+      }
     }
   }
 


### PR DESCRIPTION
Adds an osgi deactivate method to the JobDispatcher to properly shut down the JobDispatcher Runnable when Opencast shuts down.

This is supposed to help with #7049, which assumes that:

> When shutting down Opencast, it seems that the database connection is shut down before other parts of Opencast are shut down.

This should not be the case. Based on the starting levels in /assemblies/karaf-features/src/main/feature/feature.xml, the db module should not only start before all other Opencast modules, but also be shut down after all other Opencast modules. Therefore, if a module is still trying to use the db after being shut down, it likely has not properly closed its open resources.
Because the stacktrace in #7049 shows the JobDispatcher not being shut down, this patch adds a deactivate method similar to the one in ServiceRegistryJpaImpl.java to ensure that the JobDispatcher thread is properly shut down.

Unfortunately I was not able to reproduce the stacktrace shown in #7049, so I do not actually know if this patch provides an effective fix.

### How to test this patch

Shut down an Opencast with this patch installed and observe if it properly shuts down (ideally while a bunch of jobs are running).

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
