### PR TITLE
Add language to events endpoint for admin ui events table

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -3248,6 +3248,9 @@ public abstract class AbstractEventEndpoint {
       if (EventListQuery.FILTER_LOCATION_NAME.equals(name)) {
         query.withLocation(filters.get(name));
       }
+      if (EventListQuery.FILTER_LANGUAGE_NAME.equals(name)) {
+        query.withLanguage(filters.get(name));
+      }
       if (EventListQuery.FILTER_AGENT_NAME.equals(name)) {
         query.withAgentId(filters.get(name));
       }

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -90,7 +90,10 @@ import org.opencastproject.index.service.resources.list.query.EventListQuery;
 import org.opencastproject.index.service.resources.list.query.SeriesListQuery;
 import org.opencastproject.index.service.util.JSONUtils;
 import org.opencastproject.index.service.util.RestUtils;
+import org.opencastproject.list.api.ListProviderException;
+import org.opencastproject.list.api.ListProvidersService;
 import org.opencastproject.list.api.ResourceListQuery;
+import org.opencastproject.list.impl.ResourceListQueryImpl;
 import org.opencastproject.mediapackage.Attachment;
 import org.opencastproject.mediapackage.AudioStream;
 import org.opencastproject.mediapackage.Catalog;
@@ -277,6 +280,8 @@ public abstract class AbstractEventEndpoint {
 
   public abstract UserDirectoryService getUserDirectoryService();
 
+  public abstract ListProvidersService getListProvidersService();
+
   /** Default server URL */
   protected String serverUrl = "http://localhost:8080";
 
@@ -411,7 +416,7 @@ public abstract class AbstractEventEndpoint {
     if (eventOpt.isPresent()) {
       Event event = eventOpt.get();
       event.updatePreview(getAdminUIConfiguration().getPreviewSubtype());
-      JsonObject json = eventToJSON(event, Optional.empty());
+      JsonObject json = eventToJSON(event, Optional.empty(), Optional.empty());
       return okJson(json);
     }
     return notFound("Cannot find an event with id '%s'.", id);
@@ -3387,6 +3392,14 @@ public abstract class AbstractEventEndpoint {
       return okJsonList(eventsList, Optional.ofNullable(offset).orElse(0), Optional.ofNullable(limit).orElse(0), 0);
     }
 
+    Map<String, String> languages;
+    try {
+      languages = getListProvidersService().getList("LANGUAGES", new ResourceListQueryImpl(), false);
+    } catch (ListProviderException e) {
+      logger.info("Could not get languages from listprovider");
+      throw new WebApplicationException(e);
+    }
+
     for (SearchResultItem<Event> item : results.getItems()) {
       Event source = item.getSource();
       source.updatePreview(getAdminUIConfiguration().getPreviewSubtype());
@@ -3399,7 +3412,7 @@ public abstract class AbstractEventEndpoint {
           throw new WebApplicationException(e);
         }
       }
-      eventsList.add(eventToJSON(source, Optional.ofNullable(comments)));
+      eventsList.add(eventToJSON(source, Optional.ofNullable(comments), Optional.ofNullable(languages)));
     }
 
     return okJsonList(eventsList, Optional.ofNullable(offset).orElse(0), Optional.ofNullable(limit).orElse(0),
@@ -3422,7 +3435,8 @@ public abstract class AbstractEventEndpoint {
   }
 
 
-  private JsonObject eventToJSON(Event event, Optional<List<EventComment>> comments) {
+  private JsonObject eventToJSON(Event event, Optional<List<EventComment>> comments,
+      Optional<Map<String, String>> languages) {
     JsonObject json = new JsonObject();
 
     json.addProperty("id", event.getIdentifier());
@@ -3452,6 +3466,9 @@ public abstract class AbstractEventEndpoint {
     json.addProperty("agent_id", safeString(event.getAgentId()));
     json.addProperty("technical_start", safeString(event.getTechnicalStartTime()));
     json.addProperty("technical_end", safeString(event.getTechnicalEndTime()));
+    json.addProperty("language", safeString(event.getLanguage()));
+    json.addProperty("language_translation_key", languages.isPresent()
+        ? safeString(languages.get().get(event.getLanguage())) : "");
     json.add("technical_presenters", collectionToJsonArray(event.getTechnicalPresenters()));
     json.add("publications", collectionToJsonArray(eventPublicationsToJson(event)));
     if (comments.isPresent()) {

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/OsgiEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/OsgiEventEndpoint.java
@@ -29,6 +29,7 @@ import org.opencastproject.capture.admin.api.CaptureAgentStateService;
 import org.opencastproject.elasticsearch.index.ElasticsearchIndex;
 import org.opencastproject.event.comment.EventCommentService;
 import org.opencastproject.index.service.api.IndexService;
+import org.opencastproject.list.api.ListProvidersService;
 import org.opencastproject.scheduler.api.SchedulerService;
 import org.opencastproject.security.api.AuthorizationService;
 import org.opencastproject.security.api.SecurityService;
@@ -86,6 +87,7 @@ public class OsgiEventEndpoint extends AbstractEventEndpoint {
   private WorkflowService workflowService;
   private AdminUIConfiguration adminUIConfiguration;
   private UserDirectoryService userDirectoryService;
+  private ListProvidersService listProvidersService;
 
   private long expireSeconds = UrlSigningServiceOsgiUtil.DEFAULT_URL_SIGNING_EXPIRE_DURATION;
   private Boolean signWithClientIP = UrlSigningServiceOsgiUtil.DEFAULT_SIGN_WITH_CLIENT_IP;
@@ -258,6 +260,16 @@ public class OsgiEventEndpoint extends AbstractEventEndpoint {
   @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
+  }
+
+  @Override
+  public ListProvidersService getListProvidersService() {
+    return listProvidersService;
+  }
+
+  @Reference
+  public void setListProvidersService(ListProvidersService listProvidersService) {
+    this.listProvidersService = listProvidersService;
   }
 
   @Activate

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/AbstractEventEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/AbstractEventEndpointTest.java
@@ -36,6 +36,7 @@ import org.opencastproject.elasticsearch.index.ElasticsearchIndex;
 import org.opencastproject.event.comment.EventCommentService;
 import org.opencastproject.index.service.api.IndexService;
 import org.opencastproject.index.service.util.RestUtils;
+import org.opencastproject.list.api.ListProvidersService;
 import org.opencastproject.scheduler.api.Recording;
 import org.opencastproject.scheduler.api.RecordingState;
 import org.opencastproject.scheduler.api.SchedulerService;
@@ -704,6 +705,7 @@ public class AbstractEventEndpointTest {
     private ElasticsearchIndex index;
     private UrlSigningService urlSigningService;
     private UserDirectoryService userDirectoryService;
+    private ListProvidersService listProvidersService;
 
     public WorkflowService getWorkflowService() {
       return workflowService;
@@ -823,6 +825,14 @@ public class AbstractEventEndpointTest {
 
     public UserDirectoryService getUserDirectoryService() {
       return userDirectoryService;
+    }
+
+    public void setListProvidersService(ListProvidersService listProvidersService) {
+      this.listProvidersService = listProvidersService;
+    }
+
+    public ListProvidersService getListProvidersService() {
+      return listProvidersService;
     }
 
   }

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestEventEndpoint.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestEventEndpoint.java
@@ -400,11 +400,16 @@ public class TestEventEndpoint extends AbstractEventEndpoint {
     Map<String, String> licences = new HashMap<>();
     licences.put("uuid-series1", "Series 1");
     licences.put("uuid-series2", "Series 2");
+    Map<String, String> languages = new HashMap<>();
+    languages.put("ara", "LANGUAGES.ARABIC");
 
     ListProvidersService listProvidersService = EasyMock.createNiceMock(ListProvidersService.class);
+    EasyMock.expect(listProvidersService.getList(EasyMock.eq("LANGUAGES"), EasyMock.anyObject(ResourceListQuery.class),
+        EasyMock.anyBoolean())).andReturn(languages).anyTimes();
     EasyMock.expect(listProvidersService.getList(EasyMock.anyString(), EasyMock.anyObject(ResourceListQuery.class),
       EasyMock.anyBoolean())).andReturn(licences).anyTimes();
     EasyMock.replay(listProvidersService);
+    env.setListProvidersService(listProvidersService);
 
     final IncidentTree r = new IncidentTreeImpl(
             Arrays.asList(mkIncident(Severity.INFO), mkIncident(Severity.INFO), mkIncident(Severity.INFO)),
@@ -771,5 +776,10 @@ public class TestEventEndpoint extends AbstractEventEndpoint {
   @Override
   public UserDirectoryService getUserDirectoryService() {
     return env.getUserDirectoryService();
+  }
+
+  @Override
+  public ListProvidersService getListProvidersService() {
+    return env.getListProvidersService();
   }
 }

--- a/modules/admin-ui/src/test/resources/events.json
+++ b/modules/admin-ui/src/test/resources/events.json
@@ -33,7 +33,9 @@
       "has_comments": false,
       "technical_start": "2013-03-20T04:00:00Z",
       "has_preview": false,
-      "start_date": "2013-03-20T04:00:00Z"
+      "start_date": "2013-03-20T04:00:00Z",
+      "language": "",
+      "language_translation_key": ""
     },
     {
       "technical_end": "2013-03-20T05:00:00Z",
@@ -65,7 +67,9 @@
       "has_comments": false,
       "technical_start": "2013-03-20T04:00:00Z",
       "has_preview": false,
-      "start_date": "2013-03-20T04:00:00Z"
+      "start_date": "2013-03-20T04:00:00Z",
+      "language": "",
+      "language_translation_key": ""
     },
     {
       "technical_end": "2013-03-20T05:00:00Z",
@@ -97,7 +101,9 @@
       "has_comments": false,
       "technical_start": "2013-03-20T04:00:00Z",
       "has_preview": false,
-      "start_date": "2013-03-20T04:00:00Z"
+      "start_date": "2013-03-20T04:00:00Z",
+      "language": "",
+      "language_translation_key": ""
     }
   ],
   "offset": 0

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/EventListQuery.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/EventListQuery.java
@@ -95,6 +95,7 @@ public class EventListQuery extends ResourceListQueryImpl {
     this.availableFilters.add(createSeriesFilter(Optional.empty()));
     this.availableFilters.add(createLocationFilter(Optional.empty()));
     this.availableFilters.add(createAgentFilter(Optional.empty()));
+    this.availableFilters.add(createLanguageFilter(Optional.empty()));
     this.availableFilters.add(createStartDateFilter(Optional.empty()));
     this.availableFilters.add(createStatusFilter(Optional.empty()));
     this.availableFilters.add(createCommentsFilter(Optional.empty()));


### PR DESCRIPTION
Adds the event language to the information that is returned to the admin ui for displaying the events table. The frontend can use this to display a language column in the events table.

Includes #7327.

### How to test this patch

Open the admin ui. Press F12 and go to the network tab. Check that the return values for the request `events.json?limit=10&offset=0&sort=date:DESC,uid:asc` return the new language fields.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
