### PR TITLE
Fix broken Player Default

### DIFF
--- a/modules/engage-ui/src/main/java/org/opencastproject/engage/ui/PlayerRedirect.java
+++ b/modules/engage-ui/src/main/java/org/opencastproject/engage/ui/PlayerRedirect.java
@@ -70,7 +70,7 @@ public class PlayerRedirect {
 
   private static final Logger logger = LoggerFactory.getLogger(PlayerRedirect.class);
 
-  private static final String PLAYER_DEFAULT = "/paella7/ui/watch.html?id=#{id}";
+  private static final String PLAYER_DEFAULT = "/paella8/ui/watch.html?id=#{id}";
 
   private SecurityService securityService;
 

--- a/modules/engage-ui/src/test/java/org/opencastproject/engage/ui/PlayerRedirectTest.java
+++ b/modules/engage-ui/src/test/java/org/opencastproject/engage/ui/PlayerRedirectTest.java
@@ -59,7 +59,7 @@ public class PlayerRedirectTest extends EasyMockSupport {
 
     try (Response response = playerRedirect.redirect(eventId)) {
       assertEquals(Response.Status.TEMPORARY_REDIRECT.getStatusCode(), response.getStatus());
-      assertEquals("/paella7/ui/watch.html?id=event1", response.getHeaderString("location"));
+      assertEquals("/paella8/ui/watch.html?id=event1", response.getHeaderString("location"));
     }
 
     verifyAll();
@@ -91,7 +91,7 @@ public class PlayerRedirectTest extends EasyMockSupport {
 
     try (Response response = playerRedirect.redirect(eventId)) {
       assertEquals(Response.Status.TEMPORARY_REDIRECT.getStatusCode(), response.getStatus());
-      assertEquals("/paella7/ui/watch.html?id=event%2520with%2520spaces", response.getHeaderString("location"));
+      assertEquals("/paella8/ui/watch.html?id=event%2520with%2520spaces", response.getHeaderString("location"));
     }
 
     verifyAll();
@@ -106,7 +106,7 @@ public class PlayerRedirectTest extends EasyMockSupport {
 
     try (Response response = playerRedirect.redirect(eventId)) {
       assertEquals(Response.Status.TEMPORARY_REDIRECT.getStatusCode(), response.getStatus());
-      assertEquals("/paella7/ui/watch.html?id=%C3%BC%C3%A4%C3%B6%C3%9F%24%25%26%2F%28%29%3D%3F%21%C2%A7",
+      assertEquals("/paella8/ui/watch.html?id=%C3%BC%C3%A4%C3%B6%C3%9F%24%25%26%2F%28%29%3D%3F%21%C2%A7",
           response.getHeaderString("location"));
     }
 


### PR DESCRIPTION
Paella 8 is now in Opencast.
Paella 7 is a plugin and disabled by default.
Paella 7 is set as the default.
This means all video links are broken by default.
This patch updates the defaults to point to Paella 8.

### How to test this patch

Just build and launch Opencast.
Player links should work again and point to Paella 8.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
