### PR TITLE
Improve frontend-less and -reduced builds

### DIFF
--- a/docs/guides/developer/docs/develop/development-tips.md
+++ b/docs/guides/developer/docs/develop/development-tips.md
@@ -29,9 +29,9 @@ one `allinone` distribution to be created. It is already unpacked and ready to b
 
     ./mvnw clean install -Pdev
 
-The administrative user interface needs nodejs to build and phantomjs for testing purposes. These will be downloaded as
-prebuilt binaries during the maven build process. If there are no prebuilt binaries for your operating system, you can
-build the tools manually and then build opencast using the `frontend-no-prebuilt` maven profile:
+Several frontend modules need Node.js to build. It will be downloaded as a prebuilt binary during the Maven build
+process. If there are no prebuilt binaries for your operating system, you can build the tools manually and then
+build Opencast using the `frontend-no-prebuilt` Maven profile:
 
     ./mvnw clean install -Pdev,frontend-no-prebuilt
 

--- a/modules/graphql-ui/pom.xml
+++ b/modules/graphql-ui/pom.xml
@@ -14,10 +14,14 @@
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
     <nodejs.version>v20.10.0</nodejs.version>
+    <ui.include.resource>/ui=-target/classes/</ui.include.resource>
   </properties>
   <profiles>
     <profile>
       <id>frontend-no-prebuild</id>
+      <properties>
+        <ui.include.resource>/ui=target/classes/</ui.include.resource>
+      </properties>
       <build>
         <plugins>
           <plugin>
@@ -63,6 +67,9 @@
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
+      <properties>
+        <ui.include.resource>/ui=target/classes/</ui.include.resource>
+      </properties>
       <build>
         <plugins>
           <plugin>
@@ -134,7 +141,7 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
-            <Include-Resource>/ui=target/classes/</Include-Resource>
+            <Include-Resource>${ui.include.resource}</Include-Resource>
             <Import-Package>!*</Import-Package>
             <Export-Package>!*</Export-Package>
             <Http-Alias>/graphql-ui</Http-Alias>

--- a/modules/graphql-ui/pom.xml
+++ b/modules/graphql-ui/pom.xml
@@ -17,6 +17,48 @@
   </properties>
   <profiles>
     <profile>
+      <id>frontend-no-prebuild</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>npm ci</id>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <phase>validate</phase>
+                <configuration>
+                  <executable>npm</executable>
+                  <arguments>
+                    <argument>ci</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+
+              <execution>
+                <id>npm run build</id>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <phase>generate-resources</phase>
+                <configuration>
+                  <executable>npm</executable>
+                  <arguments>
+                    <argument>run</argument>
+                    <argument>build</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <id>frontend</id>
       <activation>
         <activeByDefault>true</activeByDefault>


### PR DESCRIPTION
This adds the conventional `frontend-no-prebuilt` profile to `graphql-ui`, where it was missing, and also enables that module to be built using `-P!frontend`. It also fixes a small inconsistency in the docs regarding this.