### PR TITLE
Remove redundant @Produces from API methods

### DIFF
--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/ListProviderEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/ListProviderEndpoint.java
@@ -94,7 +94,6 @@ public class ListProviderEndpoint {
 
   @GET
   @Path("providers.json")
-  @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_10_0 })
   @RestQuery(name = "availableProviders", description = "Provides the list of the available list providers", responses = { @RestResponse(description = "Returns the availables list providers.", responseCode = HttpServletResponse.SC_OK) }, returnDescription = "")
   public Response getAvailableProviders(@HeaderParam("Accept") String acceptHeader) {
     JSONArray list = new JSONArray();
@@ -106,7 +105,6 @@ public class ListProviderEndpoint {
 
   @GET
   @Path("{source}.json")
-  @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_10_0 })
   @RestQuery(name = "list", description = "Provides key-value list from the given source", pathParameters = { @RestParameter(name = "source", description = "The source for the key-value list", isRequired = true, type = RestParameter.Type.STRING) }, restParameters = {
           @RestParameter(description = "The maximum number of items to return per page", isRequired = false, name = "limit", type = RestParameter.Type.INTEGER),
           @RestParameter(description = "The offset", isRequired = false, name = "offset", type = RestParameter.Type.INTEGER),


### PR DESCRIPTION
The external API version for listproviders was bumped to 1.11 as part of the playlist feature, but individual method annotations were not updated.

These method-level @Produces annotations were overriding the class-level annotation, which led to errors. Removing them ensures consistency with the global version and reduces redundancy.

### Why it needs to be merged into the legacy branch
Plugins could ran into problems. Also its a very small Bugfix.
