### PR TITLE
Make "ISPUBLISHED" filter translatable in admin ui

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/EventsListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/EventsListProvider.java
@@ -58,7 +58,7 @@ public class EventsListProvider implements ResourceListProvider {
   public static final String STATUS = PROVIDER_PREFIX + ".STATUS";
   public static final String COMMENTS = PROVIDER_PREFIX + ".COMMENTS";
   public static final String PUBLISHER = PROVIDER_PREFIX + ".PUBLISHER";
-  public static final String ISPUBLISHED = PROVIDER_PREFIX + ".ISPUBLISHED";
+  public static final String ISPUBLISHED = PROVIDER_PREFIX + ".IS_PUBLISHED";
 
   public enum Comments {
     NONE, OPEN, RESOLVED;
@@ -139,7 +139,7 @@ public class EventsListProvider implements ResourceListProvider {
       }
     } else if (ISPUBLISHED.equals(listName)) {
       for (IsPublished isPublished : IsPublished.values()) {
-        list.put(isPublished.toString(), "FILTERS.EVENTS.ISPUBLISHED." + isPublished.toString());
+        list.put(isPublished.toString(), "FILTERS.EVENTS.IS_PUBLISHED." + isPublished.toString());
       }
     }
 
@@ -148,7 +148,7 @@ public class EventsListProvider implements ResourceListProvider {
 
   @Override
   public boolean isTranslatable(String listName) {
-    return STATUS.equals(listName) || COMMENTS.equals(listName);
+    return STATUS.equals(listName) || COMMENTS.equals(listName) || ISPUBLISHED.equals(listName);
   }
 
   @Override


### PR DESCRIPTION
Sets a flag for the "ISPUBLISHED" filter that marks as translatable for the admin ui. That way, the options for the filter in the admin ui will (attempted to) be translated.
Also changed the translation string to make it the same as for the label.

### How to test this patch

You'll want to test this with the admin ui, but the admin ui currently lacks the appropriate translations. If you want to test with translations, you'll have to modify `lang-en_US.json` in the admin ui and add the following under FILTERS.EVENTS.

```
			"IS_PUBLISHED": {
				"LABEL": "Is published",
				"YES": "Yes",
				"NO": "No"
			},
```


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
