### PR TITLE
Follow up on Paella 8 default player configuration

### DIFF
--- a/docs/guides/admin/docs/configuration/player/paella.player7/configuration.md
+++ b/docs/guides/admin/docs/configuration/player/paella.player7/configuration.md
@@ -1,7 +1,10 @@
 Paella Player 7
 ===============
 
-Paella 7 is Opencast's default player.
+<div class=warn>
+Paella 7 is scheduled for removal in Opencast 21.
+For the new default player, take a look at the Paella Player 8 documentation section.
+</div>
 
 The Paella `(pronounced 'paeja')` [Player](https://paellaplayer.upv.es) is an Open Source
 JavaScript video player capable of playing an unlimited number of audio & video streams

--- a/docs/guides/admin/docs/configuration/player/paella.player8/configuration.md
+++ b/docs/guides/admin/docs/configuration/player/paella.player8/configuration.md
@@ -1,6 +1,8 @@
 Paella Player 8
 ===============
 
+Paella 8 is Opencast's default player.
+
 The Paella `(pronounced 'paeja')` [Player](https://paellaplayer.webs.upv.es) is an Open Source
 JavaScript video player capable of playing an unlimited number of audio & video streams
 synchronously, Live Streaming, Zoom, Captions, contributed user plugins and a lot more.

--- a/modules/engage-ui/src/main/java/org/opencastproject/engage/ui/PlayerRedirect.java
+++ b/modules/engage-ui/src/main/java/org/opencastproject/engage/ui/PlayerRedirect.java
@@ -70,7 +70,7 @@ public class PlayerRedirect {
 
   private static final Logger logger = LoggerFactory.getLogger(PlayerRedirect.class);
 
-  private static final String PLAYER_DEFAULT = "/paella7/ui/watch.html?id=#{id}";
+  private static final String PLAYER_DEFAULT = "/paella8/ui/watch.html?id=#{id}";
 
   private SecurityService securityService;
 

--- a/modules/engage-ui/src/test/java/org/opencastproject/engage/ui/PlayerRedirectTest.java
+++ b/modules/engage-ui/src/test/java/org/opencastproject/engage/ui/PlayerRedirectTest.java
@@ -59,7 +59,7 @@ public class PlayerRedirectTest extends EasyMockSupport {
 
     try (Response response = playerRedirect.redirect(eventId)) {
       assertEquals(Response.Status.TEMPORARY_REDIRECT.getStatusCode(), response.getStatus());
-      assertEquals("/paella7/ui/watch.html?id=event1", response.getHeaderString("location"));
+      assertEquals("/paella8/ui/watch.html?id=event1", response.getHeaderString("location"));
     }
 
     verifyAll();
@@ -91,7 +91,7 @@ public class PlayerRedirectTest extends EasyMockSupport {
 
     try (Response response = playerRedirect.redirect(eventId)) {
       assertEquals(Response.Status.TEMPORARY_REDIRECT.getStatusCode(), response.getStatus());
-      assertEquals("/paella7/ui/watch.html?id=event%2520with%2520spaces", response.getHeaderString("location"));
+      assertEquals("/paella8/ui/watch.html?id=event%2520with%2520spaces", response.getHeaderString("location"));
     }
 
     verifyAll();
@@ -106,7 +106,7 @@ public class PlayerRedirectTest extends EasyMockSupport {
 
     try (Response response = playerRedirect.redirect(eventId)) {
       assertEquals(Response.Status.TEMPORARY_REDIRECT.getStatusCode(), response.getStatus());
-      assertEquals("/paella7/ui/watch.html?id=%C3%BC%C3%A4%C3%B6%C3%9F%24%25%26%2F%28%29%3D%3F%21%C2%A7",
+      assertEquals("/paella8/ui/watch.html?id=%C3%BC%C3%A4%C3%B6%C3%9F%24%25%26%2F%28%29%3D%3F%21%C2%A7",
           response.getHeaderString("location"));
     }
 


### PR DESCRIPTION
This follows up on 76358c06f3 (#7214) which made Paella 8 the default player in the configuration file. This commit completes the transition by updating the PlayerRedirect code and documentation, following the same pattern as 204ca52d97 (#4875) which made Paella 7 the default.