### PR TITLE
Update r/19.x Editor to 19.x-2026-01-29

### DIFF
--- a/modules/editor/pom.xml
+++ b/modules/editor/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <editor.url>https://github.com/opencast/opencast-editor/releases/download/19.x-2025-12-18/oc-editor-19.x-2025-12-18.tar.gz</editor.url>
-    <editor.sha256>e43475defd5f3222c8079271e20758408b998ea947b35ac3f9e3932919e784cb</editor.sha256>
+    <editor.url>https://github.com/opencast/opencast-editor/releases/download/19.x-2026-01-29/oc-editor-19.x-2026-01-29.tar.gz</editor.url>
+    <editor.sha256>0bd24b0bb24efaca76adb3f628625065e0e43306665eb011b8b75cda2591196a</editor.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
Updating Opencast r/19.x Editor module to [19.x-2026-01-29](https://github.com/opencast/opencast-editor/releases/tag/19.x-2026-01-29)