### PR TITLE
Add paella auth.html path to mh_default_org.xml

### DIFF
--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -556,7 +556,7 @@
         <value>/engage-player/</value>
         <value>/ltitools</value>
         <value>/ltitools/</value>
-        <value>/paella7/ui/auth.html</value>
+        <value>/paella*/ui/auth.html</value>
       </list>
     </property>
   </bean>

--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -556,6 +556,7 @@
         <value>/engage-player/</value>
         <value>/ltitools</value>
         <value>/ltitools/</value>
+        <value>/paella7/ui/auth.html</value>
       </list>
     </property>
   </bean>


### PR DESCRIPTION
When opening a non public video on a multi node system from the admin UI, we need this paella auth.html path or else we will get an "Access Denied".

Related PR: https://github.com/opencast/opencast/pull/7182