### PR TITLE
Use ngram tokens in index

### DIFF
--- a/docs/upgrade/17_to_18/event_mapping.json
+++ b/docs/upgrade/17_to_18/event_mapping.json
@@ -235,7 +235,13 @@
     "text": {
       "type" : "search_as_you_type",
       "analyzer": "autocomplete_analyzer",
-      "search_analyzer": "whitespace_analyzer"
+      "search_analyzer": "whitespace_analyzer",
+      "copy_to": "text_technical"
+    },
+    "text_technical": {
+      "type" : "search_as_you_type",
+      "analyzer": "autocomplete_analyzer_technical",
+      "search_analyzer": "whitespace_analyzer_technical"
     }
   },
   "dynamic_templates" : [

--- a/docs/upgrade/17_to_18/indexSettings.json
+++ b/docs/upgrade/17_to_18/indexSettings.json
@@ -21,6 +21,16 @@
           "autocomplete_filter"
         ]
       },
+      "autocomplete_analyzer_technical": {
+        "type": "custom",
+        "tokenizer": "whitespace",
+        "char_filter":["html_strip", "camel_case_filter"],
+        "filter": [
+          "lowercase",
+          "icu_folding",
+          "ngram_filter"
+        ]
+      },
       "whitespace_analyzer": {
         "type": "custom",
         "tokenizer": "whitespace",
@@ -30,6 +40,18 @@
         "filter": [
           "lowercase",
           "icu_folding"
+        ]
+      },
+      "whitespace_analyzer_technical": {
+        "type": "custom",
+        "tokenizer": "whitespace",
+        "char_filter": [
+          "camel_case_filter"
+        ],
+        "filter": [
+          "lowercase",
+          "icu_folding",
+          "ngram_filter"
         ]
       }
     },
@@ -41,10 +63,21 @@
       }
     },
     "filter": {
+      "ngram_filter": {
+        "type": "ngram",
+        "min_gram": 3,
+        "max_gram": 3,
+        "token_chars": [
+          "letter",
+          "digit",
+          "punctuation",
+          "symbol"
+        ]
+      },
       "autocomplete_filter": {
         "type": "edge_ngram",
         "min_gram": 1,
-        "max_gram": 20,
+        "max_gram": 40,
         "token_chars": [
           "letter",
           "digit",

--- a/docs/upgrade/17_to_18/optimize_search.sh
+++ b/docs/upgrade/17_to_18/optimize_search.sh
@@ -7,8 +7,8 @@ set -o pipefail
 ES_HOST="http://localhost:9200"
 
 # Elasticsearch authentication
-ES_USER="your_username"
-ES_PASS="your_password"
+ES_USER=""
+ES_PASS=""
 
 if ! command -v jq &> /dev/null; then
     echo "Error: jq is not installed. Please install it and try again." >&2

--- a/modules/elasticsearch-impl/src/main/java/org/opencastproject/elasticsearch/impl/AbstractElasticsearchQueryBuilder.java
+++ b/modules/elasticsearch-impl/src/main/java/org/opencastproject/elasticsearch/impl/AbstractElasticsearchQueryBuilder.java
@@ -138,6 +138,7 @@ public abstract class AbstractElasticsearchQueryBuilder<T extends SearchQuery> i
     if (text != null) {
       MultiMatchQueryBuilder queryBuilder = QueryBuilders.multiMatchQuery(text);
       queryBuilder.field(TEXT, 1.2f);
+      queryBuilder.field("text_technical", 0.8f);
       additionalMultiQueryFields.forEach(field -> queryBuilder.field(field, 1.0f));
       queryBuilder.type(MultiMatchQueryBuilder.Type.BEST_FIELDS);
       queryBuilder.operator(Operator.AND);

--- a/modules/elasticsearch-impl/src/main/resources/elasticsearch/event-mapping.json
+++ b/modules/elasticsearch-impl/src/main/resources/elasticsearch/event-mapping.json
@@ -235,7 +235,13 @@
         "text": {
             "type" : "search_as_you_type",
             "analyzer": "autocomplete_analyzer",
-            "search_analyzer": "whitespace_analyzer"
+            "search_analyzer": "whitespace_analyzer",
+            "copy_to": "text_technical"
+        },
+        "text_technical": {
+            "type" : "search_as_you_type",
+            "analyzer": "autocomplete_analyzer_technical",
+            "search_analyzer": "whitespace_analyzer_technical"
         }
     },
     "dynamic_templates" : [

--- a/modules/elasticsearch-impl/src/main/resources/elasticsearch/indexSettings.json
+++ b/modules/elasticsearch-impl/src/main/resources/elasticsearch/indexSettings.json
@@ -21,6 +21,16 @@
           "autocomplete_filter"
         ]
       },
+      "autocomplete_analyzer_technical": {
+        "type": "custom",
+        "tokenizer": "whitespace",
+        "char_filter":["html_strip", "camel_case_filter"],
+        "filter": [
+          "lowercase",
+          "icu_folding",
+          "ngram_filter"
+        ]
+      },
       "whitespace_analyzer": {
         "type": "custom",
         "tokenizer": "whitespace",
@@ -30,6 +40,18 @@
         "filter": [
           "lowercase",
           "icu_folding"
+        ]
+      },
+      "whitespace_analyzer_technical": {
+        "type": "custom",
+        "tokenizer": "whitespace",
+        "char_filter": [
+          "camel_case_filter"
+        ],
+        "filter": [
+          "lowercase",
+          "icu_folding",
+          "ngram_filter"
         ]
       }
     },
@@ -41,10 +63,21 @@
       }
     },
     "filter": {
+      "ngram_filter": {
+        "type": "ngram",
+        "min_gram": 3,
+        "max_gram": 3,
+        "token_chars": [
+          "letter",
+          "digit",
+          "punctuation",
+          "symbol"
+        ]
+      },
       "autocomplete_filter": {
         "type": "edge_ngram",
         "min_gram": 1,
-        "max_gram": 20,
+        "max_gram": 40,
         "token_chars": [
           "letter",
           "digit",


### PR DESCRIPTION
Partially addresses #7323.

This patch attempts to address use cases 1 and 2 from the linked issue. It should allow users to search for partial strings again, without completely disregarding the benefits of the new behaviour.

This is a draft because I am by no means an expert on proper elasticsearch configuration and not sure this is a good approach actually. So I am looking for feedback! For example, I am not too happy with using ngrams analyzers as that will likely result in a lot of false positives in certain cases.

I am aware that this could not go into r/18.x, I just selected it because it is the base branch for this one. As this patch would require an index migration, it must go into develop and index migration scripts would need to go into the appropriate folders.

### How to test this patch

Test with an OC 18 installation. Use the migration script to update your index (beware that the migration script has no "undo" functionality!).


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
