### PR TITLE
Refactor docker compose service configuration

### DIFF
--- a/docs/scripts/devel-dependency-containers/docker-compose-all-sql.yml
+++ b/docs/scripts/devel-dependency-containers/docker-compose-all-sql.yml
@@ -1,6 +1,5 @@
 services:
-  elasticsearch:
-    container_name: opencast-opensearch
+  opensearch:
     image: opencast/opensearch:1
     init: true
     build:
@@ -18,7 +17,6 @@ services:
       - "DISABLE_SECURITY_PLUGIN=true" # disables security plugin entirely in OpenSearch by setting plugins.security.disabled: true in opensearch.yml
       - "discovery.type=single-node" # disables bootstrap checks that are enabled when network.host is set to a non-loopback address
   postgresql:
-    container_name: opencast-postgresql
     image: docker.io/library/postgres:13
     ports:
       - 127.0.0.1:5432:5432
@@ -27,7 +25,6 @@ services:
       POSTGRES_PASSWORD: dbpassword
       POSTGRES_DB: opencast
   mariadb:
-    container_name: opencast-mariadb
     image: docker.io/library/mariadb:10
     ports:
       - 127.0.0.1:3306:3306

--- a/docs/scripts/devel-dependency-containers/docker-compose-mariadb.yml
+++ b/docs/scripts/devel-dependency-containers/docker-compose-mariadb.yml
@@ -1,6 +1,5 @@
 services:
-  elasticsearch:
-    container_name: opencast-opensearch
+  opensearch:
     image: opencast/opensearch:1
     init: true
     build:
@@ -18,7 +17,6 @@ services:
       - "DISABLE_SECURITY_PLUGIN=true" # disables security plugin entirely in OpenSearch by setting plugins.security.disabled: true in opensearch.yml
       - "discovery.type=single-node" # disables bootstrap checks that are enabled when network.host is set to a non-loopback address
   mariadb:
-    container_name: opencast-mariadb
     image: docker.io/library/mariadb:10
     ports:
       - 127.0.0.1:3306:3306

--- a/docs/scripts/devel-dependency-containers/docker-compose-postgresql.yml
+++ b/docs/scripts/devel-dependency-containers/docker-compose-postgresql.yml
@@ -1,6 +1,5 @@
 services:
-  elasticsearch:
-    container_name: opencast-opensearch
+  opensearch:
     image: opencast/opensearch:1
     init: true
     build:
@@ -18,7 +17,6 @@ services:
       - "DISABLE_SECURITY_PLUGIN=true" # disables security plugin entirely in OpenSearch by setting plugins.security.disabled: true in opensearch.yml
       - "discovery.type=single-node" # disables bootstrap checks that are enabled when network.host is set to a non-loopback address
   postgresql:
-    container_name: opencast-postgresql
     image: docker.io/library/postgres:13
     ports:
       - 127.0.0.1:5432:5432

--- a/docs/scripts/devel-dependency-containers/docker-compose.yml
+++ b/docs/scripts/devel-dependency-containers/docker-compose.yml
@@ -1,6 +1,5 @@
 services:
-  elasticsearch:
-    container_name: opencast-opensearch
+  opensearch:
     image: opencast/opensearch:1
     init: true
     build:


### PR DESCRIPTION
- Renamed elasticsearch service to opensearch in all docker compose files
- Removed container_name from all services

This allows container and volume names to be overridden using the -p option of docker compose for better flexibility. For example, this enables running multiple instances of the same services simultaneously for different projects or testing scenarios.