### PR TITLE
Update develop Admin UI to 20.x-2026-01-29

### DIFF
--- a/modules/admin-ui-interface/pom.xml
+++ b/modules/admin-ui-interface/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <interface.url>https://github.com/opencast/opencast-admin-interface/releases/download/20.x-2025-12-05/oc-admin-ui-20.x-2025-12-05.tar.gz</interface.url>
-    <interface.sha256>c31680bb56e269444a005114d0d55397a8f6d79105efd61d6c9f3523775be1bf</interface.sha256>
+    <interface.url>https://github.com/opencast/opencast-admin-interface/releases/download/20.x-2026-01-29/oc-admin-ui-20.x-2026-01-29.tar.gz</interface.url>
+    <interface.sha256>b7b44ee4110b4a650bcb4a99f91f2bdc764715b399f45176217fb117f701d75b</interface.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
Updating Opencast develop Admin UI module to [20.x-2026-01-29](https://github.com/opencast/opencast-admin-interface/releases/tag/20.x-2026-01-29)