### PR TITLE
Get Extended Metadata of Events from API via the Index

### DIFF
--- a/docs/guides/admin/docs/releasenotes/extended-metadata
+++ b/docs/guides/admin/docs/releasenotes/extended-metadata
@@ -1,0 +1,2 @@
+To get extended metadata from the External API, it is now required for that metadata to be indexed. If you experience
+any issues with this, you might need to run the index rebuild for the Asset Manager again.

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreMetadataCollection.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreMetadataCollection.java
@@ -143,7 +143,7 @@ public class DublinCoreMetadataCollection {
   /**
    * Set value to a metadata field of unknown type
    */
-  private static void setValueFromDCCatalog(
+  public static void setValueFromDCCatalog(
           final List<String> filteredValues,
           final MetadataField metadataField) {
     if (filteredValues.isEmpty()) {

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -1637,7 +1637,7 @@ public class EventsEndpoint implements ManagedService {
 
     if (!extendedCatalogUIAdapters.isEmpty()) {
       Map<String, Map<String, List<String>>> extendedMetadata = event.getExtendedMetadata();
-      for (EventCatalogUIAdapter catalogUIAdapter : catalogUIAdapters) {
+      for (EventCatalogUIAdapter catalogUIAdapter : extendedCatalogUIAdapters) {
         if (extendedMetadata.containsKey(catalogUIAdapter.getFlavor().toString())) {
           Map<String, List<String>> extendedMetadataByType = extendedMetadata.get(
               catalogUIAdapter.getFlavor().toString());

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -1654,7 +1654,7 @@ public class EventsEndpoint implements ManagedService {
               metadataField.setValue(null);
             }
           }
-          metadataList.add(catalogUIAdapter.getFlavor().toString(), catalogUIAdapter.getUITitle(), dublinCoreMetadata);
+          metadataList.add(catalogUIAdapter, dublinCoreMetadata);
         }
       }
     }

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -53,6 +53,7 @@ import org.opencastproject.external.util.AclUtils;
 import org.opencastproject.external.util.ExternalMetadataUtils;
 import org.opencastproject.index.service.api.IndexService;
 import org.opencastproject.index.service.catalog.adapter.DublinCoreMetadataUtil;
+import org.opencastproject.index.service.catalog.adapter.events.CommonEventCatalogUIAdapter;
 import org.opencastproject.index.service.exception.IndexServiceException;
 import org.opencastproject.index.service.impl.util.EventHttpServletRequest;
 import org.opencastproject.index.service.impl.util.EventUtils;
@@ -153,6 +154,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -1628,20 +1630,37 @@ public class EventsEndpoint implements ManagedService {
 
   protected Optional<MetadataList> getEventMetadata(Event event) throws IndexServiceException, Exception {
     MetadataList metadataList = new MetadataList();
-    List<EventCatalogUIAdapter> catalogUIAdapters = getEventCatalogUIAdapters();
-    EventCatalogUIAdapter eventCatalogUIAdapter = indexService.getCommonEventCatalogUIAdapter();
-    catalogUIAdapters.remove(eventCatalogUIAdapter);
-    if (catalogUIAdapters.size() > 0) {
-      MediaPackage mediaPackage = indexService.getEventMediapackage(event);
+
+    // Get configured extended metadata fields & fill with values from index
+    Set<EventCatalogUIAdapter> extendedCatalogUIAdapters = getEventCatalogUIAdapters().stream()
+        .filter(c -> !(c instanceof CommonEventCatalogUIAdapter)).collect(Collectors.toSet());
+
+    if (!extendedCatalogUIAdapters.isEmpty()) {
+      Map<String, Map<String, List<String>>> extendedMetadata = event.getExtendedMetadata();
       for (EventCatalogUIAdapter catalogUIAdapter : catalogUIAdapters) {
-        // TODO: This is very slow:
-        DublinCoreMetadataCollection fields = catalogUIAdapter.getFields(mediaPackage);
-        if (fields != null) {
-          ExternalMetadataUtils.removeCollectionList(fields);
-          metadataList.add(catalogUIAdapter, fields);
+        if (extendedMetadata.containsKey(catalogUIAdapter.getFlavor().toString())) {
+          Map<String, List<String>> extendedMetadataByType = extendedMetadata.get(
+              catalogUIAdapter.getFlavor().toString());
+          DublinCoreMetadataCollection dublinCoreMetadata = catalogUIAdapter.getRawFields(new EmptyResourceListQuery());
+          ExternalMetadataUtils.removeCollectionList(dublinCoreMetadata);
+          for (MetadataField metadataField: dublinCoreMetadata.getFields()) {
+            // currently doesn't consider namespaces
+            if (extendedMetadataByType.containsKey(metadataField.getInputID())) {
+              List<String> values = extendedMetadataByType.get(metadataField.getInputID());
+              // values are from index, but same format as in catalog
+              DublinCoreMetadataCollection.setValueFromDCCatalog(values, metadataField);
+            } else {
+              // overwrite any default values contained in raw fields to accurately reflect event state
+              metadataField.setValue(null);
+            }
+          }
+          metadataList.add(catalogUIAdapter.getFlavor().toString(), catalogUIAdapter.getUITitle(), dublinCoreMetadata);
         }
       }
     }
+
+    // Common metadata
+    EventCatalogUIAdapter eventCatalogUIAdapter = indexService.getCommonEventCatalogUIAdapter();
     DublinCoreMetadataCollection collection = EventUtils.getEventMetadata(event, eventCatalogUIAdapter,
         new EmptyResourceListQuery());
     ExternalMetadataUtils.changeSubjectToSubjects(collection);


### PR DESCRIPTION
Instead of reading extended metadata catalogs from disk, we can use the fact that extended metadata are in the index (#3274) to get them from there when requesting metadata from the External API. This should be significantly faster.

The returned format should be the same, which made the code a bit uglier, but means no new API version. To test, configure extended metadata and request an event from the API with `withmetadata` set.

Indexing extended metadata was first introduced in OC 13, which required an index rebuild anyway, but since there were some issues with that in the recent past (see #6984), this might require another index rebuild for the Asset Manager depending on when the last index rebuild was run.

One small caveat: The extended metadata in the index currently don't consider that one could configure two metadata fields with the same id for the same catalog, but for different namespaces. As this should be very rare, I'm not touching that right now bc we want to move away from dublincore anyway.

Fixes #7473 