### PR TITLE
Only cache ffmpeg upstream

### DIFF
--- a/.github/workflows/maint-cache-ffmpeg.yml
+++ b/.github/workflows/maint-cache-ffmpeg.yml
@@ -17,6 +17,7 @@ jobs:
           - autobuild
     name: Get FFmpeg (${{ matrix.release }} ${{ matrix.arch }})
     runs-on: ubuntu-latest
+    if: github.repository == 'opencast/opencast'
     steps:
       - name: Install s3cmd
         run: |


### PR DESCRIPTION
This PR adds a check to make sure the ffmpeg caching GHA script only runs in opencast/opencast
