### PR TITLE
Bring back language filter for events

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -3248,6 +3248,9 @@ public abstract class AbstractEventEndpoint {
       if (EventListQuery.FILTER_LOCATION_NAME.equals(name)) {
         query.withLocation(filters.get(name));
       }
+      if (EventListQuery.FILTER_LANGUAGE_NAME.equals(name)) {
+        query.withLanguage(filters.get(name));
+      }
       if (EventListQuery.FILTER_AGENT_NAME.equals(name)) {
         query.withAgentId(filters.get(name));
       }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/EventListQuery.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/EventListQuery.java
@@ -95,6 +95,7 @@ public class EventListQuery extends ResourceListQueryImpl {
     this.availableFilters.add(createSeriesFilter(Optional.empty()));
     this.availableFilters.add(createLocationFilter(Optional.empty()));
     this.availableFilters.add(createAgentFilter(Optional.empty()));
+    this.availableFilters.add(createLanguageFilter(Optional.empty()));
     this.availableFilters.add(createStartDateFilter(Optional.empty()));
     this.availableFilters.add(createStatusFilter(Optional.empty()));
     this.availableFilters.add(createCommentsFilter(Optional.empty()));


### PR DESCRIPTION
This patch allows the language filter for events in the EventListQuery to be used again.
Unfortunately I did not find when the language filter was removed and why. As far as I can tell it should be safe to add it, and would like to do so since it was requested https://github.com/opencast/opencast-admin-interface/issues/1468

### How to test this patch

Install this PR, then test the new "Language" filter in the events table (filters are next to the search field).

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
