### PR TITLE
Add support for uploading captions to YouTube

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/publish-youtube-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/publish-youtube-woh.md
@@ -16,10 +16,12 @@ with both streams inside of it.
 Parameter Table
 ---------------
 
-|configuration keys         |description                                                                   |
-|---------------------------|------------------------------------------------------------------------------|
-|source-flavors             |The flavors to publish to YouTube                                             |
-|source-tags                |The tags to publish to YouTube                                                |
+|configuration keys         |description                                                                                                       |
+|---------------------------|------------------------------------------------------------------------------------------------------------------|
+|source-flavors             |The flavors of the video track to publish to YouTube.                                                             |
+|source-tags                |The tags of the video track to publish to YouTube.                                                                |
+|caption-flavors            |The flavors of the captions to publish to YouTube.                                                                |
+|caption-tags               |The tags of the captions to publish to YouTube.                                                                   |
 
 
 Operation Example
@@ -30,4 +32,5 @@ Operation Example
     description: Publishing to YouTube
     configurations:
       - source-tags: youtube
+      - caption-flavors: captions/*
 ```

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishYouTubeWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishYouTubeWorkflowOperationHandler.java
@@ -43,11 +43,13 @@ import org.opencastproject.workflow.api.WorkflowOperationHandler;
 import org.opencastproject.workflow.api.WorkflowOperationResult;
 import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
 
+import org.apache.commons.lang3.StringUtils;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -99,42 +101,69 @@ public class PublishYouTubeWorkflowOperationHandler extends AbstractWorkflowOper
     List<String> sourceTags = tagsAndFlavors.getSrcTags();
     List<MediaPackageElementFlavor> sourceFlavors = tagsAndFlavors.getSrcFlavors();
 
-    AbstractMediaPackageElementSelector<MediaPackageElement> elementSelector;
+    AbstractMediaPackageElementSelector<MediaPackageElement> videoSelector;
 
     if (sourceTags == null && sourceFlavors == null) {
       logger.warn("No tags or flavor have been specified");
       return createResult(mediaPackage, Action.CONTINUE);
     }
-    elementSelector = new SimpleElementSelector();
+    videoSelector = new SimpleElementSelector();
 
     if (!sourceFlavors.isEmpty()) {
       for (MediaPackageElementFlavor flavor : sourceFlavors) {
-        elementSelector.addFlavor(flavor);
+        videoSelector.addFlavor(flavor);
       }
     }
     if (!sourceTags.isEmpty()) {
       for (String tag : sourceTags) {
-        elementSelector.addTag(tag);
+        videoSelector.addTag(tag);
       }
+    }
+
+    // Caption configuration
+    List<String> captionTags = asList(StringUtils.trimToNull(
+            workflowInstance.getCurrentOperation().getConfiguration("caption-tags")));
+    List<MediaPackageElementFlavor> captionFlavors = new ArrayList<>();
+    List<String> captionFlavorStrings = asList(StringUtils.trimToNull(
+            workflowInstance.getCurrentOperation().getConfiguration("caption-flavors")));
+    for (String flavorString : captionFlavorStrings) {
+      try {
+        captionFlavors.add(MediaPackageElementFlavor.parseFlavor(flavorString));
+      } catch (IllegalArgumentException e) {
+        throw new WorkflowOperationException(flavorString + " is not a valid flavor!");
+      }
+    }
+    AbstractMediaPackageElementSelector<MediaPackageElement> captionSelector = new SimpleElementSelector();
+    for (MediaPackageElementFlavor flavor : captionFlavors) {
+      captionSelector.addFlavor(flavor);
+    }
+    for (String tag : captionTags) {
+      captionSelector.addTag(tag);
     }
 
     try {
       // Look for elements matching the tag
-      final Collection<MediaPackageElement> elements = elementSelector.select(mediaPackage, true);
-      if (elements.size() > 1) {
+      final Collection<MediaPackageElement> videoElements = videoSelector.select(mediaPackage, true);
+      if (videoElements.size() > 1) {
         throw new WorkflowOperationException("More than one element has been found for publishing to youtube: "
-            + elements);
+            + videoElements);
       }
 
-      if (elements.size() < 1) {
+      if (videoElements.size() < 1) {
         logger.info("No mediapackage element was found for publishing");
         return createResult(mediaPackage, Action.SKIP);
       }
 
+      Collection<MediaPackageElement> captionElements = captionSelector.select(mediaPackage, true);
+
       Job youtubeJob;
       try {
-        Track track = mediaPackage.getTrack(elements.iterator().next().getIdentifier());
-        youtubeJob = publicationService.publish(mediaPackage, track);
+        Track video = mediaPackage.getTrack(videoElements.iterator().next().getIdentifier());
+        List<Track> captions = new ArrayList<>();
+        for (MediaPackageElement caption : captionElements) {
+          captions.add(mediaPackage.getTrack(caption.getIdentifier()));
+        }
+        youtubeJob = publicationService.publish(mediaPackage, video, captions);
       } catch (PublicationException e) {
         throw new WorkflowOperationException(e);
       }

--- a/modules/publication-service-api/src/main/java/org/opencastproject/publication/api/YouTubePublicationService.java
+++ b/modules/publication-service-api/src/main/java/org/opencastproject/publication/api/YouTubePublicationService.java
@@ -25,6 +25,8 @@ import org.opencastproject.job.api.Job;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.Track;
 
+import java.util.List;
+
 /**
  * Publishes elements from MediaPackages to youtube.
  */
@@ -42,11 +44,13 @@ public interface YouTubePublicationService {
    *          the media package
    * @param track
    *          the track of the media package to publish
+   * @param captions
+   *          the list of captions to publish
    * @return The job
    * @throws PublicationException
    *           if there was a problem publishing the media
    */
-  Job publish(MediaPackage mediaPackage, Track track) throws PublicationException;
+  Job publish(MediaPackage mediaPackage, Track track, List<Track> captions) throws PublicationException;
 
   /**
    * Retract a media package element from the distribution channel.

--- a/modules/publication-service-youtube-remote/pom.xml
+++ b/modules/publication-service-youtube-remote/pom.xml
@@ -16,6 +16,10 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore-osgi</artifactId>
     </dependency>

--- a/modules/publication-service-youtube-remote/src/main/java/org/opencastproject/publication/youtube/remote/YouTubePublicationServiceRemoteImpl.java
+++ b/modules/publication-service-youtube-remote/src/main/java/org/opencastproject/publication/youtube/remote/YouTubePublicationServiceRemoteImpl.java
@@ -32,6 +32,7 @@ import org.opencastproject.security.api.TrustedHttpClient;
 import org.opencastproject.serviceregistry.api.RemoteBase;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
@@ -64,11 +65,19 @@ public class YouTubePublicationServiceRemoteImpl extends RemoteBase implements Y
   }
 
   @Override
-  public Job publish(MediaPackage mediaPackage, Track track) throws PublicationException {
+  public Job publish(MediaPackage mediaPackage, Track track, List<Track> captions)
+          throws PublicationException {
     final String trackId = track.getIdentifier();
     List<BasicNameValuePair> params = new ArrayList<BasicNameValuePair>();
     params.add(new BasicNameValuePair("mediapackage", MediaPackageParser.getAsXml(mediaPackage)));
     params.add(new BasicNameValuePair("elementId", trackId));
+    if (captions != null && !captions.isEmpty()) {
+      List<String> captionIds = new ArrayList<>();
+      for (Track caption : captions) {
+        captionIds.add(caption.getIdentifier());
+      }
+      params.add(new BasicNameValuePair("captionIds", StringUtils.join(captionIds, ",")));
+    }
     HttpPost post = new HttpPost();
     HttpResponse response = null;
     try {

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeAPIVersion3Service.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeAPIVersion3Service.java
@@ -23,6 +23,7 @@ package org.opencastproject.publication.youtube;
 
 import org.opencastproject.publication.youtube.auth.ClientCredentials;
 
+import com.google.api.services.youtube.model.Caption;
 import com.google.api.services.youtube.model.Playlist;
 import com.google.api.services.youtube.model.PlaylistItem;
 import com.google.api.services.youtube.model.PlaylistItemListResponse;
@@ -30,6 +31,7 @@ import com.google.api.services.youtube.model.PlaylistListResponse;
 import com.google.api.services.youtube.model.SearchListResponse;
 import com.google.api.services.youtube.model.Video;
 
+import java.io.File;
 import java.io.IOException;
 
 /**
@@ -135,5 +137,16 @@ public interface YouTubeAPIVersion3Service {
    * @throws IOException when transaction fails.
    */
   void removeMyPlaylist(String playlistId) throws IOException;
+
+  /**
+   * Add captions to a video.
+   * @param videoId the video id
+   * @param file the caption file
+   * @param language the language of the captions
+   * @param name the name of the captions
+   * @return the created caption object
+   * @throws IOException when transaction fails.
+   */
+  Caption addCaptions(String videoId, File file, String language, String name) throws IOException;
 
 }

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeAPIVersion3ServiceImpl.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeAPIVersion3ServiceImpl.java
@@ -33,6 +33,8 @@ import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.youtube.YouTube;
 import com.google.api.services.youtube.YouTubeRequest;
+import com.google.api.services.youtube.model.Caption;
+import com.google.api.services.youtube.model.CaptionSnippet;
 import com.google.api.services.youtube.model.Playlist;
 import com.google.api.services.youtube.model.PlaylistItem;
 import com.google.api.services.youtube.model.PlaylistItemListResponse;
@@ -281,4 +283,27 @@ public class YouTubeAPIVersion3ServiceImpl implements YouTubeAPIVersion3Service 
   private <T> T execute(final YouTubeRequest<T> command) throws IOException {
     return command.execute();
   }
+
+  @Override
+  public Caption addCaptions(String videoId, File file, String language, String name) throws IOException {
+    final Caption captionObjectDefiningMetadata = new Caption();
+    final CaptionSnippet snippet = new CaptionSnippet();
+    snippet.setVideoId(videoId);
+    snippet.setLanguage(language);
+    snippet.setName(name);
+    snippet.setIsDraft(false);
+    captionObjectDefiningMetadata.setSnippet(snippet);
+
+    final BufferedInputStream inputStream = new BufferedInputStream(new FileInputStream(file));
+    final InputStreamContent mediaContent = new InputStreamContent("application/octet-stream", inputStream);
+    mediaContent.setLength(file.length());
+
+    final YouTube.Captions.Insert captionInsert = youTube.captions()
+            .insert("snippet", captionObjectDefiningMetadata, mediaContent);
+    final MediaHttpUploader uploader = captionInsert.getMediaHttpUploader();
+    uploader.setDirectUploadEnabled(false);
+
+    return execute(captionInsert);
+  }
+
 }

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
@@ -62,7 +62,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.Dictionary;
 import java.util.List;
@@ -225,10 +224,21 @@ public class YouTubeV3PublicationServiceImpl
   }
 
   @Override
-  public Job publish(final MediaPackage mediaPackage, final Track track) throws PublicationException {
+  public Job publish(final MediaPackage mediaPackage, final Track track, final List<Track> captions)
+          throws PublicationException {
     if (mediaPackage.contains(track)) {
       try {
-        final List<String> args = Arrays.asList(MediaPackageParser.getAsXml(mediaPackage), track.getIdentifier());
+        final List<String> args = new ArrayList<>();
+        args.add(MediaPackageParser.getAsXml(mediaPackage));
+        args.add(track.getIdentifier());
+        if (captions != null && !captions.isEmpty()) {
+          final List<String> captionIds = new ArrayList<>();
+          for (Track caption : captions) {
+            captionIds.add(caption.getIdentifier());
+          }
+          args.add(StringUtils.join(captionIds, ","));
+        }
+
         return serviceRegistry.createJob(JOB_TYPE, Operation.Publish.toString(), args, youtubePublishJobLoad);
       } catch (ServiceRegistryException e) {
         throw new PublicationException("Unable to create a job for track: " + track.toString(), e);
@@ -248,11 +258,14 @@ public class YouTubeV3PublicationServiceImpl
    *          the mediapackage
    * @param elementId
    *          the mediapackage element id to publish
+   * @param captions
+   *          the mediapackage caption elements to publish
    * @return the published element
    * @throws PublicationException
    *           if publication fails
    */
-  private Publication publish(final Job job, final MediaPackage mediaPackage, final String elementId)
+  private Publication publish(final Job job, final MediaPackage mediaPackage, final String elementId,
+                              final List<Track> captions)
           throws PublicationException {
     if (mediaPackage == null) {
       throw new IllegalArgumentException("Mediapackage must be specified");
@@ -301,6 +314,31 @@ public class YouTubeV3PublicationServiceImpl
         playlist = existingPlaylist;
       }
       youTubeService.addPlaylistItem(playlist.getId(), video.getId());
+
+      if (captions != null) {
+        for (Track caption : captions) {
+          try {
+            final File captionFile = workspace.get(caption.getURI());
+            String language = null;
+            for (String tag : caption.getTags()) {
+              if (tag.startsWith("lang:")) {
+                language = tag.substring(5);
+                break;
+              }
+            }
+            if (language == null) {
+              logger.warn("No language tag (lang:<bcp-code>) found for caption track {}. Skipping upload.", caption);
+              continue;
+            }
+            // Google YouTube API requires ISO 639-1 language code.
+            // Opencast flavors often use that too.
+            youTubeService.addCaptions(video.getId(), captionFile, language, caption.getFlavor().toString());
+          } catch (Exception e) {
+            logger.warn("Failed to upload captions {} for video {}: {}", caption, video.getId(), e.getMessage());
+          }
+        }
+      }
+
       // Create new publication element
       final URL url = new URL("http://www.youtube.com/watch?v=" + video.getId());
       return PublicationImpl.publication(
@@ -394,7 +432,17 @@ public class YouTubeV3PublicationServiceImpl
       MediaPackage mediapackage = MediaPackageParser.getFromXml(arguments.get(0));
       switch (op) {
         case Publish:
-          Publication publicationElement = publish(job, mediapackage, arguments.get(1));
+          final List<Track> captions = new ArrayList<>();
+          if (arguments.size() > 2) {
+            final String[] captionIds = arguments.get(2).split(",");
+            for (String captionId : captionIds) {
+              final Track caption = mediapackage.getTrack(captionId);
+              if (caption != null) {
+                captions.add(caption);
+              }
+            }
+          }
+          Publication publicationElement = publish(job, mediapackage, arguments.get(1), captions);
           return (publicationElement == null) ? null : MediaPackageElementParser.getAsXml(publicationElement);
         case Retract:
           Publication retractedElement = retract(job, mediapackage);

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/auth/ClientCredentials.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/auth/ClientCredentials.java
@@ -58,8 +58,12 @@ public final class ClientCredentials {
   }
 
   public List<String> getScopes() {
-    return Collections.list("https://www.googleapis.com/auth/youtube",
-        "https://www.googleapis.com/auth/youtube.upload", "https://www.googleapis.com/auth/youtube.readonly");
+    return Collections.list(
+        "https://www.googleapis.com/auth/youtube",
+        "https://www.googleapis.com/auth/youtube.upload",
+        "https://www.googleapis.com/auth/youtube.readonly",
+        "https://www.googleapis.com/auth/youtube.force-ssl"
+    );
   }
 
   public File getClientSecrets() {

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/endpoint/YouTubePublicationRestService.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/endpoint/YouTubePublicationRestService.java
@@ -41,11 +41,15 @@ import org.opencastproject.util.doc.rest.RestQuery;
 import org.opencastproject.util.doc.rest.RestResponse;
 import org.opencastproject.util.doc.rest.RestService;
 
+import org.apache.commons.lang3.StringUtils;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
@@ -109,6 +113,12 @@ public class YouTubePublicationRestService extends AbstractJobProducerEndpoint {
               isRequired = true,
               description = "The element to publish",
               type = Type.STRING
+          ),
+          @RestParameter(
+              name = "captionIds",
+              isRequired = false,
+              description = "The captions to publish",
+              type = Type.STRING
           )
       },
       responses = {
@@ -118,14 +128,24 @@ public class YouTubePublicationRestService extends AbstractJobProducerEndpoint {
   )
   public Response publish(
       @FormParam("mediapackage") final String mediaPackageXml,
-      @FormParam("elementId") final String elementId
+      @FormParam("elementId") final String elementId,
+      @FormParam("captionIds") final String captionIds
   ) {
     final Job job;
     try {
       final MediaPackage mediapackage = MediaPackageParser.getFromXml(mediaPackageXml);
       final Track track = mediapackage.getTrack(elementId);
       if (track != null) {
-        job = service.publish(mediapackage, track);
+        final List<Track> captions = new ArrayList<>();
+        if (StringUtils.isNotBlank(captionIds)) {
+          for (String captionId : StringUtils.split(captionIds, ",")) {
+            final Track caption = mediapackage.getTrack(captionId.trim());
+            if (caption != null) {
+              captions.add(caption);
+            }
+          }
+        }
+        job = service.publish(mediapackage, track, captions);
       } else {
         return badRequest();
       }

--- a/modules/publication-service-youtube-v3/src/test/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImplTest.java
+++ b/modules/publication-service-youtube-v3/src/test/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImplTest.java
@@ -110,7 +110,7 @@ public class YouTubeV3PublicationServiceImplTest {
           anyObject(Float.class))).andReturn(new JobImpl()).once();
     replay(youTubeService, orgDirectory, security, registry, userDirectoryService, workspace);
     service.updated(getServiceProperties());
-    service.publish(mediaPackage, mediaPackage.getTracks()[0]);
+    service.publish(mediaPackage, mediaPackage.getTracks()[0], null);
   }
 
   private Dictionary getServiceProperties() throws IOException {

--- a/modules/publication-service-youtube-v3/src/test/java/org/opencastproject/publication/youtube/auth/ClientCredentialsTest.java
+++ b/modules/publication-service-youtube-v3/src/test/java/org/opencastproject/publication/youtube/auth/ClientCredentialsTest.java
@@ -68,4 +68,5 @@ public class ClientCredentialsTest {
       }
     }
   }
+
 }


### PR DESCRIPTION
This commit extends the YouTube publication service and the `publish-youtube` workflow operation handler to support uploading caption tracks along with the video.

The metadata for the uploaded captions is determined as follows:
- Language: Extracted from the media package element's tags. The service looks for a tag starting with `lang:` and uses the remainder as the BCP-47 language code (e.g., `lang:en`).
- Name: The flavor of the caption track is used as the caption track name on YouTube (e.g., `captions/vtt`).

The `publish-youtube` workflow operation now includes two new configuration options, `caption-flavors` and `caption-tags`, to specify which elements should be uploaded as captions.