### PR TITLE
Update r/18.x Editor to 18.x-2026-01-29

### DIFF
--- a/modules/editor/pom.xml
+++ b/modules/editor/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <editor.url>https://github.com/opencast/opencast-editor/releases/download/18.x-2025-11-28/oc-editor-18.x-2025-11-28.tar.gz</editor.url>
-    <editor.sha256>4e6fca6a24311fcbef86b96d3a4b30724d30e79ebe2f603afb1caa4f4942da47</editor.sha256>
+    <editor.url>https://github.com/opencast/opencast-editor/releases/download/18.x-2026-01-29/oc-editor-18.x-2026-01-29.tar.gz</editor.url>
+    <editor.sha256>436c096f9c3c009ecbb7d8528eeae23948326192019410dda2cc7c4bea95f595</editor.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
Updating Opencast r/18.x Editor module to [18.x-2026-01-29](https://github.com/opencast/opencast-editor/releases/tag/18.x-2026-01-29)