### PR TITLE
Fix two Asset Manager Queries

### DIFF
--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/Database.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/Database.java
@@ -190,7 +190,7 @@ public class Database {
           Pair.of("storageId", storageId),
           Pair.of("version", version.value()),
           Pair.of("mediaPackageId", mpId)
-      );
+      ).apply(em);
 
       // Update asset
       Optional<SnapshotDtos.Medium> optSnapshot = getSnapshot(version, mpId);

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/Database.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/Database.java
@@ -376,13 +376,18 @@ public class Database {
   public Optional<AssetDtos.Full> findAssetByChecksumAndStoreAndOrg(final String checksum, final String storeId,
       final String orgId) {
     return db.execTx(em -> {
-      return namedQuery.findOpt(
+      return namedQuery.findSome(
               "Asset.findByChecksumStorageIdAndOrganizationId",
+              // limit to one result (which one doesn't matter as the checksum, storage and org ID are equal)
+              0,
+              1,
               AssetDto.class,
               Pair.of("checksum", checksum),
               Pair.of("storageId", storeId),
               Pair.of("orgId", orgId))
           .apply(em)
+          .stream()
+          .findFirst()
           .map(result -> {
             SnapshotDto snapshot = result.getSnapshot();
             return new AssetDtos.Full(


### PR DESCRIPTION
This fixes two bugs introduced with #6689 in Opencast 19:

1. **Fix missing apply in storage id update.** This breaks moving snapshots from one store to another, e.g. timed media archiver or `move-storage` operation.
2. **Fix select asset query and add limit to one result.** Selecting assets based on checksum, storage location and organization is not unique, i.e. multiple asset records over multiple snapshots could be returned. Using `findOpt` assums a single result and otherwise errors out with no result. I added an explicit limit to one result. It doesn't matter which one is returned as all asset records point to files with the same checksum.

### How to test this patch

For 1: Force a move between storage locations, e.g. with timed media archiver, `move-storage` operation or using the API directly.

For 2: Force usage of the records in the asset table, e.g.:

1. Create and ingest a mediapackage with some elements. Create multiple snapshots in that ingest workflow.
2. Start another workflow that contains the `cleanup` operation and afterwards creates a `snapshot`.

Without this patch, the second step will fail as the assets are no longer in the workspace. However, the asset manager should simply be able to reuse the already archived assets from other snapshots.

### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature
