### PR TITLE
Force a file copy when cloning mediapackage elements

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageSupport.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageSupport.java
@@ -96,7 +96,7 @@ public final class MediaPackageSupport {
             continue;
           } else if (MergeMode.Merge == mode) {
             logger.debug("Renaming element " + e.getIdentifier() + " while merging " + dest + " with " + src);
-            e.setIdentifier(null);
+            e.generateIdentifier();
             dest.add(e);
           } else if (MergeMode.Fail == mode) {
             throw new MediaPackageException("Target media package " + dest + " already contains element with id "

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/CompositeWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/CompositeWorkflowOperationHandler.java
@@ -129,9 +129,6 @@ public class CompositeWorkflowOperationHandler extends AbstractWorkflowOperation
   /** The composer service */
   private ComposerService composerService = null;
 
-  /** The local workspace */
-  private Workspace workspace = null;
-
   /**
    * Callback for the OSGi declarative services configuration.
    *

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ConcatWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ConcatWorkflowOperationHandler.java
@@ -106,9 +106,6 @@ public class ConcatWorkflowOperationHandler extends AbstractWorkflowOperationHan
   /** The composer service */
   private ComposerService composerService = null;
 
-  /** The local workspace */
-  private Workspace workspace = null;
-
   /**
    * Callback for the OSGi declarative services configuration.
    *

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ConcatWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ConcatWorkflowOperationHandler.java
@@ -299,9 +299,8 @@ public class ConcatWorkflowOperationHandler extends AbstractWorkflowOperationHan
       logger.warn("No tracks found for concating operation, skipping concatenation!");
       return createResult(mediaPackage, Action.SKIP);
     } else if (tracks.size() == 1) {
-      Track track = (Track) tracks.get(0).clone();
-      track.setIdentifier(null);
-      addNewTrack(mediaPackage, track, targetTagsOption, targetFlavor);
+      Track copiedTrack = (Track) createDerivedMediaPackageElementFrom(tracks.getFirst());
+      addNewTrack(mediaPackage, copiedTrack, targetTagsOption, targetFlavor);
       logger.info("At least two tracks are needed for the concating operation, skipping concatenation!");
       return createResult(mediaPackage, Action.SKIP);
     }

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/DemuxWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/DemuxWorkflowOperationHandler.java
@@ -76,9 +76,6 @@ public class DemuxWorkflowOperationHandler extends AbstractWorkflowOperationHand
   /** The composer service */
   private ComposerService composerService = null;
 
-  /** The local workspace */
-  private Workspace workspace = null;
-
   /**
    * Callback for the OSGi declarative services configuration.
    *

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/EncodeWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/EncodeWorkflowOperationHandler.java
@@ -78,9 +78,6 @@ public class EncodeWorkflowOperationHandler extends AbstractWorkflowOperationHan
   /** The composer service */
   private ComposerService composerService = null;
 
-  /** The local workspace */
-  private Workspace workspace = null;
-
   /**
    * Callback for the OSGi declarative services configuration.
    *

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageConvertWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageConvertWorkflowOperationHandler.java
@@ -83,9 +83,6 @@ public class ImageConvertWorkflowOperationHandler extends AbstractWorkflowOperat
   /** The composer service */
   private ComposerService composerService = null;
 
-  /** The workspace */
-  private Workspace workspace = null;
-
   /**
    * Callback for the OSGi declarative services configuration.
    *

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageToVideoWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageToVideoWorkflowOperationHandler.java
@@ -78,9 +78,6 @@ public class ImageToVideoWorkflowOperationHandler extends AbstractWorkflowOperat
   /** The composer service */
   private ComposerService composerService = null;
 
-  /** The local workspace */
-  private Workspace workspace = null;
-
   /**
    * Callback for the OSGi declarative services configuration.
    *

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageWorkflowOperationHandler.java
@@ -97,9 +97,6 @@ public class ImageWorkflowOperationHandler extends AbstractWorkflowOperationHand
   /** The composer service */
   private ComposerService composerService = null;
 
-  /** The local workspace */
-  private Workspace workspace = null;
-
   /**
    * Callback for the OSGi declarative services configuration.
    *

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/MultiEncodeWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/MultiEncodeWorkflowOperationHandler.java
@@ -87,9 +87,6 @@ public class MultiEncodeWorkflowOperationHandler extends AbstractWorkflowOperati
   /** The composer service */
   private ComposerService composerService = null;
 
-  /** The local workspace */
-  private Workspace workspace = null;
-
   @Activate
   public void activate(ComponentContext cc) {
     super.activate(cc);

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/MuxWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/MuxWorkflowOperationHandler.java
@@ -79,9 +79,6 @@ public class MuxWorkflowOperationHandler extends AbstractWorkflowOperationHandle
   /** The composer service */
   private ComposerService composerService = null;
 
-  /** The local workspace */
-  private Workspace workspace = null;
-
   /**
    * Callback for the OSGi declarative services configuration.
    *

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PartialImportWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PartialImportWorkflowOperationHandler.java
@@ -59,7 +59,6 @@ import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
 import org.opencastproject.workspace.api.Workspace;
 
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
@@ -76,8 +75,6 @@ import org.w3c.dom.smil.SMILParElement;
 import org.xml.sax.SAXException;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
@@ -841,23 +838,10 @@ public class PartialImportWorkflowOperationHandler extends AbstractWorkflowOpera
 
   private void copyPartialToSource(MediaPackage mediaPackage, MediaPackageElementFlavor targetFlavor, Track track)
           throws NotFoundException, IOException {
-    FileInputStream in = null;
-    try {
-      Track copyTrack = (Track) track.clone();
-      File originalFile = workspace.get(copyTrack.getURI());
-      in = new FileInputStream(originalFile);
-
-      copyTrack.generateIdentifier();
-      copyTrack.setURI(workspace.put(mediaPackage.getIdentifier().toString(), copyTrack.getIdentifier(),
-              FilenameUtils.getName(copyTrack.getURI().toString()), in));
-      copyTrack.setFlavor(targetFlavor);
-      copyTrack.referTo(track);
-      mediaPackage.add(copyTrack);
-      logger.info("Copied partial source element {} to {} with target flavor {}", track.toString(),
-              copyTrack.toString(), targetFlavor.toString());
-    } finally {
-      IOUtils.closeQuietly(in);
-    }
+    Track copyTrack = (Track) createDerivedMediaPackageElementFrom(track);
+    copyTrack.setFlavor(targetFlavor);
+    mediaPackage.add(copyTrack);
+    logger.info("Copied partial source element {} to {} with target flavor {}", track, copyTrack, targetFlavor);
   }
 
   /**

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PartialImportWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PartialImportWorkflowOperationHandler.java
@@ -143,9 +143,6 @@ public class PartialImportWorkflowOperationHandler extends AbstractWorkflowOpera
   /** The composer service */
   private ComposerService composerService = null;
 
-  /** The local workspace */
-  private Workspace workspace = null;
-
   /**
    * Callback for the OSGi declarative services configuration.
    *

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PrepareAVWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PrepareAVWorkflowOperationHandler.java
@@ -92,9 +92,6 @@ public class PrepareAVWorkflowOperationHandler extends AbstractWorkflowOperation
   /** The composer service */
   private ComposerService composerService = null;
 
-  /** The local workspace */
-  private Workspace workspace = null;
-
   /**
    * Callback for the OSGi declarative services configuration.
    *

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PrepareAVWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PrepareAVWorkflowOperationHandler.java
@@ -228,8 +228,7 @@ public class PrepareAVWorkflowOperationHandler extends AbstractWorkflowOperation
         }
         composedTrack = prepare(videoTrack, mediaPackage, videoOnlyEncodingProfileName);
       } else {
-        composedTrack = (Track) videoTrack.clone();
-        composedTrack.setIdentifier(null);
+        composedTrack = (Track) createDerivedMediaPackageElementFrom(videoTrack);
         mediaPackage.add(composedTrack);
       }
     } else if (videoTrack == null && audioTrack != null) {
@@ -245,8 +244,7 @@ public class PrepareAVWorkflowOperationHandler extends AbstractWorkflowOperation
         }
         composedTrack = prepare(audioTrack, mediaPackage, audioOnlyEncodingProfileName);
       } else {
-        composedTrack = (Track) audioTrack.clone();
-        composedTrack.setIdentifier(null);
+        composedTrack = (Track) createDerivedMediaPackageElementFrom(audioTrack);
         mediaPackage.add(composedTrack);
       }
     } else if (audioTrack == videoTrack) {
@@ -262,8 +260,7 @@ public class PrepareAVWorkflowOperationHandler extends AbstractWorkflowOperation
         }
         composedTrack = prepare(videoTrack, mediaPackage, audioVideoEncodingProfileName);
       } else {
-        composedTrack = (Track) videoTrack.clone();
-        composedTrack.setIdentifier(null);
+        composedTrack = (Track) createDerivedMediaPackageElementFrom(videoTrack);
         mediaPackage.add(composedTrack);
       }
     } else {

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ProcessSmilWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ProcessSmilWorkflowOperationHandler.java
@@ -99,8 +99,6 @@ public class ProcessSmilWorkflowOperationHandler extends AbstractWorkflowOperati
   private ComposerService composerService = null;
   /** The smil service to parse the smil */
   private SmilService smilService;
-  /** The local workspace */
-  private Workspace workspace = null;
 
   private Predicate<EncodingProfile> isManifestEP = p -> p.getOutputType() == EncodingProfile.MediaType.Manifest;
 
@@ -490,7 +488,7 @@ public class ProcessSmilWorkflowOperationHandler extends AbstractWorkflowOperati
 
   /**
    * Find the matching encoding profile for this track and tag by name
-   * 
+   *
    * @param track
    * @param profiles
    *          - profiles used to encode a track to multiple formats

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SanitizeAdaptiveWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SanitizeAdaptiveWorkflowOperationHandler.java
@@ -78,9 +78,6 @@ public class SanitizeAdaptiveWorkflowOperationHandler extends AbstractWorkflowOp
   private static final String PLUS = "+";
   private static final String MINUS = "-";
 
-  /** The local workspace */
-  private Workspace workspace = null;
-
   /**
    * Callback for declarative services configuration that will introduce us to the local workspace service.
    * Implementation assumes that the reference is configured as being static.

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SegmentPreviewsWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SegmentPreviewsWorkflowOperationHandler.java
@@ -100,9 +100,6 @@ public class SegmentPreviewsWorkflowOperationHandler extends AbstractWorkflowOpe
   /** The mpeg7 catalog service */
   private Mpeg7CatalogService mpeg7CatalogService = null;
 
-  /** The local workspace */
-  private Workspace workspace = null;
-
   /**
    * Callback for the OSGi declarative services configuration.
    *

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SelectStreamsWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SelectStreamsWorkflowOperationHandler.java
@@ -42,7 +42,6 @@ import org.opencastproject.workflow.api.WorkflowOperationHandler;
 import org.opencastproject.workflow.api.WorkflowOperationResult;
 import org.opencastproject.workspace.api.Workspace;
 
-import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -50,7 +49,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -408,8 +406,7 @@ public class SelectStreamsWorkflowOperationHandler extends AbstractWorkflowOpera
     } else if (!nonHiddenAudio.isPresent() || nonHiddenAudio.get() == nonHiddenVideo) {
       // It could be the case that the non-hidden video stream is also the non-hidden audio stream. In that
       // case, we don't have to mux. But have to clone it.
-      final Track clonedTrack = (Track) nonHiddenVideo.track.clone();
-      clonedTrack.setIdentifier(null);
+      final Track clonedTrack = (Track) createDerivedMediaPackageElementFrom(nonHiddenVideo.track);
       resultingTracks.add(clonedTrack);
     } else {
       // Otherwise, we mux!
@@ -436,8 +433,7 @@ public class SelectStreamsWorkflowOperationHandler extends AbstractWorkflowOpera
       ) {
         logger.debug("Add clone of track {} to mediapackage {}", t.track.getIdentifier(),
             mediaPackage.getIdentifier());
-        final Track clonedTrack = (Track) t.track.clone();
-        clonedTrack.setIdentifier(null);
+        final Track clonedTrack = (Track) createDerivedMediaPackageElementFrom(t.track);
         resultingTracks.add(clonedTrack);
       } else if (t.hasVideo() && !t.hideVideo && t.hasAudio() && t.hideAudio) {
         // If track has non-hidden video and hidden audio, hide audio and add it to the MP
@@ -582,24 +578,11 @@ public class SelectStreamsWorkflowOperationHandler extends AbstractWorkflowOpera
 
   private TrackJobResult copyTrack(final Track track) throws WorkflowOperationException {
     logger.debug("Create copy of track {}", track);
-    final Track copiedTrack = (Track) track.clone();
-    copiedTrack.generateIdentifier();
     try {
-      // Generate a new filename
-      String targetFilename = copiedTrack.getIdentifier();
-      final String extension = FilenameUtils.getExtension(track.getURI().getPath());
-      if (!extension.isEmpty()) {
-        targetFilename += "." + extension;
-      }
-
-      // Copy the files on dis and put them into the working file repository
-      final URI newUri = workspace.put(track.getMediaPackage().getIdentifier().toString(), copiedTrack.getIdentifier(),
-              targetFilename, workspace.read(track.getURI()));
-      copiedTrack.setURI(newUri);
+      final Track copiedTrack = (Track) createDerivedMediaPackageElementFrom(track);
+      return new TrackJobResult(copiedTrack, 0);
     } catch (IOException | NotFoundException e) {
       throw new WorkflowOperationException(String.format("Error while copying track %s", track.getIdentifier()), e);
     }
-
-    return new TrackJobResult(copiedTrack, 0);
   }
 }

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SelectStreamsWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SelectStreamsWorkflowOperationHandler.java
@@ -81,9 +81,6 @@ public class SelectStreamsWorkflowOperationHandler extends AbstractWorkflowOpera
   /** The composer service */
   private ComposerService composerService = null;
 
-  /** The local workspace */
-  private Workspace workspace = null;
-
   private enum AudioMuxing {
     NONE, FORCE, DUPLICATE;
 

--- a/modules/cover-image-workflowoperation/src/main/java/org/opencastproject/workflow/handler/coverimage/CoverImageWorkflowOperationHandler.java
+++ b/modules/cover-image-workflowoperation/src/main/java/org/opencastproject/workflow/handler/coverimage/CoverImageWorkflowOperationHandler.java
@@ -49,9 +49,6 @@ public class CoverImageWorkflowOperationHandler extends CoverImageWorkflowOperat
   /** The cover image service */
   private CoverImageService coverImageService;
 
-  /** The workspace service */
-  private Workspace workspace;
-
   /** Reference to the static metadata service */
   private StaticMetadataService metadataService;
 

--- a/modules/crop-workflowoperation/src/main/java/org/opencastproject/workflow/handler/crop/CropWorkflowOperationHandler.java
+++ b/modules/crop-workflowoperation/src/main/java/org/opencastproject/workflow/handler/crop/CropWorkflowOperationHandler.java
@@ -79,9 +79,6 @@ public class CropWorkflowOperationHandler extends AbstractWorkflowOperationHandl
   /** The composer service */
   private CropService cropService = null;
 
-  /** The local workspace */
-  private Workspace workspace = null;
-
   /**
    * {@inheritDoc}
    *

--- a/modules/distribution-service-streaming-wowza/src/main/java/org/opencastproject/distribution/streaming/wowza/WowzaStreamingDistributionService.java
+++ b/modules/distribution-service-streaming-wowza/src/main/java/org/opencastproject/distribution/streaming/wowza/WowzaStreamingDistributionService.java
@@ -776,7 +776,7 @@ public class WowzaStreamingDistributionService extends AbstractDistributionServi
     setTransport(track, protocol);
     track.setURI(getStreamingUri(smilUri, protocol));
     track.referTo(element);
-    track.setIdentifier(null);
+    track.generateIdentifier();
     track.setAudio(null);
     track.setVideo(null);
     track.setChecksum(null);

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/ConfigurablePublishWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/ConfigurablePublishWorkflowOperationHandler.java
@@ -333,7 +333,7 @@ public class ConfigurablePublishWorkflowOperationHandler extends ConfigurableWor
       if (elements.size() > 0) {
         for (MediaPackageElement element : elements) {
           // Make sure the mediapackage is prompted to create a new identifier for this element
-          element.setIdentifier(null);
+          element.generateIdentifier();
           PublicationImpl.addElementToPublication(publication, element);
         }
       } else {

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java
@@ -149,8 +149,6 @@ public class PublishEngageWorkflowOperationHandler extends AbstractWorkflowOpera
   /** The search service */
   private SearchService searchService = null;
 
-  private Workspace workspace;
-
   /** The server url */
   private URL serverUrl;
 

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java
@@ -452,7 +452,7 @@ public class PublishEngageWorkflowOperationHandler extends AbstractWorkflowOpera
 
         // Add published elements
         for (MediaPackageElement element : mediaPackageElements) {
-          element.setIdentifier(null);
+          element.generateIdentifier();
           PublicationImpl.addElementToPublication(publicationElement, element);
         }
 
@@ -582,7 +582,7 @@ public class PublishEngageWorkflowOperationHandler extends AbstractWorkflowOpera
           MediaPackageElement sourceElement = mp.getElementById(sourceElementId);
 
           // Make sure the mediapackage is prompted to create a new identifier for this element
-          distributedElement.setIdentifier(null);
+          distributedElement.generateIdentifier();
           if (sourceElement != null) {
             // Adjust the flavor and tags for downloadable elements
             if (downloadElementIds.contains(sourceElementId)) {

--- a/modules/execute-workflowoperation/src/main/java/org/opencastproject/execute/operation/handler/ExecuteManyWorkflowOperationHandler.java
+++ b/modules/execute-workflowoperation/src/main/java/org/opencastproject/execute/operation/handler/ExecuteManyWorkflowOperationHandler.java
@@ -131,9 +131,6 @@ public class ExecuteManyWorkflowOperationHandler extends AbstractWorkflowOperati
   /** Reference to the media inspection service */
   private MediaInspectionService inspectionService = null;
 
-  /** The workspace service */
-  protected Workspace workspace;
-
   /**
    * {@inheritDoc}
    *

--- a/modules/execute-workflowoperation/src/main/java/org/opencastproject/execute/operation/handler/ExecuteOnceWorkflowOperationHandler.java
+++ b/modules/execute-workflowoperation/src/main/java/org/opencastproject/execute/operation/handler/ExecuteOnceWorkflowOperationHandler.java
@@ -114,9 +114,6 @@ public class ExecuteOnceWorkflowOperationHandler extends AbstractWorkflowOperati
   /** Reference to the media inspection service */
   private MediaInspectionService inspectionService = null;
 
-  /** The workspace service */
-  protected Workspace workspace;
-
   /**
    * {@inheritDoc}
    *
@@ -265,7 +262,7 @@ public class ExecuteOnceWorkflowOperationHandler extends AbstractWorkflowOperati
 
   /**
    * {@inheritDoc}
-   * 
+   *
    * @see org.opencastproject.workflow.api.WorkflowOperationHandler#skip(
    *      org.opencastproject.workflow.api.WorkflowInstance, JobContext)
    */
@@ -292,7 +289,7 @@ public class ExecuteOnceWorkflowOperationHandler extends AbstractWorkflowOperati
 
   /**
    * Sets the service
-   * 
+   *
    * @param service
    */
   @Reference
@@ -302,7 +299,7 @@ public class ExecuteOnceWorkflowOperationHandler extends AbstractWorkflowOperati
 
   /**
    * Sets a reference to the workspace service.
-   * 
+   *
    * @param workspace
    */
   @Reference
@@ -312,7 +309,7 @@ public class ExecuteOnceWorkflowOperationHandler extends AbstractWorkflowOperati
 
   /**
    * Sets the media inspection service
-   * 
+   *
    * @param mediaInspectionService
    *          an instance of the media inspection service
    */

--- a/modules/inspection-workflowoperation/src/main/java/org/opencastproject/workflow/handler/inspection/InspectWorkflowOperationHandler.java
+++ b/modules/inspection-workflowoperation/src/main/java/org/opencastproject/workflow/handler/inspection/InspectWorkflowOperationHandler.java
@@ -103,9 +103,6 @@ public class InspectWorkflowOperationHandler extends AbstractWorkflowOperationHa
   /** The dublin core catalog service */
   private DublinCoreCatalogService dcService;
 
-  /** The local workspace */
-  private Workspace workspace;
-
   @Reference
   public void setDublincoreService(DublinCoreCatalogService dcService) {
     this.dcService = dcService;

--- a/modules/metadata-to-acl-workflowoperation/src/main/java/org/opencastproject/workflow/handler/metadatatoacl/MetadataToAclWorkflowOperationHandler.java
+++ b/modules/metadata-to-acl-workflowoperation/src/main/java/org/opencastproject/workflow/handler/metadatatoacl/MetadataToAclWorkflowOperationHandler.java
@@ -77,7 +77,6 @@ public class MetadataToAclWorkflowOperationHandler extends AbstractWorkflowOpera
 
   private AuthorizationService authorizationService;
   private UserDirectoryService userDirectory;
-  private Workspace workspace;
 
   @Override
   public WorkflowOperationResult start(WorkflowInstance workflowInstance, JobContext context)

--- a/modules/rename-files-workflowoperation/src/main/java/org/opencastproject/workflow/handler/rename/RenameFilesWorkflowOperationHandler.java
+++ b/modules/rename-files-workflowoperation/src/main/java/org/opencastproject/workflow/handler/rename/RenameFilesWorkflowOperationHandler.java
@@ -70,9 +70,6 @@ public class RenameFilesWorkflowOperationHandler extends AbstractWorkflowOperati
   /** The logging facility */
   private static final Logger logger = LoggerFactory.getLogger(RenameFilesWorkflowOperationHandler.class);
 
-  /** The local workspace */
-  private Workspace workspace = null;
-
   /**
    * Callback for declarative services configuration that will introduce us to the local workspace service.
    * Implementation assumes that the reference is configured as being static.

--- a/modules/smil-workflowoperation/src/main/java/org/opencastproject/workflow/handler/smil/CutMarksToSmilWorkflowOperationHandler.java
+++ b/modules/smil-workflowoperation/src/main/java/org/opencastproject/workflow/handler/smil/CutMarksToSmilWorkflowOperationHandler.java
@@ -94,9 +94,6 @@ public class CutMarksToSmilWorkflowOperationHandler extends AbstractWorkflowOper
   /** The logging facility */
   private static final Logger logger = LoggerFactory.getLogger(CutMarksToSmilWorkflowOperationHandler.class);
 
-  /** The local workspace */
-  private Workspace workspace = null;
-
   /**
    * Callback for declarative services configuration that will introduce us to the local workspace service.
    * Implementation assumes that the reference is configured as being static.

--- a/modules/speech-to-text-workflowoperation/src/main/java/org/opencastproject/workflow/handler/speechtotext/SpeechToTextAttachWorkflowOperationHandler.java
+++ b/modules/speech-to-text-workflowoperation/src/main/java/org/opencastproject/workflow/handler/speechtotext/SpeechToTextAttachWorkflowOperationHandler.java
@@ -79,9 +79,6 @@ public class SpeechToTextAttachWorkflowOperationHandler extends AbstractWorkflow
     attachment, track
   }
 
-  /** The workspace service. */
-  private Workspace workspace;
-
   /** The inspection service. */
   private MediaInspectionService mediaInspectionService;
 

--- a/modules/speech-to-text-workflowoperation/src/main/java/org/opencastproject/workflow/handler/speechtotext/SpeechToTextWorkflowOperationHandler.java
+++ b/modules/speech-to-text-workflowoperation/src/main/java/org/opencastproject/workflow/handler/speechtotext/SpeechToTextWorkflowOperationHandler.java
@@ -133,9 +133,6 @@ public class
   /** The speech-to-text service. */
   private SpeechToTextService speechToTextService = null;
 
-  /** The workspace service. */
-  private Workspace workspace;
-
   /** The inspection service. */
   private MediaInspectionService mediaInspectionService;
 

--- a/modules/subtitle-timeshift-workflowoperation/src/main/java/org/opencastproject/workflow/handler/subtitletimeshift/SubtitleTimeshiftWorkflowOperationHandler.java
+++ b/modules/subtitle-timeshift-workflowoperation/src/main/java/org/opencastproject/workflow/handler/subtitletimeshift/SubtitleTimeshiftWorkflowOperationHandler.java
@@ -87,12 +87,6 @@ public class SubtitleTimeshiftWorkflowOperationHandler extends AbstractWorkflowO
   private static final Logger logger = LoggerFactory.getLogger(SubtitleTimeshiftWorkflowOperationHandler.class);
 
   /**
-   * Reference to the workspace service
-   */
-  private Workspace workspace = null;
-
-
-  /**
    * OSGi setter for the workspace class
    *
    * @param workspace an instance of the workspace

--- a/modules/textanalyzer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/textanalyzer/TextAnalysisWorkflowOperationHandler.java
+++ b/modules/textanalyzer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/textanalyzer/TextAnalysisWorkflowOperationHandler.java
@@ -121,9 +121,6 @@ public class TextAnalysisWorkflowOperationHandler extends AbstractWorkflowOperat
   /** The stability threshold */
   private int stabilityThreshold = DEFAULT_STABILITY_THRESHOLD;
 
-  /** The local workspace */
-  private Workspace workspace = null;
-
   /** The mpeg7 catalog service */
   private Mpeg7CatalogService mpeg7CatalogService = null;
 

--- a/modules/textanalyzer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/textanalyzer/TextAnalysisWorkflowOperationHandler.java
+++ b/modules/textanalyzer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/textanalyzer/TextAnalysisWorkflowOperationHandler.java
@@ -360,7 +360,7 @@ public class TextAnalysisWorkflowOperationHandler extends AbstractWorkflowOperat
         // Put the catalog into the workspace and add it to the media package
         MediaPackageElementBuilder builder = MediaPackageElementBuilderFactory.newInstance().newElementBuilder();
         Catalog catalog = (Catalog) builder.newElement(MediaPackageElement.Type.Catalog, MediaPackageElements.TEXTS);
-        catalog.setIdentifier(null);
+        catalog.generateIdentifier();
         catalog.setReference(segmentCatalog.getReference());
         mediaPackage.add(catalog); // the catalog now has an ID, so we can store the file properly
         InputStream in = mpeg7CatalogService.serialize(textCatalog);

--- a/modules/themes-workflowoperation/src/main/java/org/opencastproject/workflow/handler/themes/ThemeWorkflowOperationHandler.java
+++ b/modules/themes-workflowoperation/src/main/java/org/opencastproject/workflow/handler/themes/ThemeWorkflowOperationHandler.java
@@ -124,9 +124,6 @@ public class ThemeWorkflowOperationHandler extends AbstractWorkflowOperationHand
   /** The static file service */
   private StaticFileService staticFileService;
 
-  /** The workspace */
-  private Workspace workspace;
-
   /** OSGi callback for the series service. */
   @Reference
   public void setSeriesService(SeriesService seriesService) {

--- a/modules/timelinepreviews-workflowoperation/src/main/java/org/opencastproject/workflow/handler/timelinepreviews/TimelinePreviewsWorkflowOperationHandler.java
+++ b/modules/timelinepreviews-workflowoperation/src/main/java/org/opencastproject/workflow/handler/timelinepreviews/TimelinePreviewsWorkflowOperationHandler.java
@@ -101,9 +101,6 @@ public class TimelinePreviewsWorkflowOperationHandler extends AbstractWorkflowOp
   /** The timeline previews service. */
   private TimelinePreviewsService timelinePreviewsService = null;
 
-  /** The workspace service. */
-  private Workspace workspace = null;
-
   @Override
   @Activate
   public void activate(ComponentContext cc) {

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AmberscriptAttachTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AmberscriptAttachTranscriptionOperationHandler.java
@@ -70,8 +70,6 @@ public class AmberscriptAttachTranscriptionOperationHandler extends AbstractWork
   private TranscriptionService service = null;
   private CaptionService captionService;
 
-  private Workspace workspace;
-
   @Override
   @Activate
   protected void activate(ComponentContext cc) {

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AttachTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AttachTranscriptionOperationHandler.java
@@ -69,7 +69,6 @@ public class AttachTranscriptionOperationHandler extends AbstractWorkflowOperati
 
   /** The transcription service */
   private TranscriptionService service = null;
-  private Workspace workspace;
   private CaptionService captionService;
 
   @Override

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/GoogleSpeechAttachTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/GoogleSpeechAttachTranscriptionOperationHandler.java
@@ -76,7 +76,6 @@ public class GoogleSpeechAttachTranscriptionOperationHandler extends AbstractWor
    * The transcription service
    */
   private TranscriptionService service = null;
-  private Workspace workspace;
   private CaptionService captionService;
 
   @Override

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/MicrosoftAzureStartTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/MicrosoftAzureStartTranscriptionOperationHandler.java
@@ -84,8 +84,6 @@ public class MicrosoftAzureStartTranscriptionOperationHandler extends AbstractWo
   private TranscriptionService service = null;
   /** The composer service. */
   private ComposerService composerService;
-  /** The workspace. */
-  private Workspace workspace;
 
   /** The configuration options for this handler */
   private static final SortedMap<String, String> CONFIG_OPTIONS;

--- a/modules/videoeditor-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videoeditor/SilenceDetectionWorkflowOperationHandler.java
+++ b/modules/videoeditor-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videoeditor/SilenceDetectionWorkflowOperationHandler.java
@@ -112,9 +112,6 @@ public class SilenceDetectionWorkflowOperationHandler extends AbstractWorkflowOp
   /** The smil service for smil parsing. */
   private SmilService smilService;
 
-  /** The workspace. */
-  private Workspace workspace;
-
   @Override
   public WorkflowOperationResult start(WorkflowInstance workflowInstance, JobContext context)
           throws WorkflowOperationException {

--- a/modules/videoeditor-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videoeditor/VideoEditorWorkflowOperationHandler.java
+++ b/modules/videoeditor-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videoeditor/VideoEditorWorkflowOperationHandler.java
@@ -361,15 +361,18 @@ public class VideoEditorWorkflowOperationHandler extends ResumableWorkflowOperat
 
     Collection<Track> sourceTracks = trackSelector.select(mp, false);
 
-    for (Track sourceTrack : sourceTracks) {
-      // Set target track flavor
-      Track clonedTrack = (Track) sourceTrack.clone();
-      clonedTrack.setIdentifier(null);
-      // Use the same URI as the original
-      clonedTrack.setURI(sourceTrack.getURI());
-      clonedTrack
-              .setFlavor(new MediaPackageElementFlavor(sourceTrack.getFlavor().getType(), targetFlavorSubTypeProperty));
-      mp.addDerived(clonedTrack, sourceTrack);
+    try {
+      for (Track sourceTrack : sourceTracks) {
+        // Set target track flavor
+        Track clonedTrack = (Track) createDerivedMediaPackageElementFrom(sourceTrack);
+        clonedTrack.setFlavor(new MediaPackageElementFlavor(
+            sourceTrack.getFlavor().getType(),
+            targetFlavorSubTypeProperty
+        ));
+        mp.addDerived(clonedTrack, sourceTrack);
+      }
+    } catch (NotFoundException | IOException e) {
+      throw new WorkflowOperationException(e);
     }
 
     return createResult(mp, Action.SKIP);

--- a/modules/videoeditor-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videoeditor/VideoEditorWorkflowOperationHandler.java
+++ b/modules/videoeditor-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videoeditor/VideoEditorWorkflowOperationHandler.java
@@ -139,10 +139,6 @@ public class VideoEditorWorkflowOperationHandler extends ResumableWorkflowOperat
    * The VideoEditor service to edit files.
    */
   private VideoEditorService videoEditorService;
-  /**
-   * The workspace.
-   */
-  private Workspace workspace;
 
   @Override
   @Activate

--- a/modules/videoeditor-workflowoperation/src/test/java/org/opencastproject/workflow/handler/videoeditor/VideoEditorWorkflowOperationHandlerTest.java
+++ b/modules/videoeditor-workflowoperation/src/test/java/org/opencastproject/workflow/handler/videoeditor/VideoEditorWorkflowOperationHandlerTest.java
@@ -191,11 +191,17 @@ public class VideoEditorWorkflowOperationHandlerTest {
   }
 
   @Test
-  public void testEditorOperationSkip() throws WorkflowOperationException {
+  public void testEditorOperationSkip() throws WorkflowOperationException, NotFoundException, IOException {
+    EasyMock.expect(workspaceMock.put((String) EasyMock.anyObject(), (String) EasyMock.anyObject(),
+        (String) EasyMock.anyObject(), (InputStream) EasyMock.anyObject()))
+        .andReturn(URI.create("http://localhost:8080/foo/presenter.mp4"));
+    EasyMock.replay(workspaceMock);
+
     WorkflowInstance workflowInstance = getWorkflowInstance(mp, getDefaultConfiguration(true));
     WorkflowOperationResult result = videoEditorWorkflowOperationHandler.skip(workflowInstance, null);
     Assert.assertNotNull(
         "VideoEditor workflow operation returns null but should be an instantiated WorkflowOperationResult", result);
+    EasyMock.verify(workspaceMock);
 
     // mediapackage should contain new derived track with flavor given by "target-flavor-subtype" configuration
     WorkflowOperationInstance worflowOperationInstance = workflowInstance.getCurrentOperation();
@@ -218,11 +224,17 @@ public class VideoEditorWorkflowOperationHandlerTest {
   }
 
   @Test
-  public void testEditorOperationInteractiveSkip() throws WorkflowOperationException {
+  public void testEditorOperationInteractiveSkip() throws WorkflowOperationException, NotFoundException, IOException {
+    EasyMock.expect(workspaceMock.put((String) EasyMock.anyObject(), (String) EasyMock.anyObject(),
+            (String) EasyMock.anyObject(), (InputStream) EasyMock.anyObject()))
+        .andReturn(URI.create("http://localhost:8080/foo/presenter.mp4"));
+    EasyMock.replay(workspaceMock);
+
     WorkflowInstance workflowInstance = getWorkflowInstance(mp, getDefaultConfiguration(false));
     WorkflowOperationResult result = videoEditorWorkflowOperationHandler.start(workflowInstance, null);
     Assert.assertNotNull(
         "VideoEditor workflow operation returns null but should be an instantiated WorkflowOperationResult", result);
+    EasyMock.verify(workspaceMock);
 
     // mediapackage should contain new derived track with flavor given by "target-flavor-subtype" configuration
     WorkflowOperationInstance worflowOperationInstance = workflowInstance.getCurrentOperation();

--- a/modules/videogrid-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videogrid/VideoGridWorkflowOperationHandler.java
+++ b/modules/videogrid-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videogrid/VideoGridWorkflowOperationHandler.java
@@ -131,7 +131,6 @@ public class VideoGridWorkflowOperationHandler extends AbstractWorkflowOperation
   };
 
   /** Services */
-  private Workspace workspace = null;
   private VideoGridService videoGridService = null;
   private MediaInspectionService inspectionService = null;
   private ComposerService composerService = null;

--- a/modules/videosegmenter-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videosegmenter/VideoSegmenterWorkflowOperationHandler.java
+++ b/modules/videosegmenter-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videosegmenter/VideoSegmenterWorkflowOperationHandler.java
@@ -85,9 +85,6 @@ public class VideoSegmenterWorkflowOperationHandler extends AbstractWorkflowOper
   /** The composer service */
   private VideoSegmenterService videosegmenter = null;
 
-  /** The local workspace */
-  private Workspace workspace = null;
-
   /**
    * {@inheritDoc}
    *

--- a/modules/waveform-workflowoperation/src/main/java/org/opencastproject/workflow/handler/waveform/WaveformWorkflowOperationHandler.java
+++ b/modules/waveform-workflowoperation/src/main/java/org/opencastproject/workflow/handler/waveform/WaveformWorkflowOperationHandler.java
@@ -106,9 +106,6 @@ public class WaveformWorkflowOperationHandler extends AbstractWorkflowOperationH
   /** The waveform service. */
   private WaveformService waveformService = null;
 
-  /** The workspace service. */
-  private Workspace workspace = null;
-
   @Override
   public void activate(ComponentContext cc) {
     super.activate(cc);

--- a/modules/workflow-service-api/pom.xml
+++ b/modules/workflow-service-api/pom.xml
@@ -21,6 +21,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-workspace-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/AbstractWorkflowOperationHandler.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/AbstractWorkflowOperationHandler.java
@@ -30,6 +30,7 @@ import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElement;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
+import org.opencastproject.util.NotFoundException;
 import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
 import org.opencastproject.workspace.api.Workspace;
 
@@ -42,6 +43,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -146,6 +148,21 @@ public abstract class AbstractWorkflowOperationHandler implements WorkflowOperat
       }
     }
     return list;
+  }
+
+  protected MediaPackageElement createDerivedMediaPackageElementFrom(MediaPackageElement source)
+          throws NotFoundException, IOException {
+    MediaPackageElement derived = (MediaPackageElement) source.clone();
+    derived.generateIdentifier();
+    derived.referTo(source);
+    // copy file
+    derived.setURI(workspace.put(
+        source.getMediaPackage().getIdentifier().toString(),
+        derived.getIdentifier(),
+        getFileNameFromElements(source, derived),
+        workspace.read(source.getURI())
+    ));
+    return derived;
   }
 
   /**

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/AbstractWorkflowOperationHandler.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/AbstractWorkflowOperationHandler.java
@@ -31,6 +31,7 @@ import org.opencastproject.mediapackage.MediaPackageElement;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
 import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
+import org.opencastproject.workspace.api.Workspace;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -63,6 +64,9 @@ public abstract class AbstractWorkflowOperationHandler implements WorkflowOperat
 
   /** Optional service registry */
   protected ServiceRegistry serviceRegistry = null;
+
+  /** Optional workspace */
+  protected Workspace workspace = null;
 
   /** The JobBarrier polling interval */
   private long jobBarrierPollingInterval = JobBarrier.DEFAULT_POLLING_INTERVAL;

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/AddCatalogWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/AddCatalogWorkflowOperationHandler.java
@@ -85,9 +85,6 @@ public class AddCatalogWorkflowOperationHandler extends AbstractWorkflowOperatio
   /** The mimetype of the added catalogs */
   private static final MimeType CATALOG_MIME_TYPE = MimeType.mimeType("text", "xml");
 
-  /** The workspace, where the catalog files are put. */
-  private Workspace workspace;
-
   /**
    * Sets the workspace to use.
    *

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/CleanupWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/CleanupWorkflowOperationHandler.java
@@ -86,11 +86,6 @@ public class CleanupWorkflowOperationHandler extends AbstractWorkflowOperationHa
   /** Time to wait in seconds before removing files */
   public static final String DELAY = "delay";
 
-  /**
-   * The workspace to use in retrieving and storing files.
-   */
-  protected Workspace workspace;
-
   /** The http client to use when connecting to remote servers */
   protected TrustedHttpClient client = null;
 

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/CloneWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/CloneWorkflowOperationHandler.java
@@ -28,8 +28,6 @@ import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.mediapackage.selector.AbstractMediaPackageElementSelector;
 import org.opencastproject.mediapackage.selector.SimpleElementSelector;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
-import org.opencastproject.util.Checksum;
-import org.opencastproject.util.ChecksumType;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
 import org.opencastproject.workflow.api.ConfiguredTagsAndFlavors;
@@ -41,16 +39,13 @@ import org.opencastproject.workflow.api.WorkflowOperationResult;
 import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
 import org.opencastproject.workspace.api.Workspace;
 
-import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.io.IOException;
-import java.net.URI;
 import java.util.Collection;
 import java.util.List;
 
@@ -168,36 +163,22 @@ public class CloneWorkflowOperationHandler extends AbstractWorkflowOperationHand
   }
 
   private MediaPackageElement copyElement(MediaPackageElement element) throws WorkflowOperationException {
-    MediaPackageElement newElement = (MediaPackageElement) element.clone();
-    newElement.generateIdentifier();
+    MediaPackageElement derivedElement;
+    String sourceFilePath = null;
+    String derivedFilePath;
 
-    File sourceFile = null;
-    String toFileName = null;
     try {
-      URI sourceURI = element.getURI();
-      sourceFile = workspace.get(sourceURI);
-
-      toFileName = newElement.getIdentifier();
-      String extension = FilenameUtils.getExtension(sourceFile.getName());
-      if (!"".equals(extension)) {
-        toFileName += "." + extension;
-      }
-
-      logger.debug("Start copying element {} to target {}.", sourceFile.getPath(), toFileName);
-
-      URI newUri = workspace.put(element.getMediaPackage().getIdentifier().toString(), newElement.getIdentifier(),
-              toFileName, workspace.read(sourceURI));
-      newElement.setURI(newUri);
-      newElement.setChecksum(Checksum.create(ChecksumType.DEFAULT_TYPE, workspace.get(newUri)));
-
-      logger.debug("Element {} copied to target {}.", sourceFile.getPath(), toFileName);
+      derivedElement = createDerivedMediaPackageElementFrom(element);
+      sourceFilePath = workspace.get(element.getURI()).getPath();
+      derivedFilePath = workspace.get(derivedElement.getURI()).getPath();
+      logger.debug("Element {} copied to target {}.", sourceFilePath, derivedFilePath);
     } catch (IOException e) {
-      throw new WorkflowOperationException("Unable to copy " + sourceFile.getPath() + " to " + toFileName + ".", e);
+      throw new WorkflowOperationException("Unable to copy " + sourceFilePath, e);
     } catch (NotFoundException e) {
       throw new WorkflowOperationException("Unable to find " + element.getURI() + " in the workspace", e);
     }
 
-    return newElement;
+    return derivedElement;
   }
 
   @Reference

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/CloneWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/CloneWorkflowOperationHandler.java
@@ -79,9 +79,6 @@ public class CloneWorkflowOperationHandler extends AbstractWorkflowOperationHand
   /** The logging facility */
   private static final Logger logger = LoggerFactory.getLogger(CloneWorkflowOperationHandler.class);
 
-  /** The workspace reference */
-  protected Workspace workspace = null;
-
   /**
    * Callback for the OSGi environment to set the workspace reference.
    *

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ConfigureByDublinCoreTermWOH.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ConfigureByDublinCoreTermWOH.java
@@ -78,9 +78,6 @@ public class ConfigureByDublinCoreTermWOH extends ResumableWorkflowOperationHand
   /** Name of the configuration option that provides the copy boolean we are looking for */
   public static final String COPY_PROPERTY = "copy";
 
-  /** The local workspace */
-  private Workspace workspace = null;
-
   /**
    * Callback for declarative services configuration that will introduce us to the local workspace service.
    * Implementation assumes that the reference is configured as being static.

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/CopyWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/CopyWorkflowOperationHandler.java
@@ -83,9 +83,6 @@ public class CopyWorkflowOperationHandler extends AbstractWorkflowOperationHandl
   /** The logging facility */
   private static final Logger logger = LoggerFactory.getLogger(CopyWorkflowOperationHandler.class);
 
-  /** The workspace reference */
-  protected Workspace workspace = null;
-
   /**
    * Callback for the OSGi environment to set the workspace reference.
    *

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DuplicateEventWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DuplicateEventWorkflowOperationHandler.java
@@ -169,9 +169,6 @@ public class DuplicateEventWorkflowOperationHandler extends AbstractWorkflowOper
   /** AssetManager to use for creating new media packages. */
   private AssetManager assetManager;
 
-  /** The workspace to use for retrieving and storing files. */
-  protected Workspace workspace;
-
   /** The distribution service */
   protected DistributionService distributionService;
 

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DuplicateEventWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DuplicateEventWorkflowOperationHandler.java
@@ -441,11 +441,8 @@ public class DuplicateEventWorkflowOperationHandler extends AbstractWorkflowOper
     });
   }
 
-  private void updateTags(
-      MediaPackageElement element,
-      ConfiguredTagsAndFlavors.TargetTags targetTags) {
-    element.setIdentifier(null);
-
+  private void updateTags(MediaPackageElement element, ConfiguredTagsAndFlavors.TargetTags targetTags) {
+    element.generateIdentifier();
     applyTargetTagsToElement(targetTags, element);
   }
 
@@ -504,7 +501,7 @@ public class DuplicateEventWorkflowOperationHandler extends AbstractWorkflowOper
           final URI tmpUri = workspace.put(destination.getIdentifier().toString(), element.getIdentifier(),
               FilenameUtils.getName(element.getURI().toString()), inputStream);
           temporaryFiles.add(tmpUri);
-          element.setIdentifier(null);
+          element.generateIdentifier();
           element.setURI(tmpUri);
         }
 
@@ -543,7 +540,7 @@ public class DuplicateEventWorkflowOperationHandler extends AbstractWorkflowOper
       final Date creationDate
   ) throws WorkflowOperationException {
     final DublinCoreCatalog destinationDublinCore = DublinCoreUtil.loadEpisodeDublinCore(workspace, source).get();
-    destinationDublinCore.setIdentifier(null);
+    destinationDublinCore.generateIdentifier();
     destinationDublinCore.setURI(sourceDublinCore.getURI());
     destinationDublinCore.set(DublinCore.PROPERTY_CREATED,
         OpencastMetadataCodec.encodeDate(creationDate, Precision.Second));

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ExportWorkflowPropertiesWOH.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ExportWorkflowPropertiesWOH.java
@@ -82,9 +82,6 @@ public class ExportWorkflowPropertiesWOH extends AbstractWorkflowOperationHandle
   /** The logging facility */
   private static final Logger logger = LoggerFactory.getLogger(ExportWorkflowPropertiesWOH.class);
 
-  /** The workspace */
-  private Workspace workspace;
-
   /** OSGi DI */
   @Reference
   void setWorkspace(Workspace workspace) {

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ImportWorkflowPropertiesWOH.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ImportWorkflowPropertiesWOH.java
@@ -76,9 +76,6 @@ public class ImportWorkflowPropertiesWOH extends AbstractWorkflowOperationHandle
 
   private static final Logger logger = LoggerFactory.getLogger(ImportWorkflowPropertiesWOH.class);
 
-  /* Service references */
-  private Workspace workspace;
-
   /** OSGi DI */
   @Reference
   void setWorkspace(Workspace workspace) {

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/SeriesWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/SeriesWorkflowOperationHandler.java
@@ -113,9 +113,6 @@ public class SeriesWorkflowOperationHandler extends AbstractWorkflowOperationHan
   /** The series service */
   private SeriesService seriesService;
 
-  /** The workspace */
-  private Workspace workspace;
-
   /** The security service */
   private SecurityService securityService;
 

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TagByDublinCoreTermWOH.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TagByDublinCoreTermWOH.java
@@ -89,9 +89,6 @@ public class TagByDublinCoreTermWOH extends ResumableWorkflowOperationHandlerBas
   /** Name of the configuration option that provides the copy boolean we are looking for */
   public static final String COPY_PROPERTY = "copy";
 
-  /** The local workspace */
-  private Workspace workspace = null;
-
   /**
    * Callback for declarative services configuration that will introduce us to the local workspace service.
    * Implementation assumes that the reference is configured as being static.

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TagByDublinCoreTermWOH.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TagByDublinCoreTermWOH.java
@@ -32,6 +32,7 @@ import org.opencastproject.mediapackage.selector.SimpleElementSelector;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
 import org.opencastproject.metadata.dublincore.DublinCoreUtil;
 import org.opencastproject.metadata.dublincore.DublinCoreValue;
+import org.opencastproject.util.NotFoundException;
 import org.opencastproject.workflow.api.ConfiguredTagsAndFlavors;
 import org.opencastproject.workflow.api.WorkflowInstance;
 import org.opencastproject.workflow.api.WorkflowOperationException;
@@ -48,6 +49,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
@@ -169,9 +171,11 @@ public class TagByDublinCoreTermWOH extends ResumableWorkflowOperationHandlerBas
           MediaPackageElement element = e;
 
           if (copy) {
-            element = (MediaPackageElement) e.clone();
-            element.setIdentifier(null);
-            element.setURI(e.getURI()); // use the same URI as the original
+            try {
+              element = createDerivedMediaPackageElementFrom(e);
+            } catch (NotFoundException | IOException ex) {
+              throw new WorkflowOperationException(ex);
+            }
           }
           if (!configuredTargetFlavor.isEmpty()) {
             element.setFlavor(configuredTargetFlavor.get(0));

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TagWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TagWorkflowOperationHandler.java
@@ -27,6 +27,7 @@ import org.opencastproject.mediapackage.MediaPackageElement;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.mediapackage.selector.SimpleElementSelector;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
+import org.opencastproject.util.NotFoundException;
 import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
 import org.opencastproject.workflow.api.ConfiguredTagsAndFlavors;
 import org.opencastproject.workflow.api.WorkflowInstance;
@@ -42,6 +43,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
@@ -121,9 +123,11 @@ public class TagWorkflowOperationHandler extends AbstractWorkflowOperationHandle
     for (MediaPackageElement e : elements) {
       MediaPackageElement element = e;
       if (copy) {
-        element = (MediaPackageElement) e.clone();
-        element.setIdentifier(null);
-        element.setURI(e.getURI()); // use the same URI as the original
+        try {
+          element = createDerivedMediaPackageElementFrom(e);
+        } catch (NotFoundException | IOException ex) {
+          throw new WorkflowOperationException(ex);
+        }
       }
 
       if (!configuredTargetFlavor.isEmpty()) {

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TransferMetadataWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TransferMetadataWorkflowOperationHandler.java
@@ -68,9 +68,6 @@ public class TransferMetadataWorkflowOperationHandler extends AbstractWorkflowOp
 
   private static Logger logger = LoggerFactory.getLogger(TransferMetadataWorkflowOperationHandler.class);
 
-  /** Reference to the workspace */
-  private Workspace workspace = null;
-
   /**
    * {@inheritDoc}
    *

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/WebvttToCutMarksWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/WebvttToCutMarksWorkflowOperationHandler.java
@@ -126,9 +126,6 @@ public class WebvttToCutMarksWorkflowOperationHandler extends AbstractWorkflowOp
     ALWAYS_INCLUDE
   }
 
-  /** The workspace. */
-  private Workspace workspace;
-
   @Override
   public WorkflowOperationResult start(WorkflowInstance workflowInstance, JobContext context)
           throws WorkflowOperationException {

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ZipWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ZipWorkflowOperationHandler.java
@@ -120,11 +120,6 @@ public class ZipWorkflowOperationHandler extends AbstractWorkflowOperationHandle
   protected File tempStorageDir = null;
 
   /**
-   * The workspace to use in retrieving and storing files.
-   */
-  protected Workspace workspace;
-
-  /**
    * Sets the workspace to use.
    *
    * @param workspace


### PR DESCRIPTION
Some operations clone mediapackage elements and add the cloned element back to the mediapackage, e.g. when the `editor` is skipped and only clones the source elements to the targets. This should result in a copy of the underlying file in the workspace, however, not all operations did that. This PR introduces a new helper function for cloning mediapackage elements that also creates a file copy.

Note that the following places, where mediapackage elements are cloned, remain unchanged, either because the nature of the clone is different (e.g. building the distribution mediapackage object) or the file is already copied in another way:

* [`XACMLAuthorizationService.java`:285](https://github.com/opencast/opencast/blob/48114bf67aa12b6b91e4d26bb3e98cd7d6cce2db/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java#L285)
* [`AdaptivePlaylist.java`:758](https://github.com/opencast/opencast/blob/48114bf67aa12b6b91e4d26bb3e98cd7d6cce2db/modules/common/src/main/java/org/opencastproject/mediapackage/AdaptivePlaylist.java#L758)
* [`AwsS3DistributionServiceImpl.java`:543](https://github.com/opencast/opencast/blob/48114bf67aa12b6b91e4d26bb3e98cd7d6cce2db/modules/distribution-service-aws-s3/src/main/java/org/opencastproject/distribution/aws/s3/AwsS3DistributionServiceImpl.java#L543)
* [`AwsS3DistributionServiceImpl.java`:847](https://github.com/opencast/opencast/blob/48114bf67aa12b6b91e4d26bb3e98cd7d6cce2db/modules/distribution-service-aws-s3/src/main/java/org/opencastproject/distribution/aws/s3/AwsS3DistributionServiceImpl.java#L847)
* [`DownloadDistributionServiceImpl.java`:354](https://github.com/opencast/opencast/blob/48114bf67aa12b6b91e4d26bb3e98cd7d6cce2db/modules/distribution-service-download/src/main/java/org/opencastproject/distribution/download/DownloadDistributionServiceImpl.java#L354)
* [`DownloadDistributionServiceImpl.java`:482](https://github.com/opencast/opencast/blob/48114bf67aa12b6b91e4d26bb3e98cd7d6cce2db/modules/distribution-service-download/src/main/java/org/opencastproject/distribution/download/DownloadDistributionServiceImpl.java#L482)
* [`WowzaStreamingDistributionService.java`:757](https://github.com/opencast/opencast/blob/48114bf67aa12b6b91e4d26bb3e98cd7d6cce2db/modules/distribution-service-streaming-wowza/src/main/java/org/opencastproject/distribution/streaming/wowza/WowzaStreamingDistributionService.java#L757)
* [`PublishEngageWorkflowOperationHandler.java`:729](https://github.com/opencast/opencast/blob/48114bf67aa12b6b91e4d26bb3e98cd7d6cce2db/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java#L729)
* [`PublishEngageWorkflowOperationHandler.java`:739](https://github.com/opencast/opencast/blob/48114bf67aa12b6b91e4d26bb3e98cd7d6cce2db/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java#L739)
* [`DublinCoreXmlFormat.java`:187](https://github.com/opencast/opencast/blob/48114bf67aa12b6b91e4d26bb3e98cd7d6cce2db/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreXmlFormat.java#L187)
* [`SchedulerServiceImpl.java`:545](https://github.com/opencast/opencast/blob/48114bf67aa12b6b91e4d26bb3e98cd7d6cce2db/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java#L545)
* [`SchedulerServiceImpl.java`:758](https://github.com/opencast/opencast/blob/48114bf67aa12b6b91e4d26bb3e98cd7d6cce2db/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java#L758)
* [`SubtitleTimeshiftWorkflowOperationHandler.java`:225](https://github.com/opencast/opencast/blob/48114bf67aa12b6b91e4d26bb3e98cd7d6cce2db/modules/subtitle-timeshift-workflowoperation/src/main/java/org/opencastproject/workflow/handler/subtitletimeshift/SubtitleTimeshiftWorkflowOperationHandler.java#L225)
* [`DuplicateEventWorkflowOperationHandler.java`:396](https://github.com/opencast/opencast/blob/48114bf67aa12b6b91e4d26bb3e98cd7d6cce2db/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DuplicateEventWorkflowOperationHandler.java#L396)
* [`DuplicateEventWorkflowOperationHandler.java`:505](https://github.com/opencast/opencast/blob/48114bf67aa12b6b91e4d26bb3e98cd7d6cce2db/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DuplicateEventWorkflowOperationHandler.java#L505)

### How to test this patch

Could be hard to confirm this without an attached debugger. Pause the execution after a clone and verify that the mediapackage object does not contain elements that share one URL.

### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature