### PR TITLE
Simplify/improve checkstyle configuration

### DIFF
--- a/docs/checkstyle/opencast-checkstyle.xml
+++ b/docs/checkstyle/opencast-checkstyle.xml
@@ -25,9 +25,15 @@
   </module>
 
   <!-- Allow to disable checkstyle for sections of the code with `// CHECKSTYLE:OFF`
-       and `// CHECKSTYLE:ON`. Unlike `SuppressionCommentFilter` below, this
-       also works for checks not in "TreeWalker" -->
-  <module name="SuppressWithPlainTextCommentFilter"/>
+       and `// CHECKSTYLE:ON`. -->
+  <module name="SuppressWithPlainTextCommentFilter">
+    <property name="offCommentFormat" value="// CHECKSTYLE:OFF(?! checkstyle:)"/>
+  </module>
+  <module name="SuppressWithPlainTextCommentFilter">
+    <property name="offCommentFormat" value="// CHECKSTYLE:OFF checkstyle:(.*)"/>
+    <property name="onCommentFormat" value="// CHECKSTYLE:ON checkstyle:(.*)"/>
+    <property name="checkFormat" value="$1"/>
+  </module>
 
   <!-- Checks whether files end with a new line.                        -->
   <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
@@ -41,9 +47,6 @@
   <module name="Translation" />
 
   <module name="TreeWalker">
-    <!-- Allow Java code to suppress checkstyle audits via CHECKSTYLE:OFF and CHECKSTYLE:ON comments -->
-    <module name="SuppressionCommentFilter"/>
-
     <!-- Indentation -->
     <module name="Indentation">
       <property name="basicOffset" value="2"/>

--- a/modules/admin-ui-interface/pom.xml
+++ b/modules/admin-ui-interface/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
     <interface.url>https://github.com/opencast/opencast-admin-interface/releases/download/20.x-2026-01-29/oc-admin-ui-20.x-2026-01-29.tar.gz</interface.url>
     <interface.sha256>b7b44ee4110b4a650bcb4a99f91f2bdc764715b399f45176217fb117f701d75b</interface.sha256>
   </properties>

--- a/modules/admin-ui/pom.xml
+++ b/modules/admin-ui/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
     <skipTests>false</skipTests>
   </properties>
   <dependencies>

--- a/modules/adopter-registration-api/pom.xml
+++ b/modules/adopter-registration-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/adopter-registration-impl/pom.xml
+++ b/modules/adopter-registration-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/analyze-mediapackage-workflowoperation/pom.xml
+++ b/modules/analyze-mediapackage-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/asset-manager-api/pom.xml
+++ b/modules/asset-manager-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/asset-manager-impl/pom.xml
+++ b/modules/asset-manager-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <!-- Opencast -->

--- a/modules/asset-manager-static-file-authorization/pom.xml
+++ b/modules/asset-manager-static-file-authorization/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/asset-manager-storage-aws/pom.xml
+++ b/modules/asset-manager-storage-aws/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/asset-manager-storage-fs/pom.xml
+++ b/modules/asset-manager-storage-fs/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/asset-manager-workflowoperation/pom.xml
+++ b/modules/asset-manager-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/authorization-manager/pom.xml
+++ b/modules/authorization-manager/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/authorization-xacml/pom.xml
+++ b/modules/authorization-xacml/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/caption-api/pom.xml
+++ b/modules/caption-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/caption-impl/pom.xml
+++ b/modules/caption-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/caption-remote/pom.xml
+++ b/modules/caption-remote/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/capture-admin-service-api/pom.xml
+++ b/modules/capture-admin-service-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/capture-admin-service-impl/pom.xml
+++ b/modules/capture-admin-service-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/comments-workflowoperation/pom.xml
+++ b/modules/comments-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/common-jpa-impl/pom.xml
+++ b/modules/common-jpa-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <!-- Opencast -->

--- a/modules/common/pom.xml
+++ b/modules/common/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/common/src/main/java/org/opencastproject/util/ReadinessIndicator.java
+++ b/modules/common/src/main/java/org/opencastproject/util/ReadinessIndicator.java
@@ -21,7 +21,7 @@
 
 package org.opencastproject.util;
 
-//CHECKSTYLE:OFF
+// CHECKSTYLE:OFF
 
 // This class provides the
 // 'osgi.service;objectClass="[...]ReadinessIndicator"' capability,

--- a/modules/composer-ffmpeg/pom.xml
+++ b/modules/composer-ffmpeg/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/composer-service-api/pom.xml
+++ b/modules/composer-service-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/composer-service-remote/pom.xml
+++ b/modules/composer-service-remote/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/composer-workflowoperation/pom.xml
+++ b/modules/composer-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/conductor/pom.xml
+++ b/modules/conductor/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/cover-image-api/pom.xml
+++ b/modules/cover-image-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/cover-image-impl/pom.xml
+++ b/modules/cover-image-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
     <batik.version>1.17</batik.version>
   </properties>
   <dependencies>

--- a/modules/cover-image-remote/pom.xml
+++ b/modules/cover-image-remote/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/cover-image-workflowoperation/pom.xml
+++ b/modules/cover-image-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/crop-api/pom.xml
+++ b/modules/crop-api/pom.xml
@@ -11,7 +11,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/crop-ffmpeg/pom.xml
+++ b/modules/crop-ffmpeg/pom.xml
@@ -11,7 +11,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <!-- Opencast dependencies -->

--- a/modules/crop-remote/pom.xml
+++ b/modules/crop-remote/pom.xml
@@ -14,7 +14,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/crop-workflowoperation/pom.xml
+++ b/modules/crop-workflowoperation/pom.xml
@@ -11,7 +11,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/db/pom.xml
+++ b/modules/db/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/dictionary-api/pom.xml
+++ b/modules/dictionary-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <!-- Opencast dependencies -->

--- a/modules/dictionary-none/pom.xml
+++ b/modules/dictionary-none/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <!-- Opencast dependencies -->

--- a/modules/dictionary-regexp/pom.xml
+++ b/modules/dictionary-regexp/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <!-- Opencast dependencies -->

--- a/modules/distribution-service-api/pom.xml
+++ b/modules/distribution-service-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/distribution-service-aws-s3-api/pom.xml
+++ b/modules/distribution-service-aws-s3-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/distribution-service-aws-s3-remote/pom.xml
+++ b/modules/distribution-service-aws-s3-remote/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/distribution-service-aws-s3/pom.xml
+++ b/modules/distribution-service-aws-s3/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <!-- AWS SDK BEGIN -->

--- a/modules/distribution-service-download-remote/pom.xml
+++ b/modules/distribution-service-download-remote/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/distribution-service-download/pom.xml
+++ b/modules/distribution-service-download/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/distribution-service-streaming-remote/pom.xml
+++ b/modules/distribution-service-streaming-remote/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/distribution-service-streaming-wowza/pom.xml
+++ b/modules/distribution-service-streaming-wowza/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/distribution-workflowoperation/pom.xml
+++ b/modules/distribution-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/dublincore/pom.xml
+++ b/modules/dublincore/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/editor-service-api/pom.xml
+++ b/modules/editor-service-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/editor-service-remote/pom.xml
+++ b/modules/editor-service-remote/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/editor-service/pom.xml
+++ b/modules/editor-service/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/editor/pom.xml
+++ b/modules/editor/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
     <editor.url>https://github.com/opencast/opencast-editor/releases/download/19.x-2026-01-29/oc-editor-19.x-2026-01-29.tar.gz</editor.url>
     <editor.sha256>0bd24b0bb24efaca76adb3f628625065e0e43306665eb011b8b75cda2591196a</editor.sha256>
   </properties>

--- a/modules/elasticsearch-api/pom.xml
+++ b/modules/elasticsearch-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/elasticsearch-impl/pom.xml
+++ b/modules/elasticsearch-impl/pom.xml
@@ -13,7 +13,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/elasticsearch-index/pom.xml
+++ b/modules/elasticsearch-index/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <!-- osgi support -->

--- a/modules/email-template-service-api/pom.xml
+++ b/modules/email-template-service-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/email-template-service-impl/pom.xml
+++ b/modules/email-template-service-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/engage-ui/pom.xml
+++ b/modules/engage-ui/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/event-comment/pom.xml
+++ b/modules/event-comment/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/execute-api/pom.xml
+++ b/modules/execute-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/execute-impl/pom.xml
+++ b/modules/execute-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/execute-remote/pom.xml
+++ b/modules/execute-remote/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/execute-workflowoperation/pom.xml
+++ b/modules/execute-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/external-api/pom.xml
+++ b/modules/external-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <!-- osgi support -->

--- a/modules/graphql-ui/pom.xml
+++ b/modules/graphql-ui/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
     <nodejs.version>v20.10.0</nodejs.version>
   </properties>
   <profiles>

--- a/modules/graphql/pom.xml
+++ b/modules/graphql/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/hello-world-api/pom.xml
+++ b/modules/hello-world-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <build>
     <plugins>

--- a/modules/hello-world-impl/pom.xml
+++ b/modules/hello-world-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <!-- Opencast dependencies -->

--- a/modules/hello-world-workflowoperation/pom.xml
+++ b/modules/hello-world-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/incident-workflowoperation/pom.xml
+++ b/modules/incident-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/index-service/pom.xml
+++ b/modules/index-service/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <!-- osgi support -->

--- a/modules/ingest-download-service-api/pom.xml
+++ b/modules/ingest-download-service-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/ingest-download-service-impl/pom.xml
+++ b/modules/ingest-download-service-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <!-- Opencast dependencies -->

--- a/modules/ingest-download-service-remote/pom.xml
+++ b/modules/ingest-download-service-remote/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/ingest-download-service-workflowoperation/pom.xml
+++ b/modules/ingest-download-service-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/ingest-service-api/pom.xml
+++ b/modules/ingest-service-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/ingest-service-impl/pom.xml
+++ b/modules/ingest-service-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/inspection-service-api/pom.xml
+++ b/modules/inspection-service-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/inspection-service-ffmpeg/pom.xml
+++ b/modules/inspection-service-ffmpeg/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/inspection-service-remote/pom.xml
+++ b/modules/inspection-service-remote/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/inspection-workflowoperation/pom.xml
+++ b/modules/inspection-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/jacoco-reports/pom.xml
+++ b/modules/jacoco-reports/pom.xml
@@ -13,7 +13,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <!-- FIXME: This sucks, but because of https://github.com/jacoco/jacoco/wiki/MavenMultiModule we need to

--- a/modules/kernel/pom.xml
+++ b/modules/kernel/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/list-providers-service/pom.xml
+++ b/modules/list-providers-service/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/live-schedule-api/pom.xml
+++ b/modules/live-schedule-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/live-schedule-impl/pom.xml
+++ b/modules/live-schedule-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/logging-workflowoperation/pom.xml
+++ b/modules/logging-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/lti-service-api/pom.xml
+++ b/modules/lti-service-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/lti-service-impl/pom.xml
+++ b/modules/lti-service-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <!-- osgi support -->

--- a/modules/lti-service-remote/pom.xml
+++ b/modules/lti-service-remote/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <!-- osgi support -->

--- a/modules/lti/pom.xml
+++ b/modules/lti/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/mattermost-notification-workflowoperation/pom.xml
+++ b/modules/mattermost-notification-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/message-broker-api/pom.xml
+++ b/modules/message-broker-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/metadata-api/pom.xml
+++ b/modules/metadata-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/metadata-to-acl-workflowoperation/pom.xml
+++ b/modules/metadata-to-acl-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/metadata/pom.xml
+++ b/modules/metadata/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/metrics-exporter/pom.xml
+++ b/modules/metrics-exporter/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
     <prometheus.version>0.16.0</prometheus.version>
   </properties>
   <dependencies>

--- a/modules/mpeg7/pom.xml
+++ b/modules/mpeg7/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/notification-workflowoperation/pom.xml
+++ b/modules/notification-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/oaipmh-api/pom.xml
+++ b/modules/oaipmh-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/oaipmh-persistence/pom.xml
+++ b/modules/oaipmh-persistence/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/oaipmh-remote/pom.xml
+++ b/modules/oaipmh-remote/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/oaipmh/pom.xml
+++ b/modules/oaipmh/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/playlists/pom.xml
+++ b/modules/playlists/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/plugin-manager/pom.xml
+++ b/modules/plugin-manager/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <!-- Opencast dependencies -->

--- a/modules/publication-service-api/pom.xml
+++ b/modules/publication-service-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/publication-service-configurable-remote/pom.xml
+++ b/modules/publication-service-configurable-remote/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/publication-service-configurable/pom.xml
+++ b/modules/publication-service-configurable/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/publication-service-oaipmh-remote/pom.xml
+++ b/modules/publication-service-oaipmh-remote/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/publication-service-oaipmh/pom.xml
+++ b/modules/publication-service-oaipmh/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/publication-service-youtube-remote/pom.xml
+++ b/modules/publication-service-youtube-remote/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/publication-service-youtube-v3/pom.xml
+++ b/modules/publication-service-youtube-v3/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
     <project.youtube.version>v3-rev183-1.22.0</project.youtube.version>
     <project.http.version>1.22.0</project.http.version>
     <project.oauth.version>1.22.0</project.oauth.version>

--- a/modules/redirect/pom.xml
+++ b/modules/redirect/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/rename-files-workflowoperation/pom.xml
+++ b/modules/rename-files-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/rest-test-environment/pom.xml
+++ b/modules/rest-test-environment/pom.xml
@@ -16,7 +16,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/runtime-info-ui/pom.xml
+++ b/modules/runtime-info-ui/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/runtime-info/pom.xml
+++ b/modules/runtime-info/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/scheduler-api/pom.xml
+++ b/modules/scheduler-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/scheduler-impl/pom.xml
+++ b/modules/scheduler-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/scheduler-remote/pom.xml
+++ b/modules/scheduler-remote/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/schema/pom.xml
+++ b/modules/schema/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/search-service-api/pom.xml
+++ b/modules/search-service-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/search-service-impl/pom.xml
+++ b/modules/search-service-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/security-aai/pom.xml
+++ b/modules/security-aai/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/security-cas-client-wrapper/pom.xml
+++ b/modules/security-cas-client-wrapper/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/security-cas/pom.xml
+++ b/modules/security-cas/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/security-jwt/pom.xml
+++ b/modules/security-jwt/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
     <java-jwt.version>3.18.1</java-jwt.version>
     <jwks-rsa.version>0.22.1</jwks-rsa.version>
   </properties>

--- a/modules/security-ldap/pom.xml
+++ b/modules/security-ldap/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/security-lti/pom.xml
+++ b/modules/security-lti/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/security-shibboleth/pom.xml
+++ b/modules/security-shibboleth/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/series-service-api/pom.xml
+++ b/modules/series-service-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/series-service-impl/pom.xml
+++ b/modules/series-service-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/series-service-remote/pom.xml
+++ b/modules/series-service-remote/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/serviceregistry/pom.xml
+++ b/modules/serviceregistry/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/shared-filesystem-utils/pom.xml
+++ b/modules/shared-filesystem-utils/pom.xml
@@ -31,7 +31,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/silencedetection-api/pom.xml
+++ b/modules/silencedetection-api/pom.xml
@@ -13,7 +13,6 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <build>
     <plugins>

--- a/modules/silencedetection-impl/pom.xml
+++ b/modules/silencedetection-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <build>
     <plugins>

--- a/modules/silencedetection-remote/pom.xml
+++ b/modules/silencedetection-remote/pom.xml
@@ -13,7 +13,6 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <build>
     <plugins>

--- a/modules/smil-api/pom.xml
+++ b/modules/smil-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>
@@ -56,7 +55,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <configuration>
-          <skip>${checkstyle.skip}</skip>
           <!-- disabled checking external w3c SMIL interfaces -->
           <excludes>
             org/w3c/**

--- a/modules/smil-impl/pom.xml
+++ b/modules/smil-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/smil-workflowoperation/pom.xml
+++ b/modules/smil-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/speech-to-text-api/pom.xml
+++ b/modules/speech-to-text-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/speech-to-text-impl/pom.xml
+++ b/modules/speech-to-text-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/speech-to-text-remote/pom.xml
+++ b/modules/speech-to-text-remote/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/speech-to-text-workflowoperation/pom.xml
+++ b/modules/speech-to-text-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/static-file-service-api/pom.xml
+++ b/modules/static-file-service-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/static-file-service-impl/pom.xml
+++ b/modules/static-file-service-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/static/pom.xml
+++ b/modules/static/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/statistics-export-service-api/pom.xml
+++ b/modules/statistics-export-service-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/statistics-export-service-impl/pom.xml
+++ b/modules/statistics-export-service-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/statistics-provider-influx/pom.xml
+++ b/modules/statistics-provider-influx/pom.xml
@@ -13,7 +13,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/statistics-provider-matomo/pom.xml
+++ b/modules/statistics-provider-matomo/pom.xml
@@ -13,7 +13,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/statistics-provider-random/pom.xml
+++ b/modules/statistics-provider-random/pom.xml
@@ -13,7 +13,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/statistics-service-api/pom.xml
+++ b/modules/statistics-service-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/statistics-service-impl/pom.xml
+++ b/modules/statistics-service-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/statistics-service-remote/pom.xml
+++ b/modules/statistics-service-remote/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/statistics-writer-workflowoperation/pom.xml
+++ b/modules/statistics-writer-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/studio-service/pom.xml
+++ b/modules/studio-service/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/studio/pom.xml
+++ b/modules/studio/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
     <opencast.studio.url>https://github.com/opencast/studio/releases/download/2025-12-17/oc-studio-2025-12-18-integrated.tar.gz</opencast.studio.url>
     <opencast.studio.sha256>cba5f7b617c82c24ac048e63eb76be9ebf5fa2630dfdce7da4f919538e21e376</opencast.studio.sha256>
   </properties>

--- a/modules/subtitle-parser/pom.xml
+++ b/modules/subtitle-parser/pom.xml
@@ -13,7 +13,6 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
 
   <dependencies>

--- a/modules/subtitle-timeshift-workflowoperation/pom.xml
+++ b/modules/subtitle-timeshift-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/termination-state-api/pom.xml
+++ b/modules/termination-state-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/termination-state-aws/pom.xml
+++ b/modules/termination-state-aws/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <!-- Other Opencast dependencies -->

--- a/modules/termination-state-impl/pom.xml
+++ b/modules/termination-state-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <!-- Other Opencast dependencies -->

--- a/modules/textanalyzer-api/pom.xml
+++ b/modules/textanalyzer-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/textanalyzer-impl/pom.xml
+++ b/modules/textanalyzer-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/textanalyzer-remote/pom.xml
+++ b/modules/textanalyzer-remote/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/textanalyzer-workflowoperation/pom.xml
+++ b/modules/textanalyzer-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/textextractor-tesseract/pom.xml
+++ b/modules/textextractor-tesseract/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <!-- Opencast dependencies -->

--- a/modules/themes-workflowoperation/pom.xml
+++ b/modules/themes-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/themes/pom.xml
+++ b/modules/themes/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/timelinepreviews-api/pom.xml
+++ b/modules/timelinepreviews-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/timelinepreviews-ffmpeg/pom.xml
+++ b/modules/timelinepreviews-ffmpeg/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/timelinepreviews-remote/pom.xml
+++ b/modules/timelinepreviews-remote/pom.xml
@@ -10,12 +10,9 @@
     <version>20-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
-
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.opencastproject</groupId>

--- a/modules/timelinepreviews-workflowoperation/pom.xml
+++ b/modules/timelinepreviews-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/tobira/pom.xml
+++ b/modules/tobira/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
     <prometheus.version>0.9.0</prometheus.version>
   </properties>
   <dependencies>

--- a/modules/transcription-service-amberscript/pom.xml
+++ b/modules/transcription-service-amberscript/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/transcription-service-api/pom.xml
+++ b/modules/transcription-service-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/transcription-service-google-speech-impl/pom.xml
+++ b/modules/transcription-service-google-speech-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/transcription-service-ibm-watson-impl/pom.xml
+++ b/modules/transcription-service-ibm-watson-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/transcription-service-microsoft-azure/pom.xml
+++ b/modules/transcription-service-microsoft-azure/pom.xml
@@ -13,7 +13,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/transcription-service-microsoft-azure/src/main/java/org/opencastproject/transcription/microsoft/azure/model/MicrosoftAzureSpeechTranscriptions.java
+++ b/modules/transcription-service-microsoft-azure/src/main/java/org/opencastproject/transcription/microsoft/azure/model/MicrosoftAzureSpeechTranscriptions.java
@@ -30,14 +30,14 @@ public class MicrosoftAzureSpeechTranscriptions {
   // Documentation:
   // https://eastus.dev.cognitive.microsoft.com/docs/services/speech-to-text-api-v3-1/operations/Transcriptions_List
 
-  //CHECKSTYLE:OFF checkstyle:VisibilityModifier
+  // CHECKSTYLE:OFF checkstyle:VisibilityModifier
 
   public List<MicrosoftAzureSpeechTranscription> values;
 
   @SerializedName("@nextLink")
   public String nextLink;
 
-  //CHECKSTYLE:ON checkstyle:VisibilityModifier
+  // CHECKSTYLE:ON checkstyle:VisibilityModifier
 
   /** Default constructor. */
   public MicrosoftAzureSpeechTranscriptions() { }

--- a/modules/transcription-service-persistence/pom.xml
+++ b/modules/transcription-service-persistence/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/transcription-service-workflowoperation/pom.xml
+++ b/modules/transcription-service-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/urlsigning-common/pom.xml
+++ b/modules/urlsigning-common/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/urlsigning-service-api/pom.xml
+++ b/modules/urlsigning-service-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/urlsigning-service-impl/pom.xml
+++ b/modules/urlsigning-service-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <!-- Third Party -->

--- a/modules/urlsigning-verifier-service-api/pom.xml
+++ b/modules/urlsigning-verifier-service-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <!-- Opencast -->

--- a/modules/urlsigning-verifier-service-impl/pom.xml
+++ b/modules/urlsigning-verifier-service-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <!-- Third Party -->

--- a/modules/user-interface-configuration/pom.xml
+++ b/modules/user-interface-configuration/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/userdirectory-brightspace/pom.xml
+++ b/modules/userdirectory-brightspace/pom.xml
@@ -14,7 +14,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/userdirectory-canvas/pom.xml
+++ b/modules/userdirectory-canvas/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/userdirectory-ldap/pom.xml
+++ b/modules/userdirectory-ldap/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/userdirectory-moodle/pom.xml
+++ b/modules/userdirectory-moodle/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/userdirectory-sakai/pom.xml
+++ b/modules/userdirectory-sakai/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/userdirectory-studip/pom.xml
+++ b/modules/userdirectory-studip/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/userdirectory/pom.xml
+++ b/modules/userdirectory/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/usertracking-api/pom.xml
+++ b/modules/usertracking-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/usertracking-impl/pom.xml
+++ b/modules/usertracking-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/videoeditor-api/pom.xml
+++ b/modules/videoeditor-api/pom.xml
@@ -13,7 +13,6 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
 
   <dependencies>

--- a/modules/videoeditor-ffmpeg-impl/pom.xml
+++ b/modules/videoeditor-ffmpeg-impl/pom.xml
@@ -13,7 +13,6 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <build>
     <plugins>

--- a/modules/videoeditor-remote/pom.xml
+++ b/modules/videoeditor-remote/pom.xml
@@ -13,7 +13,6 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <build>
     <plugins>

--- a/modules/videoeditor-workflowoperation/pom.xml
+++ b/modules/videoeditor-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/videogrid-remote/pom.xml
+++ b/modules/videogrid-remote/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/videogrid-service-api/pom.xml
+++ b/modules/videogrid-service-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/videogrid-service-impl/pom.xml
+++ b/modules/videogrid-service-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/videogrid-workflowoperation/pom.xml
+++ b/modules/videogrid-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/videosegmenter-api/pom.xml
+++ b/modules/videosegmenter-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/videosegmenter-ffmpeg/pom.xml
+++ b/modules/videosegmenter-ffmpeg/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <!-- Opencast dependencies -->

--- a/modules/videosegmenter-remote/pom.xml
+++ b/modules/videosegmenter-remote/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <!-- Opencast dependencies -->

--- a/modules/videosegmenter-workflowoperation/pom.xml
+++ b/modules/videosegmenter-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/waveform-api/pom.xml
+++ b/modules/waveform-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/waveform-ffmpeg/pom.xml
+++ b/modules/waveform-ffmpeg/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/waveform-remote/pom.xml
+++ b/modules/waveform-remote/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/waveform-workflowoperation/pom.xml
+++ b/modules/waveform-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/workflow-condition-parser/pom.xml
+++ b/modules/workflow-condition-parser/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/workflow-service-api/pom.xml
+++ b/modules/workflow-service-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/workflow-service-impl/pom.xml
+++ b/modules/workflow-service-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/workflow-service-remote/pom.xml
+++ b/modules/workflow-service-remote/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/workflow-workflowoperation/pom.xml
+++ b/modules/workflow-workflowoperation/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/working-file-repository-service-api/pom.xml
+++ b/modules/working-file-repository-service-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/working-file-repository-service-impl/pom.xml
+++ b/modules/working-file-repository-service-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/workspace-api/pom.xml
+++ b/modules/workspace-api/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/workspace-impl/pom.xml
+++ b/modules/workspace-impl/pom.xml
@@ -12,7 +12,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,6 @@
   <inceptionYear>2009</inceptionYear>
   <properties>
     <argLine></argLine>
-    <checkstyle.skip>false</checkstyle.skip>
     <opencast.basedir>${basedir}</opencast.basedir>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -426,7 +425,6 @@
           </dependency>
         </dependencies>
         <configuration>
-          <skip>${checkstyle.skip}</skip>
           <configLocation>${opencast.basedir}/docs/checkstyle/opencast-checkstyle.xml</configLocation>
           <headerLocation>${opencast.basedir}/docs/checkstyle/opencast-header.txt</headerLocation>
           <suppressionsLocation>${opencast.basedir}/docs/checkstyle/checkstyle-suppressions.xml</suppressionsLocation>


### PR DESCRIPTION
This removes the mostly redundant `checkstyle.skip` property from our POMs. Most modules set it to `false`, which is the default, anyway.

It also removes a redundant comment suppression module in the checkstyle config, and configures the remaining one in the way we actually expect.