### PR TITLE
Add endpoint for batch-creating users

### DIFF
--- a/modules/userdirectory/pom.xml
+++ b/modules/userdirectory/pom.xml
@@ -120,6 +120,10 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-reload4j</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/endpoint/UserEndpoint.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/endpoint/UserEndpoint.java
@@ -27,6 +27,7 @@ import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.apache.http.HttpStatus.SC_FORBIDDEN;
 import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
 import static org.apache.http.HttpStatus.SC_NOT_FOUND;
+import static org.apache.http.HttpStatus.SC_NO_CONTENT;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.opencastproject.util.RestUtil.getEndpointUrl;
 import static org.opencastproject.util.UrlSupport.uri;
@@ -49,9 +50,11 @@ import org.opencastproject.util.doc.rest.RestQuery;
 import org.opencastproject.util.doc.rest.RestResponse;
 import org.opencastproject.util.doc.rest.RestService;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.reflect.TypeToken;
+
 import org.apache.commons.lang3.StringUtils;
-import org.json.simple.JSONArray;
-import org.json.simple.JSONValue;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -60,10 +63,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import javax.persistence.RollbackException;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
@@ -106,6 +117,18 @@ public class UserEndpoint {
   private SecurityService securityService;
 
   private String endpointBaseUrl;
+
+  private static final Gson gson = new Gson();
+
+  private class UserData {
+    private String username;
+    private String password;
+    private String name;
+    private String email;
+    private Set<String> roles;
+  }
+
+  private final Type userListType = new TypeToken<List<User>>() { }.getType();
 
   /** OSGi callback. */
   public void activate(ComponentContext cc) {
@@ -227,7 +250,7 @@ public class UserEndpoint {
   @RestQuery(
       name = "createUser",
       description = "Create a new  user",
-      returnDescription = "Location of the new ressource",
+      returnDescription = "Location of the new resource",
       restParameters = {
       @RestParameter(
         name = "username",
@@ -295,6 +318,40 @@ public class UserEndpoint {
       logger.debug("Request with malformed ROLE data: {}", roles);
       return Response.status(SC_BAD_REQUEST).build();
     }
+  }
+
+  @POST
+  @Path("/users.json")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @RestQuery(
+      name = "createUsers",
+      description = "Create a list of new users",
+      returnDescription = "If the operation succeeded or not",
+      responses = {
+          @RestResponse(
+              responseCode = SC_BAD_REQUEST,
+              description = "Malformed request syntax."),
+          @RestResponse(
+              responseCode = SC_CONFLICT,
+              description = "At least one user already existed."),
+          @RestResponse(
+              responseCode = SC_NO_CONTENT,
+              description = "Users have been created.") })
+  public Response createUsers(String body) throws UnauthorizedException {
+    logger.debug("Provided user JSON: {}", body);
+    try {
+      for (var user: parseUserData(body)) {
+        jpaUserAndRoleProvider.addUser(user);
+        logger.info("Created user {}", user.getUsername());
+      }
+    } catch (RollbackException e) {
+      logger.debug("Error storing user in database", e);
+      return Response.status(Response.Status.CONFLICT).build();
+    } catch (IllegalArgumentException e) {
+      logger.debug("Error parsing the provided JSON body", e);
+      return Response.status(Response.Status.BAD_REQUEST).entity(e.getMessage()).build();
+    }
+    return Response.status(Response.Status.CREATED).build();
   }
 
   @PUT
@@ -414,25 +471,49 @@ public class UserEndpoint {
    *          String representation of JSON array containing roles
    */
   private Set<JpaRole> parseRoles(String roles) throws IllegalArgumentException {
-    JSONArray rolesArray = null;
     /* Try parsing JSON. Return Bad Request if malformed. */
+    final String[] rolesArray;
     try {
-      rolesArray = (JSONArray) JSONValue.parseWithException(StringUtils.isEmpty(roles) ? "[]" : roles);
-    } catch (Exception e) {
+      rolesArray = gson.fromJson(StringUtils.isEmpty(roles) ? "[]" : roles, String[].class);
+    } catch (JsonSyntaxException e) {
       throw new IllegalArgumentException("Error parsing JSON array", e);
     }
 
-    Set<JpaRole> rolesSet = new HashSet<JpaRole>();
+    Set<JpaRole> rolesSet = new HashSet<>();
     /* Add given roles */
-    for (Object role : rolesArray) {
-      try {
-        rolesSet.add(new JpaRole((String) role, (JpaOrganization) securityService.getOrganization()));
-      } catch (ClassCastException e) {
-        throw new IllegalArgumentException("Error parsing array vales as String", e);
-      }
+    for (var role : rolesArray) {
+      rolesSet.add(new JpaRole(role, (JpaOrganization) securityService.getOrganization()));
     }
 
     return rolesSet;
+  }
+
+  private List<JpaUser> parseUserData(String userJson) {
+    final UserData[] userArray;
+    try {
+      userArray = gson.fromJson(userJson, UserData[].class);
+    } catch (JsonSyntaxException e) {
+      throw new IllegalArgumentException("Error parsing JSON array", e);
+    }
+
+    if (Objects.isNull(userArray)) {
+      throw new IllegalArgumentException("The JSON may not be empty or `null`");
+    }
+
+    var users = new ArrayList<JpaUser>(userArray.length);
+    var organization = (JpaOrganization) securityService.getOrganization();
+    var provider = jpaUserAndRoleProvider.getName();
+    for (var u: userArray) {
+      if (Objects.isNull(u.username)) {
+        throw new IllegalArgumentException("Field `username` may not be `null`");
+      }
+      // parse roles
+      Set<JpaRole> roles = Objects.isNull(u.roles)
+          ? Collections.emptySet()
+          : u.roles.stream().map(r -> new JpaRole(r, organization)).collect(Collectors.toSet());
+      users.add(new JpaUser(u.username, u.password, organization, u.name, u.email, provider, true, roles));
+    }
+    return users;
   }
 
 }


### PR DESCRIPTION
If you have to create a large set of users, using the current endpoint which can only create a single user at a time is very slow. For example, looking at the demo servers, it takes develop.opencast.org about 1:45h each nicht to create the 25000 users.

This patch allows you to send a single request which will create a bunch of users at once, speeding up the process significantly.

Unfortunately, the users are still added to the database one after another. But changing that would probably require larger changes. But even like this, the process becomes quite a bit faster.

This targets the legacy branch to allow all demo servers to use the same scripts. It's code related to an internal API not usually used in day to day operations with low risk of breaking anything critical, even if this patch was buggy.

### How to test this patch

```
❯ curl -u admin:opencast \
  -X POST \
  -H 'Content-type: application/json' \
  http://127.0.0.1:8080/user-utils/users.json \
  --data-raw '@users.json'
```

with `users.json` being something like:
```json
[
{"username":"a","password":"b"},
{"username":"c","password":"d","roles":["ROLE_XY"]}
]
```

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature
