### PR TITLE
Fix most POSIX compliance errors in upgrade shell scripts

### DIFF
--- a/docs/upgrade/10_to_11/delete-old-indices.sh
+++ b/docs/upgrade/10_to_11/delete-old-indices.sh
@@ -21,7 +21,7 @@ delete_indices() {
 	local INDEX="$1"
 	shift  # shift arguments to the left so we can get the rest as an array
 	local SUB_INDICES=("$@")
-	for SUB_INDEX in ${SUB_INDICES[@]}; do
+	for SUB_INDEX in "${SUB_INDICES[@]}"; do
 		DELETE_INDEX="${INDEX}_${SUB_INDEX}"
 		echo -e "Starting to delete ${DELETE_INDEX}.\n"
 
@@ -56,7 +56,7 @@ SUB_INDICES=("${VERSION}" "${EVENT}" "${SERIES}" "${THEME}" "${GROUP}")
 delete_indices $ADMIN_UI_INDEX "${SUB_INDICES[@]}"
 
 # Delete External API sub indices
-SUB_INDICES=($VERSION $EVENT $SERIES $GROUP)
+SUB_INDICES=("$VERSION" "$EVENT" "$SERIES" "$GROUP")
 delete_indices $EXTERNAL_API_INDEX "${SUB_INDICES[@]}"
 
 echo -e "Cleanup done.\n"

--- a/docs/upgrade/16_to_17/add_is_published.sh
+++ b/docs/upgrade/16_to_17/add_is_published.sh
@@ -12,7 +12,7 @@ FIELD_NAME="is_published"
 ES_USER="your_username"
 ES_PASS="your_password"
 
-if ! command -v jq &> /dev/null; then
+if ! command -v jq > /dev/null 2>&1; then
     echo "Error: jq is not installed. Please install it and try again." >&2
     exit 1
 fi

--- a/docs/upgrade/16_to_17/update_index_mapping.sh
+++ b/docs/upgrade/16_to_17/update_index_mapping.sh
@@ -1,6 +1,7 @@
- curl -X PUT --data "@update_series_mapping.json" -H 'Content-Type: application/json' 'http://localhost:9200/opencast_series/_mapping'
- curl -X POST -H 'Content-Type: application/json' 'http://localhost:9200/opencast_series/_update_by_query?refresh&conflicts=proceed'
- curl -X PUT --data "@update_event_mapping.json" -H 'Content-Type: application/json' 'http://localhost:9200/opencast_event/_mapping'
- curl -X POST -H 'Content-Type: application/json' 'http://localhost:9200/opencast_event/_update_by_query?refresh&conflicts=proceed'
- curl -X PUT --data "@update_theme_mapping.json" -H 'Content-Type: application/json' 'http://localhost:9200/opencast_theme/_mapping'
- curl -X POST -H 'Content-Type: application/json' 'http://localhost:9200/opencast_theme/_update_by_query?refresh&conflicts=proceed'
+#!/bin/sh
+curl -X PUT --data "@update_series_mapping.json" -H 'Content-Type: application/json' 'http://localhost:9200/opencast_series/_mapping'
+curl -X POST -H 'Content-Type: application/json' 'http://localhost:9200/opencast_series/_update_by_query?refresh&conflicts=proceed'
+curl -X PUT --data "@update_event_mapping.json" -H 'Content-Type: application/json' 'http://localhost:9200/opencast_event/_mapping'
+curl -X POST -H 'Content-Type: application/json' 'http://localhost:9200/opencast_event/_update_by_query?refresh&conflicts=proceed'
+curl -X PUT --data "@update_theme_mapping.json" -H 'Content-Type: application/json' 'http://localhost:9200/opencast_theme/_mapping'
+curl -X POST -H 'Content-Type: application/json' 'http://localhost:9200/opencast_theme/_update_by_query?refresh&conflicts=proceed'

--- a/docs/upgrade/17_to_18/extract_es_data.sh
+++ b/docs/upgrade/17_to_18/extract_es_data.sh
@@ -14,10 +14,10 @@ ES_USER="your_username"
 ES_PASS="your_password"
 
 # Clear output and error log files
-> "$OUTPUT_FILE"
-> "$ERROR_LOG"
+echo > "$OUTPUT_FILE"
+echo > "$ERROR_LOG"
 
-if ! command -v jq &> /dev/null; then
+if ! command -v jq > /dev/null 2>&1; then
     echo "Error: jq is not installed. Please install it and try again." >&2
     exit 1
 fi

--- a/docs/upgrade/17_to_18/optimize_search.sh
+++ b/docs/upgrade/17_to_18/optimize_search.sh
@@ -10,7 +10,7 @@ ES_HOST="http://localhost:9200"
 ES_USER="your_username"
 ES_PASS="your_password"
 
-if ! command -v jq &> /dev/null; then
+if ! command -v jq > /dev/null 2>&1; then
     echo "Error: jq is not installed. Please install it and try again." >&2
     exit 1
 fi
@@ -65,7 +65,7 @@ reindex() {
     response=$(curl --silent --user "$ES_USER:$ES_PASS" -X GET "$ES_HOST/_tasks/$TASK_ID")
     completed=$(echo "$response" | jq -r '.completed')
 
-    if [[ "$completed" == "true" ]]; then
+    if [ "${completed}" = "true" ]; then
       echo "Task $TASK_ID completed"
       break
     fi
@@ -99,7 +99,7 @@ reindex() {
     response=$(curl --silent --user "$ES_USER:$ES_PASS" -X GET "$ES_HOST/_tasks/$TASK_ID_2")
     completed=$(echo "$response" | jq -r '.completed')
 
-    if [[ "$completed" == "true" ]]; then
+    if [ "${completed}" = "true" ]; then
       echo "Task $TASK_ID_2 completed"
       break
     fi
@@ -124,9 +124,9 @@ update_text_field() {
   echo "Updating text field '$FIELD_NAME' in index '$INDEX_NAME'..."
 
   SCRIPT="
-  ctx._source['$FIELD_NAME'] = [];
-  if (ctx._source.containsKey('"$FIELD_NAME"_fuzzy')) {
-    ctx._source['"$FIELD_NAME"_fuzzy'] = [];
+  ctx._source['${FIELD_NAME}'] = [];
+  if (ctx._source.containsKey('${FIELD_NAME}_fuzzy')) {
+    ctx._source['${FIELD_NAME}_fuzzy'] = [];
   }
   for(c in params.fields) {
     if (ctx._source.containsKey(c) && ctx._source[c] != null) {


### PR DESCRIPTION
This patch fixes most of the POSIX compliance errors in our upgrade shell scripts plus some warnings `shellcheck` made about dangerous or undefined behavior.

What remains are three occurrences of `set -o pipefail` for which there is no simple POSIX-compliance alternative.

This patch is related to:

- https://github.com/opencast/opencast/pull/7369
- https://github.com/opencast/opencast/issues/7289

### How to test this patch

Use `shellcheck` or run the scripts using `dash`.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature
