### PR TITLE
Only get unique roles in admin ui

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AclEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AclEndpoint.java
@@ -80,9 +80,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import javax.ws.rs.DELETE;
 import javax.ws.rs.FormParam;
@@ -282,9 +284,10 @@ public class AclEndpoint {
     }
 
     List<Role> roles = roleDirectoryService.findRoles(roleQuery, roleTarget, offset, limit);
+    Set<Role> uniqueRoles = new LinkedHashSet<>(roles);
 
     JSONArray jsonRoles = new JSONArray();
-    for (Role role: roles) {
+    for (Role role: uniqueRoles) {
       JSONObject jsonRole = new JSONObject();
       jsonRole.put("name", role.getName());
       jsonRole.put("type", role.getType().toString());


### PR DESCRIPTION
Asking all role providers for all roles can result in quite a few duplicate roles, especially for non-user roles. In the admin ui we are only interested in unique roles, so this patch makes the GET roles endpoint filter
the roles before returning them.

### How to test this patch

Go to the admin ui, to event details, to the access policy tab. Check which roles are displayed in the dropdowns, particularly non-user roles like "ROLE_ADMIN". Then install this patch and check the displayed roles again. All roles should still be displayed like before, but if any role was displayed multiple times, it should only be displayed once now. 

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
