### PR TITLE
Add new MIME types for Microsoft Word, Excel, and PowerPoint documents

### DIFF
--- a/modules/common/src/main/resources/org/opencastproject/util/MimeTypes.xml
+++ b/modules/common/src/main/resources/org/opencastproject/util/MimeTypes.xml
@@ -40,6 +40,36 @@
     <Extensions>pdf</Extensions>
   </MimeType>
   <MimeType>
+    <Type>application/msword</Type>
+    <Description>Microsoft Word document</Description>
+    <Extensions>doc,dot</Extensions>
+  </MimeType>
+  <MimeType>
+    <Type>application/vnd.openxmlformats-officedocument.wordprocessingml.document</Type>
+    <Description>Microsoft Word document</Description>
+    <Extensions>docx</Extensions>
+  </MimeType>
+  <MimeType>
+    <Type>application/vnd.ms-excel</Type>
+    <Description>Microsoft Excel document</Description>
+    <Extensions>xls,xlt</Extensions>
+  </MimeType>
+  <MimeType>
+    <Type>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</Type>
+    <Description>Microsoft Excel document</Description>
+    <Extensions>xlsx</Extensions>
+  </MimeType>
+  <MimeType>
+    <Type>application/vnd.ms-powerpoint</Type>
+    <Description>Microsoft PowerPoint document</Description>
+    <Extensions>ppt,pps,pot</Extensions>
+  </MimeType>
+  <MimeType>
+    <Type>application/vnd.openxmlformats-officedocument.presentationml.presentation</Type>
+    <Description>Microsoft PowerPoint document</Description>
+    <Extensions>pptx</Extensions>
+  </MimeType>
+  <MimeType>
     <Type>application/sdp</Type>
     <Description>SDP stream descriptor</Description>
     <Extensions>sdp</Extensions>


### PR DESCRIPTION
Adds the MimeType for Microsoft Word, Excel, and PowerPoint documents.

Targeted `r/17.x` as it's a simple change. Let me know if it should be moved to another branch.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature
