### PR TITLE
Disable error states by default

### DIFF
--- a/docs/guides/admin/docs/releasenotes/disable-service-states-by-default.txt
+++ b/docs/guides/admin/docs/releasenotes/disable-service-states-by-default.txt
@@ -1,1 +1,1 @@
-#NNNN: Disable service states by default.  These tended to cause more issues in modern systems.  Functionality is still present, just disabled by default.
+#7450: Disable service states by default.  These tended to cause more issues in modern systems.  Functionality is still present, just disabled by default.

--- a/docs/guides/admin/docs/releasenotes/disable-service-states-by-default.txt
+++ b/docs/guides/admin/docs/releasenotes/disable-service-states-by-default.txt
@@ -1,0 +1,1 @@
+#NNNN: Disable service states by default.  These tended to cause more issues in modern systems.  Functionality is still present, just disabled by default.

--- a/etc/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg
+++ b/etc/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg
@@ -1,8 +1,10 @@
 # Configuration for the service registry
 
 # Number of failed jobs on a service before to set it in error state. Set to -1 to disable error states completely.
-# Default: 10
-#max.attempts=10
+# This is generally not something you wish to enable unless you are frequently seeing worker nodes which fail every job
+# they accept, eg: cloud servers starting in broken states.
+# Default: -1
+#max.attempts=-1
 
 # Comma-separated list of service types that should never go into error state, e.g. org.opencastproject.assetmanager
 # Default: None

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -211,7 +211,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
   static final String NO_ERROR_STATE_SERVICE_TYPES_CONFIG_KEY = "no.error.state.service.types";
 
   /** Default value for {@link #maxAttemptsBeforeErrorState} */
-  private static final int DEFAULT_MAX_ATTEMPTS_BEFORE_ERROR_STATE = 10;
+  private static final int DEFAULT_MAX_ATTEMPTS_BEFORE_ERROR_STATE = -1;
 
   /** Default value for {@link #errorStatesEnabled} */
   private static final boolean DEFAULT_ERROR_STATES_ENABLED = true;


### PR DESCRIPTION
This PR disables service error states by default, as discussed in the developer meeting at Manchester.  This PR also adds documentation around when you migth need these states.  Does this need additional markdown docs, if so where?

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriatex
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] ~explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch~
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
