### PR TITLE
Fix build date in BundleInfoRestEndpoint

### DIFF
--- a/modules/kernel/src/main/java/org/opencastproject/kernel/bundleinfo/BundleInfoRestEndpoint.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/bundleinfo/BundleInfoRestEndpoint.java
@@ -43,6 +43,7 @@ import org.osgi.service.component.annotations.Activate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Dictionary;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -77,7 +78,15 @@ public abstract class BundleInfoRestEndpoint {
 
   @Activate
   public void activate(ComponentContext cc) {
-    lastModified = cc.getBundleContext().getBundle().getLastModified();
+    Dictionary<String, String> headers = cc.getBundleContext().getBundle().getHeaders();
+
+    if (headers != null) {
+      String lastModifiedObj = headers.get("Bnd-LastModified");
+
+      if (lastModifiedObj != null) {
+        lastModified = Long.valueOf(lastModifiedObj);
+      }
+    }
   }
 
   @GET


### PR DESCRIPTION
Fixes #904.

`.getLastModified()` returns the following: "Returns the time when this bundle was last modified. A bundle is considered to be modified when it is installed, updated or uninstalled."

However, what we are looking for here is when the date when the bundle was built. There is no convenient method for that, so we have to parse it from the headers ourselves.

### How to test this patch

1. Built your Opencast.
2. Wait a day.
3. Restart Opencast.
4. Check the built date in the admin ui. It should show todays date, which is wrong.
5. Install this patch.
6. Wait a day.
7. Restart Opencast.
8. Check the built date in the admin ui. It should show yesterdays date, which is correct.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature