### PR TITLE
Change subject type from text to mixed_text

### DIFF
--- a/docs/guides/admin/docs/releasenotes/subject-mixed-text.txt
+++ b/docs/guides/admin/docs/releasenotes/subject-mixed-text.txt
@@ -1,0 +1,1 @@
+- [#7462](https://github.com/opencast/opencast/pull/7462/): Changed type of event and series `subject` field from `text` to `mixed_text`. Which allows better handling of keywords and a consistent handling between UI and external API.

--- a/etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg
+++ b/etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg
@@ -63,7 +63,7 @@ property.contributors.order=8
 # Subject
 property.subject.inputID=subject
 property.subject.label=EVENTS.EVENTS.DETAILS.METADATA.SUBJECT
-property.subject.type=text
+property.subject.type=mixed_text
 property.subject.readOnly=false
 property.subject.required=false
 property.subject.order=1

--- a/etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-series-common.cfg
+++ b/etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-series-common.cfg
@@ -63,7 +63,7 @@ property.organizer.order=6
 # Subject
 property.subject.inputID=subject
 property.subject.label=EVENTS.SERIES.DETAILS.METADATA.SUBJECT
-property.subject.type=text
+property.subject.type=mixed_text
 property.subject.readOnly=false
 property.subject.required=false
 property.subject.order=1

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
@@ -422,7 +422,7 @@ public class SeriesEndpoint {
     MetadataField subject = metadata.getOutputFields().get(DublinCore.PROPERTY_SUBJECT.getLocalName());
     metadata.removeField(subject);
     MetadataField newSubject = new MetadataField(subject);
-    newSubject.setValue(series.getSubject());
+    newSubject.setValue(series.getSubjects());
     metadata.addField(newSubject);
 
     MetadataField description = metadata.getOutputFields().get(DublinCore.PROPERTY_DESCRIPTION.getLocalName());

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/event/Event.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/event/Event.java
@@ -49,6 +49,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -72,7 +73,7 @@ import javax.xml.stream.XMLStreamWriter;
     name = "event",
     namespace = IndexObject.INDEX_XML_NAMESPACE,
     propOrder = {
-        "identifier", "organization", "title", "description", "subject", "location", "presenters",
+        "identifier", "organization", "title", "description", "subjects", "subject", "location", "presenters",
         "contributors", "seriesId", "seriesName", "language", "source", "created", "creator",
         "publisher", "license", "rights", "extendedMetadata", "accessPolicy", "managedAcl", "workflowState",
         "workflowId", "workflowDefinitionId", "recordingStartTime", "recordingEndTime", "duration",
@@ -136,8 +137,9 @@ public class Event implements IndexObject {
   private String description = null;
 
   /** The subject */
+  @XmlElementWrapper(name = "subjects")
   @XmlElement(name = "subject")
-  private String subject = null;
+  private List<String> subjects = new ArrayList<>();
 
   /** The location */
   @XmlElement(name = "location")
@@ -366,8 +368,8 @@ public class Event implements IndexObject {
    * @param subject
    *          the subject to set
    */
-  public void setSubject(String subject) {
-    this.subject = subject;
+  public void setSubjects(List<String> subject) {
+    this.subjects = subject;
   }
 
   /**
@@ -375,8 +377,34 @@ public class Event implements IndexObject {
    *
    * @return the subject
    */
-  public String getSubject() {
-    return subject;
+  public List<String> getSubjects() {
+    return subjects;
+  }
+
+  /**
+   * Sets the recording subject
+   *
+   * @param subject
+   *          the subject to set
+   */
+  @XmlElement(name = "subject")
+  @Deprecated
+  private void setSubject(String subject) {
+    if (this.subjects.isEmpty() && Objects.nonNull(subject)) {
+      // The external api is splitting the subject by comma, this mimics that behavior
+      // if the metadata is saved it will be stored as list
+      this.subjects.addAll(List.of(subject.split(",")));
+    }
+  }
+
+  /**
+   * Returns the recording subject.
+   *
+   * @return the subject
+   */
+  @Deprecated
+  private String getSubject() {
+    return String.join(",", this.subjects);
   }
 
   /**

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/event/EventIndexUtils.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/event/EventIndexUtils.java
@@ -139,8 +139,9 @@ public final class EventIndexUtils {
     if (StringUtils.isNotBlank(event.getLanguage())) {
       metadata.addField(EventIndexSchema.LANGUAGE, event.getLanguage(), false);
     }
-    if (StringUtils.isNotBlank(event.getSubject())) {
-      metadata.addField(EventIndexSchema.SUBJECT, event.getSubject(), true);
+    if (event.getSubjects() != null) {
+      List<String> subjects = event.getSubjects();
+      metadata.addField(EventIndexSchema.SUBJECT, subjects.toArray(new String[0]), true);
     }
     if (StringUtils.isNotBlank(event.getSource())) {
       metadata.addField(EventIndexSchema.SOURCE, event.getSource(), false);
@@ -461,7 +462,7 @@ public final class EventIndexUtils {
   public static Event updateEvent(Event event, DublinCore dc) {
     event.setTitle(dc.getFirst(DublinCore.PROPERTY_TITLE));
     event.setDescription(dc.getFirst(DublinCore.PROPERTY_DESCRIPTION));
-    event.setSubject(dc.getFirst(DublinCore.PROPERTY_SUBJECT));
+    event.setSubjects(dc.get(DublinCore.PROPERTY_SUBJECT, DublinCore.LANGUAGE_ANY));
     event.setLocation(dc.getFirst(DublinCore.PROPERTY_SPATIAL));
     event.setLanguage(dc.getFirst(DublinCore.PROPERTY_LANGUAGE));
     event.setSource(dc.getFirst(DublinCore.PROPERTY_SOURCE));

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/series/Series.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/series/Series.java
@@ -46,6 +46,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -66,8 +67,9 @@ import javax.xml.stream.XMLStreamWriter;
  * Object wrapper for a series.
  */
 @XmlType(name = "series", namespace = IndexObject.INDEX_XML_NAMESPACE, propOrder = { "identifier", "title",
-        "description", "subject", "organization", "language", "creator", "license", "extendedMetadata", "accessPolicy",
-        "managedAcl", "createdDateTime", "organizers", "contributors", "publishers", "rightsHolder", "theme" })
+        "description", "subjects", "subject", "organization", "language", "creator", "license", "extendedMetadata",
+        "accessPolicy", "managedAcl", "createdDateTime", "organizers", "contributors", "publishers", "rightsHolder",
+        "theme" })
 @XmlRootElement(name = "series", namespace = IndexObject.INDEX_XML_NAMESPACE)
 @XmlAccessorType(XmlAccessType.NONE)
 public class Series implements IndexObject {
@@ -91,8 +93,8 @@ public class Series implements IndexObject {
   private String description = null;
 
   /** The subject */
-  @XmlElement(name = "subject")
-  private String subject = null;
+  @XmlElement(name = "subjects")
+  private List<String> subjects = new ArrayList<>();
 
   /** The organization for the series */
   @XmlElement(name = "organization")
@@ -251,11 +253,11 @@ public class Series implements IndexObject {
   /**
    * Sets the series subject.
    *
-   * @param subject
+   * @param subjects
    *          the subject
    */
-  public void setSubject(String subject) {
-    this.subject = subject;
+  public void setSubjects(List<String> subjects) {
+    this.subjects = subjects;
   }
 
   /**
@@ -263,8 +265,31 @@ public class Series implements IndexObject {
    *
    * @return the subject
    */
-  public String getSubject() {
-    return subject;
+  public List<String> getSubjects() {
+    return subjects;
+  }
+
+  /**
+   * Returns the series subject.
+   *
+   * @return the subject
+   */
+  @Deprecated
+  private String getSubject() {
+    return String.join(",", this.subjects);
+  }
+
+  /**
+   * Sets the series subject.
+   *
+   * @param subject the subject
+   */
+  @XmlElement(name = "subject")
+  @Deprecated
+  private void setSubject(String subject) {
+    if (this.subjects.isEmpty() && Objects.nonNull(subject)) {
+      this.subjects.addAll(List.of(subject.split(",")));
+    }
   }
 
   /**

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/series/SeriesIndexUtils.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/series/SeriesIndexUtils.java
@@ -90,8 +90,8 @@ public final class SeriesIndexUtils {
     if (StringUtils.trimToNull(series.getDescription()) != null) {
       metadata.addField(SeriesIndexSchema.DESCRIPTION, series.getDescription(), true);
     }
-    if (StringUtils.trimToNull(series.getSubject()) != null) {
-      metadata.addField(SeriesIndexSchema.SUBJECT, series.getSubject(), true);
+    if (series.getSubjects() != null) {
+      metadata.addField(SeriesIndexSchema.SUBJECT, series.getSubjects().toArray(), true);
     }
     if (StringUtils.trimToNull(series.getLanguage()) != null) {
       metadata.addField(SeriesIndexSchema.LANGUAGE, series.getLanguage(), false);

--- a/modules/elasticsearch-index/src/test/java/org/opencastproject/elasticsearch/index/objects/event/EventTest.java
+++ b/modules/elasticsearch-index/src/test/java/org/opencastproject/elasticsearch/index/objects/event/EventTest.java
@@ -59,6 +59,7 @@ public class EventTest {
   private static final Object PRESENTER_JSON_KEY = "presenter";
   private static final String PRESENTERS_JSON_KEY = "presenters";
   private static final String SUBJECT_JSON_KEY = "subject";
+  private static final String SUBJECTS_JSON_KEY = "subjects";
   private static final String TITLE_JSON_KEY = "title";
   private static final String ORGANIZATION_JSON_KEY = "organization";
   private static final String IDENTIFIER_JSON_KEY = "identifier";
@@ -68,7 +69,8 @@ public class EventTest {
   private String id = "10.0000-1";
   private String title = "Land and Vegetation: Key players on the Climate Scene";
   private String description = "This is the description for this event.";
-  private String subject = "This is the subject";
+  private List<String> subjects = new ArrayList<>();
+  private String subject1 = "This is the subject";
   private String location = "arts143ca";
 
   private List<String> presenters = new ArrayList<String>();
@@ -97,6 +99,9 @@ public class EventTest {
 
   @Before
   public void setUp() throws IOException {
+    // Setup subject
+    subjects.add(subject1);
+    subjects.add("Another subject");
     // Setup presenter collection
     presenters.add(presenter1);
     presenters.add(presenter2);
@@ -120,7 +125,7 @@ public class EventTest {
     Event event = new Event(id, defaultOrganization);
     event.setTitle(title);
     event.setDescription(description);
-    event.setSubject(subject);
+    event.setSubjects(subjects);
     event.setLocation(location);
     event.setPresenters(presenters);
     event.setContributors(contributors);
@@ -135,7 +140,9 @@ public class EventTest {
     assertEquals(defaultOrganization, eventJsonObject.get(ORGANIZATION_JSON_KEY));
     assertEquals(title, eventJsonObject.get(TITLE_JSON_KEY));
     assertEquals(description, eventJsonObject.get(DESCRIPTION_JSON_KEY));
-    assertEquals(subject, eventJsonObject.get(SUBJECT_JSON_KEY));
+    JSONArray subjectsArray = (JSONArray) ((JSONObject) eventJsonObject.get(SUBJECTS_JSON_KEY))
+        .get(SUBJECT_JSON_KEY);
+    assertEquals(subject1, subjectsArray.getFirst());
     assertEquals(location, eventJsonObject.get(LOCATION_JSON_KEY));
 
     JSONArray presentersArray = (JSONArray) ((JSONObject) eventJsonObject.get(PRESENTERS_JSON_KEY))

--- a/modules/elasticsearch-index/src/test/java/org/opencastproject/elasticsearch/index/objects/series/SeriesTest.java
+++ b/modules/elasticsearch-index/src/test/java/org/opencastproject/elasticsearch/index/objects/series/SeriesTest.java
@@ -62,7 +62,8 @@ public class SeriesTest {
   private String id = "10.0000-1";
   private String title = "Land and Vegetation: Key players on the Climate Scene";
   private String description = "This is the description for this series.";
-  private String subject = "This is the subject";
+  private List<String> subjects = new ArrayList<>();
+  private String subject1 = "This is the subject";
   private String organization = "Organization";
   private String language = "Klingon";
   private String creator = "Creator Name";
@@ -85,6 +86,9 @@ public class SeriesTest {
   @Before
   public void setUp() throws IOException, IllegalStateException, java.text.ParseException {
     createdDateTime = new Date(DateTimeSupport.fromUTC("2011-07-16T20:39:05Z"));
+    // Setup subject collection
+    subjects.add(subject1);
+    subjects.add("This is another subject");
     // Setup presenter collection
     organizers.add(organizer1);
     organizers.add(organizer2);
@@ -100,11 +104,13 @@ public class SeriesTest {
 
   @Test
   public void testToJson() throws ParseException {
+
+
     // Initialize series
     Series series = new Series(id, organization);
     series.setTitle(title);
     series.setDescription(description);
-    series.setSubject(subject);
+    series.setSubjects(subjects);
     series.setLanguage(language);
     series.setCreator(creator);
     series.setLicense(license);
@@ -123,7 +129,7 @@ public class SeriesTest {
     assertEquals(id, seriesJsonObject.get(IDENTIFIER_JSON_KEY));
     assertEquals(title, seriesJsonObject.get(TITLE_JSON_KEY));
     assertEquals(description, seriesJsonObject.get(DESCRIPTION_JSON_KEY));
-    assertEquals(subject, seriesJsonObject.get(SUBJECT_JSON_KEY));
+    assertEquals(subjects, seriesJsonObject.get(SUBJECT_JSON_KEY));
     assertEquals(organization, seriesJsonObject.get(ORGANIZATION_JSON_KEY));
     assertEquals(language, seriesJsonObject.get(LANGUAGE_JSON_KEY));
     assertEquals(creator, seriesJsonObject.get(CREATOR_JSON_KEY));

--- a/modules/elasticsearch-index/src/test/java/org/opencastproject/elasticsearch/index/objects/series/SeriesTest.java
+++ b/modules/elasticsearch-index/src/test/java/org/opencastproject/elasticsearch/index/objects/series/SeriesTest.java
@@ -56,7 +56,7 @@ public class SeriesTest {
   private static final String ORGANIZERS_JSON_KEY = "organizers";
   private static final String ORGANIZER_JSON_KEY = "organizer";
   private static final String SERIES_JSON_KEY = "series";
-  private static final String SUBJECT_JSON_KEY = "subject";
+  private static final String SUBJECTS_JSON_KEY = "subjects";
   private static final String TITLE_JSON_KEY = "title";
 
   private String id = "10.0000-1";
@@ -129,7 +129,7 @@ public class SeriesTest {
     assertEquals(id, seriesJsonObject.get(IDENTIFIER_JSON_KEY));
     assertEquals(title, seriesJsonObject.get(TITLE_JSON_KEY));
     assertEquals(description, seriesJsonObject.get(DESCRIPTION_JSON_KEY));
-    assertEquals(subjects, seriesJsonObject.get(SUBJECT_JSON_KEY));
+    assertEquals(subjects, seriesJsonObject.get(SUBJECTS_JSON_KEY));
     assertEquals(organization, seriesJsonObject.get(ORGANIZATION_JSON_KEY));
     assertEquals(language, seriesJsonObject.get(LANGUAGE_JSON_KEY));
     assertEquals(creator, seriesJsonObject.get(CREATOR_JSON_KEY));

--- a/modules/elasticsearch-index/src/test/resources/adminui_event_metadata.json
+++ b/modules/elasticsearch-index/src/test/resources/adminui_event_metadata.json
@@ -7,7 +7,7 @@
       },
       "end_date":"2008-03-16T14:00:00Z",
       "title":"Land and Vegetation: Key players on the Climate Scene",
-      "subject":"This is the subject",
+      "subject": ["This is the subject"],
       "description":"This is the description for this event.",
       "publications":{
          "engage":"engage.html?e=p-1",

--- a/modules/elasticsearch-index/src/test/resources/adminui_event_metadata.json
+++ b/modules/elasticsearch-index/src/test/resources/adminui_event_metadata.json
@@ -7,7 +7,10 @@
       },
       "end_date":"2008-03-16T14:00:00Z",
       "title":"Land and Vegetation: Key players on the Climate Scene",
-      "subject": ["This is the subject"],
+      "subjects": [
+         "This is the subject",
+         "This is another subject"
+      ],
       "description":"This is the description for this event.",
       "publications":{
          "engage":"engage.html?e=p-1",

--- a/modules/elasticsearch-index/src/test/resources/adminui_event_metadata.xml
+++ b/modules/elasticsearch-index/src/test/resources/adminui_event_metadata.xml
@@ -3,7 +3,9 @@
 	<identifier>10.0000-1</identifier>
 	<title>Land and Vegetation: Key players on the Climate Scene</title>
 	<description>This is the description for this event.</description>
-	<subject>This is the subject</subject>
+	<subjects>
+    <subject>This is the subject</subject>
+  </subjects>
 	<presenters>
 		<presenter>presenter-one</presenter>
 		<presenter>presenter-two</presenter>

--- a/modules/elasticsearch-index/src/test/resources/adminui_series_metadata.json
+++ b/modules/elasticsearch-index/src/test/resources/adminui_series_metadata.json
@@ -7,7 +7,10 @@
       },
       "end_date":"2008-03-16T14:00:00Z",
       "title":"Land and Vegetation: Key players on the Climate Scene",
-      "subject":["This is the subject"],
+      "subjects":[
+         "This is the subject",
+         "This is another subject"
+      ],
       "description":"This is the description for this series.",
       "publications":{
          "engage":"engage.html?e=p-1",

--- a/modules/elasticsearch-index/src/test/resources/adminui_series_metadata.json
+++ b/modules/elasticsearch-index/src/test/resources/adminui_series_metadata.json
@@ -7,7 +7,7 @@
       },
       "end_date":"2008-03-16T14:00:00Z",
       "title":"Land and Vegetation: Key players on the Climate Scene",
-      "subject":"This is the subject",
+      "subject":["This is the subject"],
       "description":"This is the description for this series.",
       "publications":{
          "engage":"engage.html?e=p-1",

--- a/modules/elasticsearch-index/src/test/resources/adminui_series_metadata.xml
+++ b/modules/elasticsearch-index/src/test/resources/adminui_series_metadata.xml
@@ -3,7 +3,9 @@
 	<identifier>10.0000-1</identifier>
 	<title>Land and Vegetation: Key players on the Climate Scene</title>
 	<description>This is the description for this series.</description>
-	<subject>This is the subject</subject>
+	<subjects>
+		<subject>This is the subject</subject>
+	</subjects>
 	<organization>Organization</organization>
 	<language>Klingon</language>
 	<creator>Creator Name</creator>

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -1310,12 +1310,7 @@ public class EventsEndpoint implements ManagedService {
       }
     }
 
-    if (StringUtils.trimToNull(event.getSubject()) != null) {
-      json.add("subjects", splitSubjectIntoArray(event.getSubject()));
-    } else {
-      json.add("subjects", new JsonArray());
-    }
-
+    json.add("subjects", collectionToJsonArray(event.getSubjects()));
     json.addProperty("title", safeString(event.getTitle()));
 
     if (withAcl != null && withAcl) {

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -1787,9 +1787,17 @@ public class EventsEndpoint implements ManagedService {
             return error.get();
           }
           collection.removeField(field);
-          JSONArray subjectArray = (JSONArray) parser.parse(updatedFields.get(key));
-          collection.addField(
-                  MetadataJson.copyWithDifferentJsonValue(field, StringUtils.join(subjectArray.iterator(), ",")));
+          collection.addField(MetadataJson.copyWithDifferentJsonValue(field, updatedFields.get(key)));
+        } else if ("subject".equals(key)) {
+          MetadataField field = collection.getOutputFields().get(DublinCore.PROPERTY_SUBJECT.getLocalName());
+          Optional<Response> error = validateField(field, key, id, type, updatedFields);
+          if (error.isPresent()) {
+            return error.get();
+          }
+          collection.removeField(field);
+          JSONArray a = new JSONArray();
+          a.addAll(List.of(updatedFields.get(key).split(",")));
+          collection.addField(MetadataJson.copyWithDifferentJsonValue(field, a.toJSONString()));
         } else if ("startDate".equals(key)) {
           // Special handling for start date since in API v1 we expect start date and start time to be separate fields.
           MetadataField field = collection.getOutputFields().get(key);

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
@@ -798,8 +798,18 @@ public class SeriesEndpoint {
                 "The series metadata field with id '%s' and the metadata type '%s' is required and can not be empty!.",
                 key, type));
       }
-      collection.removeField(field);
-      collection.addField(MetadataJson.copyWithDifferentJsonValue(field, updatedFields.get(key)));
+      if ("subject".equals(key)) {
+        collection.removeField(field);
+        JsonArray subjects = splitSubjectIntoArray(updatedFields.get(key));
+        collection.addField(MetadataJson.copyWithDifferentJsonValue(
+            field,
+            subjects.toString()
+            )
+        );
+      } else {
+        collection.removeField(field);
+        collection.addField(MetadataJson.copyWithDifferentJsonValue(field, updatedFields.get(key)));
+      }
     }
 
     metadataList.add(adapter, collection);
@@ -1130,12 +1140,20 @@ public class SeriesEndpoint {
             collection.removeField(field);
             try {
               JSONArray subjects = (JSONArray) parser.parse(fields.get(key));
-              collection.addField(
-                      MetadataJson.copyWithDifferentJsonValue(field, StringUtils.join(subjects.iterator(), ",")));
+              collection.addField(MetadataJson.copyWithDifferentJsonValue(field, subjects.toJSONString()));
             } catch (ParseException e) {
               throw new IllegalArgumentException(
-                      String.format("Unable to parse the 'subjects' metadata array field because: %s", e.toString()));
+                      String.format("Unable to parse the 'subjects' metadata array field because: %s", e));
             }
+          } else if ("subject".equals(key)) {
+            MetadataField field = collection.getOutputFields().get("subject");
+            if (field == null) {
+              throw new NotFoundException(String.format(
+                      "Cannot find a metadata field with id '%s' from Catalog with Flavor '%s'.", key, flavorString));
+            }
+            collection.removeField(field);
+            JsonArray subjects = splitSubjectIntoArray(fields.get(key));
+            collection.addField(MetadataJson.copyWithDifferentJsonValue(field, subjects.toString()));
           } else {
             MetadataField field = collection.getOutputFields().get(key);
             if (field == null) {

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
@@ -365,12 +365,6 @@ public class SeriesEndpoint {
 
     for (SearchResultItem<Series> item : result.getItems()) {
       final Series s = item.getSource();
-      JsonArray subjects;
-      if (s.getSubject() == null) {
-        subjects = new JsonArray();
-      } else {
-        subjects = splitSubjectIntoArray(s.getSubject());
-      }
 
       Date createdDate = s.getCreatedDateTime();
       JsonObject seriesJson = new JsonObject();
@@ -379,8 +373,8 @@ public class SeriesEndpoint {
       seriesJson.addProperty("title", s.getTitle());
       seriesJson.addProperty("creator", safeString(s.getCreator()));
       seriesJson.addProperty("created", createdDate != null ? toUTC(createdDate.getTime()) : "");
-      seriesJson.add("subjects", subjects);
 
+      seriesJson.add("subjects", collectionToJsonArray(s.getSubjects()));
       seriesJson.add("contributors", collectionToJsonArray(s.getContributors()));
       seriesJson.add("organizers", collectionToJsonArray(s.getOrganizers()));
       seriesJson.add("publishers", collectionToJsonArray(s.getPublishers()));
@@ -452,12 +446,6 @@ public class SeriesEndpoint {
         securityService.getUser());
     if (optSeries.isPresent()) {
       final Series s = optSeries.get();
-      JsonArray subjects;
-      if (s.getSubject() == null) {
-        subjects = new JsonArray();
-      } else {
-        subjects = splitSubjectIntoArray(s.getSubject());
-      }
       Date createdDate = s.getCreatedDateTime();
 
       JsonObject responseContent = new JsonObject();
@@ -467,7 +455,7 @@ public class SeriesEndpoint {
       responseContent.addProperty("title", s.getTitle());
       responseContent.addProperty("description", safeString(s.getDescription()));
       responseContent.addProperty("creator", safeString(s.getCreator()));
-      responseContent.add("subjects", subjects);
+      responseContent.add("subjects", collectionToJsonArray(s.getSubjects()));
       responseContent.addProperty("organization", s.getOrganization());
       responseContent.addProperty("created", createdDate != null ? toUTC(createdDate.getTime()) : "");
       responseContent.add("contributors", collectionToJsonArray(s.getContributors()));
@@ -604,7 +592,7 @@ public class SeriesEndpoint {
     MetadataField subject = metadata.getOutputFields().get(DublinCore.PROPERTY_SUBJECT.getLocalName());
     metadata.removeField(subject);
     MetadataField newSubject = new MetadataField(subject);
-    newSubject.setValue(series.getSubject());
+    newSubject.setValue(series.getSubjects());
     metadata.addField(newSubject);
 
     MetadataField description = metadata.getOutputFields().get(DublinCore.PROPERTY_DESCRIPTION.getLocalName());

--- a/modules/external-api/src/main/java/org/opencastproject/external/util/ExternalMetadataUtils.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/util/ExternalMetadataUtils.java
@@ -43,8 +43,10 @@ public final class ExternalMetadataUtils {
     final MetadataField subject = collection.getOutputFields().get(DublinCore.PROPERTY_SUBJECT.getLocalName());
     collection.removeField(subject);
     final List<String> newValue;
-    if (subject.getValue() != null) {
+    if (subject.getValue() != null && subject.getValue() instanceof String) {
       newValue = Pattern.compile(",").splitAsStream(subject.getValue().toString()).collect(Collectors.toList());
+    } else if (subject.getValue() != null && subject.getValue() instanceof List) {
+      newValue = (List<String>)subject.getValue();
     } else {
       newValue = null;
     }
@@ -56,7 +58,7 @@ public final class ExternalMetadataUtils {
             subject.isRequired(),
             newValue,
             subject.isTranslatable(),
-            MetadataField.Type.ITERABLE_TEXT,
+            MetadataField.Type.MIXED_TEXT,
             subject.getCollection(),
             subject.getCollectionID(),
             subject.getOrder(),

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/TestSeriesEndpoint.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/TestSeriesEndpoint.java
@@ -52,6 +52,7 @@ import org.apache.commons.io.IOUtils;
 import org.easymock.EasyMock;
 import org.junit.Ignore;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -105,7 +106,7 @@ public class TestSeriesEndpoint extends SeriesEndpoint {
     Series series1 = new Series("4fd0ef66-aea5-4b7a-a62a-a4ada0eafd6f", "opencast");
     series1.setTitle("Via API");
     series1.setDescription("A series created over the external API");
-    series1.setSubject("Topic");
+    series1.setSubjects(Collections.singletonList("Topic"));
     series1.setCreator("Gracie Walsh");
     series1.setCreatedDateTime(new Date(1429175556000L));
     series1.addContributor("Nu'man Farooq Morcos");

--- a/modules/external-api/src/test/resources/episode-catalog.properties
+++ b/modules/external-api/src/test/resources/episode-catalog.properties
@@ -63,7 +63,7 @@ property.contributors.order=8
 # Subject
 property.subject.inputID=subject
 property.subject.label=EVENTS.EVENTS.DETAILS.METADATA.SUBJECT
-property.subject.type=text
+property.subject.type=mixed_text
 property.subject.readOnly=false
 property.subject.required=false
 property.subject.order=1

--- a/modules/external-api/src/test/resources/event-metadata-expected.json
+++ b/modules/external-api/src/test/resources/event-metadata-expected.json
@@ -15,7 +15,7 @@
         "readOnly": false,
         "id": "subjects",
         "label": "EVENTS.EVENTS.DETAILS.METADATA.SUBJECT",
-        "type": "text",
+        "type": "mixed_text",
         "value": [],
         "required": false
       },

--- a/modules/external-api/src/test/resources/event-metadata-update-expected.json
+++ b/modules/external-api/src/test/resources/event-metadata-update-expected.json
@@ -11,8 +11,8 @@
     "readOnly": false,
     "id": "subject",
     "label": "EVENTS.EVENTS.DETAILS.METADATA.SUBJECT",
-    "type": "text",
-    "value": "What this is about - edited",
+    "type": "mixed_text",
+    "value": ["What this is about - edited"],
     "required": false
   },
   {

--- a/modules/external-api/src/test/resources/event-update-expected.json
+++ b/modules/external-api/src/test/resources/event-update-expected.json
@@ -15,8 +15,8 @@
         "readOnly": false,
         "id": "subject",
         "label": "EVENTS.EVENTS.DETAILS.METADATA.SUBJECT",
-        "type": "text",
-        "value": "updated subject 1,updated subject 2",
+        "type": "mixed_text",
+        "value": ["updated subject 1","updated subject 2"],
         "required": false
       },
       {

--- a/modules/external-api/src/test/resources/series-catalog.properties
+++ b/modules/external-api/src/test/resources/series-catalog.properties
@@ -63,7 +63,7 @@ property.organizer.order=6
 # Subject
 property.subject.inputID=subject
 property.subject.label=EVENTS.SERIES.DETAILS.METADATA.SUBJECT
-property.subject.type=text
+property.subject.type=mixed_text
 property.subject.readOnly=false
 property.subject.required=false
 property.subject.order=1

--- a/modules/external-api/src/test/resources/series/metadata/series-metadata-dublincore.json
+++ b/modules/external-api/src/test/resources/series/metadata/series-metadata-dublincore.json
@@ -13,7 +13,7 @@
     "value": ["Topic"],
     "label": "EVENTS.SERIES.DETAILS.METADATA.SUBJECT",
     "required": false,
-    "type": "text"
+    "type": "mixed_text"
   },
   {
     "id": "description",

--- a/modules/external-api/src/test/resources/series/metadata/series-metadata.json
+++ b/modules/external-api/src/test/resources/series/metadata/series-metadata.json
@@ -16,7 +16,7 @@
         "readOnly": false,
         "value": ["Topic"],
         "label": "EVENTS.SERIES.DETAILS.METADATA.SUBJECT",
-        "type": "text",
+        "type": "mixed_text",
         "required": false
       },
       {

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/util/EventHttpServletRequest.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/util/EventHttpServletRequest.java
@@ -451,14 +451,7 @@ public class EventHttpServletRequest {
                       "Cannot find a metadata field with id 'subject' from Catalog with Flavor '%s'.", flavorString));
             }
             collection.removeField(field);
-            try {
-              JSONArray subjects = (JSONArray) parser.parse(fields.get(key));
-              collection.addField(MetadataJson
-                      .copyWithDifferentJsonValue(field, StringUtils.join(subjects.iterator(), ",")));
-            } catch (ParseException e) {
-              throw new IllegalArgumentException(
-                      String.format("Unable to parse the 'subjects' metadata array field because: %s", e.toString()));
-            }
+            collection.addField(MetadataJson.copyWithDifferentJsonValue(field, fields.get(key)));
           } else if ("startDate".equals(key)) {
             // Special handling for start date since in API v1 we expect start date and start time to be separate
             // fields.

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/util/EventUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/util/EventUtils.java
@@ -113,7 +113,7 @@ public final class EventUtils {
         field.setValue(event.getTitle());
       }
       else if (field.getOutputID().equals(DublinCore.PROPERTY_SUBJECT.getLocalName())) {
-        field.setValue(event.getSubject());
+        field.setValue(event.getSubjects());
       }
       else if (field.getOutputID().equals(DublinCore.PROPERTY_DESCRIPTION.getLocalName())) {
         field.setValue(event.getDescription());

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
@@ -749,7 +749,7 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
       Series series = seriesOpt.orElse(new Series(seriesId, orgId, securityService.getUser().getName()));
       series.setTitle(dc.getFirst(DublinCoreCatalog.PROPERTY_TITLE));
       series.setDescription(dc.getFirst(DublinCore.PROPERTY_DESCRIPTION));
-      series.setSubject(dc.getFirst(DublinCore.PROPERTY_SUBJECT));
+      series.setSubjects(dc.get(DublinCore.PROPERTY_SUBJECT, DublinCore.LANGUAGE_ANY));
       series.setLanguage(dc.getFirst(DublinCoreCatalog.PROPERTY_LANGUAGE));
       series.setLicense(dc.getFirst(DublinCoreCatalog.PROPERTY_LICENSE));
       series.setRightsHolder(dc.getFirst(DublinCore.PROPERTY_RIGHTS_HOLDER));


### PR DESCRIPTION
Changes the subject type from `text` to `mixed_text`. This allows consistent behaviour between the UI and the External API, as the External API already handles it as a list by splitting the subject field on a comma.

The PR does not implement a migration; the code is somewhat backward-compatible.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
