### PR TITLE
Make event/series IDs searchable again

### DIFF
--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/event/EventIndexUtils.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/event/EventIndexUtils.java
@@ -118,7 +118,7 @@ public final class EventIndexUtils {
   public static SearchMetadataCollection toSearchMetadata(Event event, ListProvidersService listProviderService) {
     SearchMetadataCollection metadata = new SearchMetadataCollection(
             event.getIdentifier().concat(event.getOrganization()), Event.DOCUMENT_TYPE);
-    metadata.addField(EventIndexSchema.UID, event.getIdentifier(), false);
+    metadata.addField(EventIndexSchema.UID, event.getIdentifier(), true);
     metadata.addField(EventIndexSchema.ORGANIZATION, event.getOrganization(), false);
     metadata.addField(EventIndexSchema.OBJECT, event.toXML(), false);
     if (StringUtils.isNotBlank(event.getTitle())) {
@@ -131,7 +131,7 @@ public final class EventIndexUtils {
       metadata.addField(EventIndexSchema.LOCATION, event.getLocation(), true);
     }
     if (StringUtils.isNotBlank(event.getSeriesId())) {
-      metadata.addField(EventIndexSchema.SERIES_ID, event.getSeriesId(), false);
+      metadata.addField(EventIndexSchema.SERIES_ID, event.getSeriesId(), true);
     }
     if (StringUtils.isNotBlank(event.getSeriesName())) {
       metadata.addField(EventIndexSchema.SERIES_NAME, event.getSeriesName(), true);

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/series/SeriesIndexUtils.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/series/SeriesIndexUtils.java
@@ -83,7 +83,7 @@ public final class SeriesIndexUtils {
   public static SearchMetadataCollection toSearchMetadata(Series series) {
     SearchMetadataCollection metadata = new SearchMetadataCollection(
             series.getIdentifier().concat(series.getOrganization()), Series.DOCUMENT_TYPE);
-    metadata.addField(SeriesIndexSchema.UID, series.getIdentifier(), false);
+    metadata.addField(SeriesIndexSchema.UID, series.getIdentifier(), true);
     metadata.addField(SeriesIndexSchema.ORGANIZATION, series.getOrganization(), false);
     metadata.addField(SeriesIndexSchema.OBJECT, series.toXML(), false);
     metadata.addField(SeriesIndexSchema.TITLE, series.getTitle(), true);


### PR DESCRIPTION
Searching for specific event or series by ID is very usefull. Let's make it possible again.

Partially adresses #7323
