### PR TITLE
Switch to bash for upgrade scripts

### DIFF
--- a/docs/upgrade/17_to_18/extract_es_data.sh
+++ b/docs/upgrade/17_to_18/extract_es_data.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 set -o pipefail

--- a/docs/upgrade/17_to_18/optimize_search.sh
+++ b/docs/upgrade/17_to_18/optimize_search.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -ex
 set -o pipefail


### PR DESCRIPTION
This PR specifies bash rather than a generic /bin/sh for the 18.x upgrade scripts.  This prevents Debian based distros from using their default `/bin/sh -> dash` symlink and erroring out.

Fixes #7289

### How to test this patch

Run the scripts on a deb machine.  Without this patch they error out immediately.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] ~include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature~
