### PR TITLE
Add thumbnail support to YouTube publication service

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/publish-youtube-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/publish-youtube-woh.md
@@ -10,7 +10,15 @@ Description
 The publish YouTube operation publishes a single stream to YouTube. This stream must meet YouTube's format
 requirements, and may consist of one audio and/or video stream. If you want to publish both your presenter and presentation
 streams we suggest using the [Composite](composite-woh.md) workflow operation handler to prepare a composite file
-with both streams inside of it.  
+with both streams inside of it.
+
+### Thumbnails
+
+YouTube has specific restrictions for custom thumbnails:
+- The image must be in a supported format (e.g., JPG, PNG).
+- The file size must be less than 2MB.
+- The YouTube account must be verified with a phone number to upload custom thumbnails.
+- For more details, see the [YouTube API documentation](https://developers.google.com/youtube/v3/docs/thumbnails/set).
 
 
 Parameter Table
@@ -20,6 +28,8 @@ Parameter Table
 |---------------------------|------------------------------------------------------------------------------|
 |source-flavors             |The flavors to publish to YouTube                                             |
 |source-tags                |The tags to publish to YouTube                                                |
+|thumbnail-flavors          |The flavors of the thumbnail to publish to YouTube                            |
+|thumbnail-tags             |The tags of the thumbnail to publish to YouTube                               |
 
 
 Operation Example
@@ -30,4 +40,5 @@ Operation Example
     description: Publishing to YouTube
     configurations:
       - source-tags: youtube
+      - thumbnail-tags: youtube-thumbnail
 ```

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishYouTubeWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishYouTubeWorkflowOperationHandler.java
@@ -23,6 +23,7 @@ package org.opencastproject.workflow.handler.distribution;
 
 import org.opencastproject.job.api.Job;
 import org.opencastproject.job.api.JobContext;
+import org.opencastproject.mediapackage.Attachment;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElement;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
@@ -43,11 +44,13 @@ import org.opencastproject.workflow.api.WorkflowOperationHandler;
 import org.opencastproject.workflow.api.WorkflowOperationResult;
 import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
 
+import org.apache.commons.lang3.StringUtils;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -118,6 +121,28 @@ public class PublishYouTubeWorkflowOperationHandler extends AbstractWorkflowOper
       }
     }
 
+    // Thumbnail configuration
+    List<String> thumbnailTags = asList(StringUtils.trimToNull(
+            workflowInstance.getCurrentOperation().getConfiguration("thumbnail-tags")));
+    List<MediaPackageElementFlavor> thumbnailFlavors = new ArrayList<>();
+    List<String> thumbnailFlavorStrings = asList(StringUtils.trimToNull(
+            workflowInstance.getCurrentOperation().getConfiguration("thumbnail-flavors")));
+    for (String flavorString : thumbnailFlavorStrings) {
+      try {
+        thumbnailFlavors.add(MediaPackageElementFlavor.parseFlavor(flavorString));
+      } catch (IllegalArgumentException e) {
+        throw new WorkflowOperationException(flavorString + " is not a valid flavor!");
+      }
+    }
+
+    AbstractMediaPackageElementSelector<MediaPackageElement> thumbnailSelector = new SimpleElementSelector();
+    for (MediaPackageElementFlavor flavor : thumbnailFlavors) {
+      thumbnailSelector.addFlavor(flavor);
+    }
+    for (String tag : thumbnailTags) {
+      thumbnailSelector.addTag(tag);
+    }
+
     try {
       // Look for elements matching the tag
       final Collection<MediaPackageElement> elements = elementSelector.select(mediaPackage, true);
@@ -131,10 +156,20 @@ public class PublishYouTubeWorkflowOperationHandler extends AbstractWorkflowOper
         return createResult(mediaPackage, Action.SKIP);
       }
 
+      // Look for thumbnail
+      final Collection<MediaPackageElement> thumbnails = thumbnailSelector.select(mediaPackage, true);
+      Attachment thumbnail = null;
+      if (thumbnails.size() > 1) {
+        throw new WorkflowOperationException(
+            "More than one thumbnail element has been found for publishing to youtube: " + thumbnails);
+      } else if (thumbnails.size() == 1) {
+        thumbnail = (Attachment) thumbnails.iterator().next();
+      }
+
       Job youtubeJob;
       try {
         Track track = mediaPackage.getTrack(elements.iterator().next().getIdentifier());
-        youtubeJob = publicationService.publish(mediaPackage, track);
+        youtubeJob = publicationService.publish(mediaPackage, track, thumbnail);
       } catch (PublicationException e) {
         throw new WorkflowOperationException(e);
       }

--- a/modules/publication-service-api/src/main/java/org/opencastproject/publication/api/YouTubePublicationService.java
+++ b/modules/publication-service-api/src/main/java/org/opencastproject/publication/api/YouTubePublicationService.java
@@ -22,6 +22,7 @@
 package org.opencastproject.publication.api;
 
 import org.opencastproject.job.api.Job;
+import org.opencastproject.mediapackage.Attachment;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.Track;
 
@@ -36,17 +37,19 @@ public interface YouTubePublicationService {
   String JOB_TYPE = "org.opencastproject.publication.youtube";
 
   /**
-   * Publishes a media package element.
+   * Publishes a media package element with an optional thumbnail.
    *
    * @param mediaPackage
    *          the media package
    * @param track
    *          the track of the media package to publish
+   * @param thumbnail
+   *          the thumbnail of the media package to publish
    * @return The job
    * @throws PublicationException
    *           if there was a problem publishing the media
    */
-  Job publish(MediaPackage mediaPackage, Track track) throws PublicationException;
+  Job publish(MediaPackage mediaPackage, Track track, Attachment thumbnail) throws PublicationException;
 
   /**
    * Retract a media package element from the distribution channel.

--- a/modules/publication-service-youtube-remote/src/main/java/org/opencastproject/publication/youtube/remote/YouTubePublicationServiceRemoteImpl.java
+++ b/modules/publication-service-youtube-remote/src/main/java/org/opencastproject/publication/youtube/remote/YouTubePublicationServiceRemoteImpl.java
@@ -23,6 +23,7 @@ package org.opencastproject.publication.youtube.remote;
 
 import org.opencastproject.job.api.Job;
 import org.opencastproject.job.api.JobParser;
+import org.opencastproject.mediapackage.Attachment;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageParser;
 import org.opencastproject.mediapackage.Track;
@@ -64,11 +65,14 @@ public class YouTubePublicationServiceRemoteImpl extends RemoteBase implements Y
   }
 
   @Override
-  public Job publish(MediaPackage mediaPackage, Track track) throws PublicationException {
+  public Job publish(MediaPackage mediaPackage, Track track, Attachment thumbnail) throws PublicationException {
     final String trackId = track.getIdentifier();
     List<BasicNameValuePair> params = new ArrayList<BasicNameValuePair>();
     params.add(new BasicNameValuePair("mediapackage", MediaPackageParser.getAsXml(mediaPackage)));
     params.add(new BasicNameValuePair("elementId", trackId));
+    if (thumbnail != null) {
+      params.add(new BasicNameValuePair("thumbnailId", thumbnail.getIdentifier()));
+    }
     HttpPost post = new HttpPost();
     HttpResponse response = null;
     try {

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeAPIVersion3Service.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeAPIVersion3Service.java
@@ -30,6 +30,7 @@ import com.google.api.services.youtube.model.PlaylistListResponse;
 import com.google.api.services.youtube.model.SearchListResponse;
 import com.google.api.services.youtube.model.Video;
 
+import java.io.File;
 import java.io.IOException;
 
 /**
@@ -96,6 +97,15 @@ public interface YouTubeAPIVersion3Service {
    * @throws IOException when transaction fails.
    */
   Video addVideoToMyChannel(VideoUpload videoUpload) throws IOException;
+
+  /**
+   * Set a thumbnail for a video.
+   * @param videoId the video id
+   * @param thumbnail the thumbnail file
+   * @param mimeType the thumbnail mime type
+   * @throws IOException when transaction fails.
+   */
+  void setThumbnail(String videoId, File thumbnail, String mimeType) throws IOException;
 
   /**
    * Add a previously uploaded video to specified YouTube playlist.

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeAPIVersion3ServiceImpl.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeAPIVersion3ServiceImpl.java
@@ -99,6 +99,16 @@ public class YouTubeAPIVersion3ServiceImpl implements YouTubeAPIVersion3Service 
   }
 
   @Override
+  public void setThumbnail(String videoId, File thumbnail, String mimeType) throws IOException {
+    final BufferedInputStream inputStream = new BufferedInputStream(new FileInputStream(thumbnail));
+    final InputStreamContent mediaContent = new InputStreamContent(mimeType, inputStream);
+    mediaContent.setLength(thumbnail.length());
+
+    final YouTube.Thumbnails.Set thumbnailSet = youTube.thumbnails().set(videoId, mediaContent);
+    execute(thumbnailSet);
+  }
+
+  @Override
   public Playlist createPlaylist(final String title, final String description, final String... tags)
           throws IOException {
     final PlaylistSnippet playlistSnippet = new PlaylistSnippet();

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
@@ -23,6 +23,7 @@ package org.opencastproject.publication.youtube;
 
 import org.opencastproject.job.api.AbstractJobProducer;
 import org.opencastproject.job.api.Job;
+import org.opencastproject.mediapackage.Attachment;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElement;
 import org.opencastproject.mediapackage.MediaPackageElementParser;
@@ -62,7 +63,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.Dictionary;
 import java.util.List;
@@ -225,10 +225,16 @@ public class YouTubeV3PublicationServiceImpl
   }
 
   @Override
-  public Job publish(final MediaPackage mediaPackage, final Track track) throws PublicationException {
+  public Job publish(final MediaPackage mediaPackage, final Track track, final Attachment thumbnail)
+          throws PublicationException {
     if (mediaPackage.contains(track)) {
       try {
-        final List<String> args = Arrays.asList(MediaPackageParser.getAsXml(mediaPackage), track.getIdentifier());
+        final List<String> args = new ArrayList<>();
+        args.add(MediaPackageParser.getAsXml(mediaPackage));
+        args.add(track.getIdentifier());
+        if (thumbnail != null) {
+          args.add(thumbnail.getIdentifier());
+        }
         return serviceRegistry.createJob(JOB_TYPE, Operation.Publish.toString(), args, youtubePublishJobLoad);
       } catch (ServiceRegistryException e) {
         throw new PublicationException("Unable to create a job for track: " + track.toString(), e);
@@ -248,12 +254,14 @@ public class YouTubeV3PublicationServiceImpl
    *          the mediapackage
    * @param elementId
    *          the mediapackage element id to publish
+   * @param thumbnailId
+   *          the optional mediapackage thumbnail element id to publish
    * @return the published element
    * @throws PublicationException
    *           if publication fails
    */
-  private Publication publish(final Job job, final MediaPackage mediaPackage, final String elementId)
-          throws PublicationException {
+  private Publication publish(final Job job, final MediaPackage mediaPackage, final String elementId,
+          final String thumbnailId) throws PublicationException {
     if (mediaPackage == null) {
       throw new IllegalArgumentException("Mediapackage must be specified");
     } else if (elementId == null) {
@@ -281,6 +289,15 @@ public class YouTubeV3PublicationServiceImpl
           c.getEpisodeDescription(), privacyStatus,
           file, operationProgressListener, tags);
       final Video video = youTubeService.addVideoToMyChannel(videoUpload);
+
+      if (thumbnailId != null) {
+        final MediaPackageElement thumbnailElement = mediaPackage.getElementById(thumbnailId);
+        if (thumbnailElement != null) {
+          final File thumbnailFile = workspace.get(thumbnailElement.getURI());
+          youTubeService.setThumbnail(video.getId(), thumbnailFile, thumbnailElement.getMimeType().toString());
+        }
+      }
+
       final int timeoutMinutes = 60;
       final long startUploadMilliseconds = new Date().getTime();
       while (!operationProgressListener.isComplete()) {
@@ -394,7 +411,9 @@ public class YouTubeV3PublicationServiceImpl
       MediaPackage mediapackage = MediaPackageParser.getFromXml(arguments.get(0));
       switch (op) {
         case Publish:
-          Publication publicationElement = publish(job, mediapackage, arguments.get(1));
+          String elementId = arguments.get(1);
+          String thumbnailId = arguments.size() > 2 ? arguments.get(2) : null;
+          Publication publicationElement = publish(job, mediapackage, elementId, thumbnailId);
           return (publicationElement == null) ? null : MediaPackageElementParser.getAsXml(publicationElement);
         case Retract:
           Publication retractedElement = retract(job, mediapackage);

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/endpoint/YouTubePublicationRestService.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/endpoint/YouTubePublicationRestService.java
@@ -29,6 +29,7 @@ import static org.opencastproject.util.RestUtil.R.serverError;
 import org.opencastproject.job.api.JaxbJob;
 import org.opencastproject.job.api.Job;
 import org.opencastproject.job.api.JobProducer;
+import org.opencastproject.mediapackage.Attachment;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageParser;
 import org.opencastproject.mediapackage.Track;
@@ -109,6 +110,12 @@ public class YouTubePublicationRestService extends AbstractJobProducerEndpoint {
               isRequired = true,
               description = "The element to publish",
               type = Type.STRING
+          ),
+          @RestParameter(
+              name = "thumbnailId",
+              isRequired = false,
+              description = "The optional thumbnail to publish",
+              type = Type.STRING
           )
       },
       responses = {
@@ -118,14 +125,16 @@ public class YouTubePublicationRestService extends AbstractJobProducerEndpoint {
   )
   public Response publish(
       @FormParam("mediapackage") final String mediaPackageXml,
-      @FormParam("elementId") final String elementId
+      @FormParam("elementId") final String elementId,
+      @FormParam("thumbnailId") final String thumbnailId
   ) {
     final Job job;
     try {
       final MediaPackage mediapackage = MediaPackageParser.getFromXml(mediaPackageXml);
       final Track track = mediapackage.getTrack(elementId);
+      final Attachment thumbnail = (Attachment) mediapackage.getElementById(thumbnailId);
       if (track != null) {
-        job = service.publish(mediapackage, track);
+        job = service.publish(mediapackage, track, thumbnail);
       } else {
         return badRequest();
       }

--- a/modules/publication-service-youtube-v3/src/test/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImplTest.java
+++ b/modules/publication-service-youtube-v3/src/test/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImplTest.java
@@ -110,7 +110,7 @@ public class YouTubeV3PublicationServiceImplTest {
           anyObject(Float.class))).andReturn(new JobImpl()).once();
     replay(youTubeService, orgDirectory, security, registry, userDirectoryService, workspace);
     service.updated(getServiceProperties());
-    service.publish(mediaPackage, mediaPackage.getTracks()[0]);
+    service.publish(mediaPackage, mediaPackage.getTracks()[0], null);
   }
 
   private Dictionary getServiceProperties() throws IOException {


### PR DESCRIPTION
This PR adds support for uploading a custom thumbnail when publishing to YouTube.

Two new configuration options have been added to the `publish-youtube` workflow operation:
- `thumbnail-flavor`: Specifies the flavor of the attachment to use as a thumbnail.
- `thumbnail-tags`: Specifies the tags of the attachment to use as a thumbnail.

**Note:** To test thumbnail uploads, the YouTube account must be verified with a phone number.

For details on thumbnail restrictions (size, format, etc.), please refer to the updated documentation or the [YouTube Data API documentation](https://developers.google.com/youtube/v3/docs/thumbnails/set).