### PR TITLE
Prevent build tests from building modules in parallel

### DIFF
--- a/.github/workflows/test-opencast-build.yml
+++ b/.github/workflows/test-opencast-build.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: build opencast
         run: |
-          ./mvnw clean install -Pnone -T1C \
+          ./mvnw clean install -Pnone \
             --batch-mode \
             -Dsurefire.rerunFailingTestsCount=2 \
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \


### PR DESCRIPTION
Commit 4e97638 which was part of “Fix code coverage tooling” (pull request #6987) also changed the way Opencast is built additional to what the pull request describes.

This is faster, but makes it much harder to debug why builds are broken as logs are mixed and you have to search for error logs within a ton of logs of builds from other modules.

This makes reviews (and finding your own errors) much harder while not helping much since the tests are still to slow to really wait for them to finish, so that you have to come back to check later on anyway.

Therefor, this patch remove the flag for parallel build, causing errors to be at the end of the build logs yet again.

I've created this pull request against the legacy branch to have consistent tests. This will not change anything related to Opencast itself after all.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature
