### PR TITLE
Improve YouTube video retraction

### DIFF
--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeAPIVersion3Service.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeAPIVersion3Service.java
@@ -27,7 +27,6 @@ import com.google.api.services.youtube.model.Playlist;
 import com.google.api.services.youtube.model.PlaylistItem;
 import com.google.api.services.youtube.model.PlaylistItemListResponse;
 import com.google.api.services.youtube.model.PlaylistListResponse;
-import com.google.api.services.youtube.model.SearchListResponse;
 import com.google.api.services.youtube.model.Video;
 
 import java.io.IOException;
@@ -43,16 +42,6 @@ public interface YouTubeAPIVersion3Service {
    * @throws IOException when configuration files not found.
    */
   void initialize(ClientCredentials credentials) throws IOException;
-
-  /**
-   * Search for videos on predefined channel.
-   * @param queryTerm may not be {@code null}
-   * @param pageToken may not be {@code null}
-   * @param maxResults may not be {@code null}
-   * @return zero or more results. Will not be {@code null}.
-   * @throws IOException when search fails.
-   */
-  SearchListResponse searchMyVideos(String queryTerm, String pageToken, long maxResults) throws IOException;
 
   /**
    * Get video by id.

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeAPIVersion3ServiceImpl.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeAPIVersion3ServiceImpl.java
@@ -41,7 +41,6 @@ import com.google.api.services.youtube.model.PlaylistListResponse;
 import com.google.api.services.youtube.model.PlaylistSnippet;
 import com.google.api.services.youtube.model.PlaylistStatus;
 import com.google.api.services.youtube.model.ResourceId;
-import com.google.api.services.youtube.model.SearchListResponse;
 import com.google.api.services.youtube.model.Video;
 import com.google.api.services.youtube.model.VideoListResponse;
 import com.google.api.services.youtube.model.VideoSnippet;
@@ -161,21 +160,6 @@ public class YouTubeAPIVersion3ServiceImpl implements YouTubeAPIVersion3Service 
   public void removeMyPlaylist(final String playlistId) throws IOException {
     final YouTube.Playlists.Delete deleteRequest = youTube.playlists().delete(playlistId);
     execute(deleteRequest);
-  }
-
-  @Override
-  public SearchListResponse searchMyVideos(final String queryTerm, final String pageToken, final long maxResults)
-          throws IOException {
-    final YouTube.Search.List search = youTube.search().list("id,snippet");
-    if (pageToken != null) {
-      search.set("pageToken", pageToken);
-    }
-    search.setQ(queryTerm);
-    search.setType("video");
-    search.setForMine(true);
-    search.setMaxResults(maxResults);
-    search.setFields("items(id,kind,snippet),nextPageToken,pageInfo,prevPageToken,tokenPagination");
-    return execute(search);
   }
 
   @Override

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
@@ -44,7 +44,6 @@ import org.opencastproject.util.XProperties;
 import org.opencastproject.workspace.api.Workspace;
 
 import com.google.api.services.youtube.model.Playlist;
-import com.google.api.services.youtube.model.SearchResult;
 import com.google.api.services.youtube.model.Video;
 
 import org.apache.commons.lang3.StringUtils;
@@ -302,7 +301,7 @@ public class YouTubeV3PublicationServiceImpl
       }
       youTubeService.addPlaylistItem(playlist.getId(), video.getId());
       // Create new publication element
-      final URL url = new URL("http://www.youtube.com/watch?v=" + video.getId());
+      final URL url = new URL("http://www.youtube.com/watch?v=" + video.getId() + "&list=" + playlist.getId());
       return PublicationImpl.publication(
           UUID.randomUUID().toString(), CHANNEL_NAME, url.toURI(), MimeTypes.parseMimeType(MIME_TYPE));
     } catch (Exception e) {
@@ -355,10 +354,9 @@ public class YouTubeV3PublicationServiceImpl
     if (youtube == null) {
       return null;
     }
-    final YouTubePublicationAdapter contextStrategy = new YouTubePublicationAdapter(mediaPackage, workspace);
-    final String episodeName = contextStrategy.getEpisodeName();
     try {
-      retract(mediaPackage.getSeriesTitle(), episodeName);
+      final java.net.URI uri = youtube.getURI();
+      retract(uri.toString());
     } catch (final Exception e) {
       logger.error("Failure retracting YouTube media {}", e.getMessage());
       throw new PublicationException("YouTube media retract failed on job: "
@@ -367,17 +365,41 @@ public class YouTubeV3PublicationServiceImpl
     return youtube;
   }
 
-  private void retract(final String seriesTitle, final String episodeName) throws Exception {
-    final List<SearchResult> items = youTubeService.searchMyVideos(
-        truncateTitleToMaxFieldLength(episodeName, false), null, 1).getItems();
-    if (!items.isEmpty()) {
-      final String videoId = items.get(0).getId().getVideoId();
-      if (seriesTitle != null) {
-        final Playlist playlist = youTubeService.getMyPlaylistByTitle(truncateTitleToMaxFieldLength(seriesTitle, true));
-        youTubeService.removeVideoFromPlaylist(playlist.getId(), videoId);
-      }
-      youTubeService.removeMyVideo(videoId);
+  private void retract(final String watchUrl) throws Exception {
+    if (watchUrl == null) {
+      throw new IllegalArgumentException("watchUrl must be specified");
     }
+    String videoId = null;
+    String playlistId = null;
+    try {
+      final java.net.URI uri = java.net.URI.create(watchUrl);
+      final String query = uri.getQuery();
+      if (query != null) {
+        for (String param : query.split("&")) {
+          String[] pair = param.split("=", 2);
+          if (pair.length == 2) {
+            if ("v".equals(pair[0])) {
+              videoId = pair[1];
+            } else if ("list".equals(pair[0])) {
+              playlistId = pair[1];
+            }
+          }
+        }
+      }
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Invalid YouTube watch URL: " + watchUrl, e);
+    }
+    if (videoId == null) {
+      throw new IllegalArgumentException("YouTube video ID not found in URL: " + watchUrl);
+    }
+    if (playlistId != null) {
+      try {
+        youTubeService.removeVideoFromPlaylist(playlistId, videoId);
+      } catch (Exception e) {
+        // Non-fatal: continue with video removal
+      }
+    }
+    youTubeService.removeMyVideo(videoId);
   }
 
   /**
@@ -535,5 +557,4 @@ public class YouTubeV3PublicationServiceImpl
       }
     }
   }
-
 }


### PR DESCRIPTION
Previously, the retraction of YouTube videos relied on searching for the video by its episode name. This was unreliable if multiple videos had the same name or if the name had changed.

This commit changes the retraction logic to extract the YouTube video ID directly from the publication's URI stored in the MediaPackage.

Note that during retraction we now attempt to remove the video from the specific playlist referenced in the publication URL (the YouTube watch URL includes both `v` and `list` parameters). This removal is best-effort and failures are ignored; we do not try to remove the video from any other playlists. Since a video can be part of multiple playlists, including ones not managed by Opencast, broad automated removals remain intentionally unsupported.