### PR TITLE
Get listproviders for metadata from External API

### DIFF
--- a/docs/guides/admin/docs/releasenotes/external api
+++ b/docs/guides/admin/docs/releasenotes/external api
@@ -1,0 +1,1 @@
+Since we added an optional listprovider attribute to returned metadata fields, the API version was increased to 1.12.0.

--- a/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -1555,7 +1555,7 @@ public abstract class AbstractEventEndpoint {
       metadataList.setLocked(Locked.WORKFLOW_RUNNING);
     }
 
-    return okJson(MetadataJson.listToJson(metadataList, true));
+    return okJson(MetadataJson.listToJson(metadataList, true, false));
   }
 
   /**
@@ -1670,7 +1670,7 @@ public abstract class AbstractEventEndpoint {
     }
 
     JsonObject result = new JsonObject();
-    result.add("metadata", MetadataJson.collectionToJson(mergedMetadata, true));
+    result.add("metadata", MetadataJson.collectionToJson(mergedMetadata, true, false));
     result.add("notFound", collectionToJsonArray(eventsNotFound));
     result.add("runningWorkflow", collectionToJsonArray(eventsWithRunningWorkflow));
     result.add("merged", collectionToJsonArray(eventsMerged));
@@ -1915,7 +1915,7 @@ public abstract class AbstractEventEndpoint {
 
     try {
       MetadataList metadataList = getIndexService().updateAllEventMetadata(id, metadataJSON, getIndex());
-      return okJson(MetadataJson.listToJson(metadataList, true));
+      return okJson(MetadataJson.listToJson(metadataList, true, false));
     } catch (IllegalArgumentException e) {
       return badRequest(String.format("Event %s metadata can't be updated.: %s", id, e.getMessage()));
     }
@@ -2956,7 +2956,7 @@ public abstract class AbstractEventEndpoint {
     // remove series with empty titles from the collection of the isPartOf field as these can't be converted to json
     removeSeriesWithNullTitlesFromFieldCollection(metadataList);
 
-    return okJson(MetadataJson.listToJson(metadataList, true));
+    return okJson(MetadataJson.listToJson(metadataList, true, false));
   }
 
   @GET

--- a/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
+++ b/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
@@ -400,7 +400,7 @@ public class SeriesEndpoint {
       }
     }
     metadataList.add(indexService.getCommonSeriesCatalogUIAdapter(), getSeriesMetadata(optSeries.get()));
-    return okJson(MetadataJson.listToJson(metadataList, true));
+    return okJson(MetadataJson.listToJson(metadataList, true, false));
   }
 
   /**
@@ -520,7 +520,7 @@ public class SeriesEndpoint {
           SearchIndexException {
     try {
       MetadataList metadataList = indexService.updateAllSeriesMetadata(seriesID, metadataJSON, searchIndex);
-      return okJson(MetadataJson.listToJson(metadataList, true));
+      return okJson(MetadataJson.listToJson(metadataList, true, false));
     } catch (IllegalArgumentException e) {
       return RestUtil.R.badRequest(e.getMessage());
     } catch (IndexServiceException e) {
@@ -547,7 +547,7 @@ public class SeriesEndpoint {
       safelyRemoveField(collection, "identifier");
       metadataList.add(indexService.getCommonSeriesCatalogUIAdapter(), collection);
     }
-    return okJson(MetadataJson.listToJson(metadataList, true));
+    return okJson(MetadataJson.listToJson(metadataList, true, false));
   }
 
   private void safelyRemoveField(DublinCoreMetadataCollection collection, String fieldName) {

--- a/modules/admin-service/src/test/java/org/opencastproject/adminui/endpoint/MetadataListTest.java
+++ b/modules/admin-service/src/test/java/org/opencastproject/adminui/endpoint/MetadataListTest.java
@@ -92,7 +92,7 @@ public class MetadataListTest {
     metadataList.setLocked(Locked.WORKFLOW_RUNNING);
 
     assertThat(inputJson.toJSONString(),
-      SameJSONAs.sameJSONAs(new Gson().toJson(MetadataJson.listToJson(metadataList, true, false)))
+        SameJSONAs.sameJSONAs(new Gson().toJson(MetadataJson.listToJson(metadataList, true, false)))
         .allowingAnyArrayOrdering());
 
   }

--- a/modules/admin-service/src/test/java/org/opencastproject/adminui/endpoint/MetadataListTest.java
+++ b/modules/admin-service/src/test/java/org/opencastproject/adminui/endpoint/MetadataListTest.java
@@ -92,8 +92,9 @@ public class MetadataListTest {
     metadataList.setLocked(Locked.WORKFLOW_RUNNING);
 
     assertThat(inputJson.toJSONString(),
-        SameJSONAs.sameJSONAs(new Gson().toJson(MetadataJson.listToJson(metadataList, true)))
-            .allowingAnyArrayOrdering());
+      SameJSONAs.sameJSONAs(new Gson().toJson(MetadataJson.listToJson(metadataList, true, false)))
+        .allowingAnyArrayOrdering());
+
   }
 
 }

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/MetadataJson.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/MetadataJson.java
@@ -61,10 +61,12 @@ public final class MetadataJson {
   private static final String JSON_KEY_TRANSLATABLE = "translatable";
   private static final String JSON_KEY_DELIMITER = "delimiter";
   private static final String JSON_KEY_DIFFERENT_VALUES = "differentValues";
+  private static final String JSON_KEY_LISTPROVIDER = "listprovider";
   private static final String KEY_METADATA_TITLE = "title";
   private static final String KEY_METADATA_FLAVOR = "flavor";
   private static final String KEY_METADATA_FIELDS = "fields";
   private static final String KEY_METADATA_LOCKED = "locked";
+
 
   /* Keys for the different properties of the metadata JSON Object */
   private static final String KEY_METADATA_ID = "id";
@@ -357,7 +359,8 @@ public final class MetadataJson {
     }
   }
 
-  public static JsonObject fieldToJson(final MetadataField f, final boolean withOrderedText) {
+  public static JsonObject fieldToJson(final MetadataField f, final boolean withOrderedText,
+      final boolean withListprovider) {
     Objects.requireNonNull(f);
 
     JsonObject json = new JsonObject();
@@ -385,6 +388,10 @@ public final class MetadataJson {
       json.addProperty(JSON_KEY_DIFFERENT_VALUES, f.hasDifferentValues());
     }
 
+    if (f.getListprovider() != null && withListprovider) {
+      json.addProperty(JSON_KEY_LISTPROVIDER, f.getListprovider());
+    }
+
     return json;
   }
 
@@ -399,10 +406,10 @@ public final class MetadataJson {
   }
 
   public static JsonArray collectionToJson(final DublinCoreMetadataCollection collection,
-      final boolean withOrderedText) {
+      final boolean withOrderedText, final boolean withListprovider) {
     JsonArray jsonArray = new JsonArray();
     for (MetadataField field : collection.getFields()) {
-      JsonObject fieldJson = fieldToJson(field, withOrderedText);
+      JsonObject fieldJson = fieldToJson(field, withOrderedText, withListprovider);
       jsonArray.add(fieldJson);
     }
     return jsonArray;
@@ -465,7 +472,8 @@ public final class MetadataJson {
     }
   }
 
-  public static JsonArray listToJson(final MetadataList metadataList, final boolean withOrderedText) {
+  public static JsonArray listToJson(final MetadataList metadataList, final boolean withOrderedText,
+      final boolean withListprovider) {
     JsonArray catalogs = new JsonArray();
 
     for (Map.Entry<String, MetadataList.TitledMetadataCollection> metadata
@@ -481,7 +489,7 @@ public final class MetadataJson {
 
       catalogJson.addProperty(KEY_METADATA_FLAVOR, metadata.getKey());
       catalogJson.addProperty(KEY_METADATA_TITLE, metadata.getValue().getTitle());
-      catalogJson.add(KEY_METADATA_FIELDS, collectionToJson(metadataCollection, withOrderedText));
+      catalogJson.add(KEY_METADATA_FIELDS, collectionToJson(metadataCollection, withOrderedText, withListprovider));
 
       catalogs.add(catalogJson);
     }

--- a/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
+++ b/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
@@ -1246,6 +1246,6 @@ public class EditorServiceImpl implements EditorService {
       metadataList.setLocked(MetadataList.Locked.WORKFLOW_RUNNING);
     }
 
-    return MetadataJson.listToJson(metadataList, true).toString();
+    return MetadataJson.listToJson(metadataList, true, false).toString();
   }
 }

--- a/modules/external-api/src/main/java/org/opencastproject/external/common/ApiMediaType.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/common/ApiMediaType.java
@@ -20,8 +20,11 @@
  */
 package org.opencastproject.external.common;
 
+import static org.opencastproject.external.common.ApiVersion.VERSION_1_12_0;
+
 public final class ApiMediaType {
 
+  public static final String VERSION_1_12_0 = "application/v1.12.0+json";
   public static final String VERSION_1_11_0 = "application/v1.11.0+json";
   public static final String VERSION_1_10_0 = "application/v1.10.0+json";
   public static final String VERSION_1_9_0 = "application/v1.9.0+json";
@@ -52,8 +55,10 @@ public final class ApiMediaType {
   public static ApiMediaType parse(String acceptHeader) throws ApiMediaTypeException {
     /* MH-12802: The External API does not support content negotiation */
     ApiMediaType mediaType;
-    if (acceptHeader == null || acceptHeader.contains(VERSION_1_11_0) || acceptHeader.contains(JSON)
+    if (acceptHeader == null || acceptHeader.contains(VERSION_1_12_0) || acceptHeader.contains(JSON)
         || acceptHeader.contains(APPLICATION_ANY) || acceptHeader.contains(ANY)) {
+      mediaType = new ApiMediaType(ApiVersion.VERSION_1_12_0, ApiFormat.JSON, VERSION_1_12_0);
+    } else if (acceptHeader.contains(VERSION_1_11_0)) {
       mediaType = new ApiMediaType(ApiVersion.VERSION_1_11_0, ApiFormat.JSON, VERSION_1_11_0);
     } else if (acceptHeader.contains(VERSION_1_10_0)) {
       mediaType = new ApiMediaType(ApiVersion.VERSION_1_10_0, ApiFormat.JSON, VERSION_1_10_0);

--- a/modules/external-api/src/main/java/org/opencastproject/external/common/ApiVersion.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/common/ApiVersion.java
@@ -34,11 +34,12 @@ public enum ApiVersion {
   VERSION_1_8_0(1, 8, 0),
   VERSION_1_9_0(1, 9, 0),
   VERSION_1_10_0(1, 10, 0),
-  VERSION_1_11_0(1, 11, 0);
+  VERSION_1_11_0(1, 11, 0),
+  VERSION_1_12_0(1, 12, 0);
 
 
   /** The most recent version of the External API */
-  public static final ApiVersion CURRENT_VERSION = VERSION_1_11_0;
+  public static final ApiVersion CURRENT_VERSION = VERSION_1_12_0;
 
   private int major;
   private int minor;

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/BaseEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/BaseEndpoint.java
@@ -76,7 +76,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_0_0, ApiMediaType.VERSION_1_1_0, ApiMediaType.VERSION_1_2_0,
             ApiMediaType.VERSION_1_3_0, ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0,
             ApiMediaType.VERSION_1_6_0, ApiMediaType.VERSION_1_7_0, ApiMediaType.VERSION_1_8_0,
-            ApiMediaType.VERSION_1_9_0, ApiMediaType.VERSION_1_10_0, ApiMediaType.VERSION_1_11_0})
+            ApiMediaType.VERSION_1_9_0, ApiMediaType.VERSION_1_10_0, ApiMediaType.VERSION_1_11_0,
+            ApiMediaType.VERSION_1_12_0})
 @RestService(name = "externalapiservice", title = "External API Service", notes = {},
              abstractText = "Provides a location for external apis to query the current server of the API.")
 @Tag(
@@ -308,6 +309,7 @@ public class BaseEndpoint {
     versions.add(ApiVersion.VERSION_1_9_0.toString());
     versions.add(ApiVersion.VERSION_1_10_0.toString());
     versions.add(ApiVersion.VERSION_1_11_0.toString());
+    versions.add(ApiVersion.VERSION_1_12_0.toString());
     JsonObject json = new JsonObject();
     json.add("versions", collectionToJsonArray(versions));
     json.addProperty("default", ApiVersion.CURRENT_VERSION.toString());

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/CaptureAgentsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/CaptureAgentsEndpoint.java
@@ -59,7 +59,7 @@ import javax.ws.rs.core.Response;
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_1_0, ApiMediaType.VERSION_1_2_0, ApiMediaType.VERSION_1_3_0,
             ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0, ApiMediaType.VERSION_1_6_0,
             ApiMediaType.VERSION_1_7_0, ApiMediaType.VERSION_1_8_0, ApiMediaType.VERSION_1_9_0,
-            ApiMediaType.VERSION_1_10_0, ApiMediaType.VERSION_1_11_0 })
+            ApiMediaType.VERSION_1_10_0, ApiMediaType.VERSION_1_11_0, ApiMediaType.VERSION_1_12_0 })
 @RestService(
     name = "externalapicaptureagents",
     title = "External API Capture Agents Service",

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -22,6 +22,7 @@ package org.opencastproject.external.endpoint;
 
 import static org.apache.commons.lang3.StringUtils.trimToNull;
 import static org.opencastproject.external.common.ApiVersion.VERSION_1_11_0;
+import static org.opencastproject.external.common.ApiVersion.VERSION_1_12_0;
 import static org.opencastproject.external.common.ApiVersion.VERSION_1_1_0;
 import static org.opencastproject.external.common.ApiVersion.VERSION_1_4_0;
 import static org.opencastproject.external.common.ApiVersion.VERSION_1_7_0;
@@ -190,7 +191,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_0_0, ApiMediaType.VERSION_1_1_0, ApiMediaType.VERSION_1_2_0,
             ApiMediaType.VERSION_1_3_0, ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0,
             ApiMediaType.VERSION_1_6_0, ApiMediaType.VERSION_1_7_0, ApiMediaType.VERSION_1_8_0,
-            ApiMediaType.VERSION_1_9_0, ApiMediaType.VERSION_1_10_0, ApiMediaType.VERSION_1_11_0 })
+            ApiMediaType.VERSION_1_9_0, ApiMediaType.VERSION_1_10_0, ApiMediaType.VERSION_1_11_0,
+            ApiMediaType.VERSION_1_12_0 })
 @RestService(name = "externalapievents", title = "External API Events Service", notes = {},
              abstractText = "Provides resources and operations related to the events")
 @Tag(name = "External API")
@@ -2307,7 +2309,7 @@ public class EventsEndpoint implements ManagedService {
   @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_1_0, ApiMediaType.VERSION_1_2_0, ApiMediaType.VERSION_1_3_0,
               ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0, ApiMediaType.VERSION_1_6_0,
               ApiMediaType.VERSION_1_7_0, ApiMediaType.VERSION_1_8_0, ApiMediaType.VERSION_1_9_0,
-              ApiMediaType.VERSION_1_10_0, ApiMediaType.VERSION_1_11_0 })
+              ApiMediaType.VERSION_1_10_0, ApiMediaType.VERSION_1_11_0, ApiMediaType.VERSION_1_12_0 })
   @RestQuery(
       name = "geteventscheduling",
       description = "Returns an event's scheduling information.",
@@ -2348,7 +2350,7 @@ public class EventsEndpoint implements ManagedService {
   @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_1_0, ApiMediaType.VERSION_1_2_0, ApiMediaType.VERSION_1_3_0,
               ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0, ApiMediaType.VERSION_1_6_0,
               ApiMediaType.VERSION_1_7_0, ApiMediaType.VERSION_1_8_0, ApiMediaType.VERSION_1_9_0,
-              ApiMediaType.VERSION_1_10_0, ApiMediaType.VERSION_1_11_0 })
+              ApiMediaType.VERSION_1_10_0, ApiMediaType.VERSION_1_11_0, ApiMediaType.VERSION_1_12_0 })
   @RestQuery(
       name = "updateeventscheduling",
       description = "Update an event's scheduling information.",

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -22,7 +22,6 @@ package org.opencastproject.external.endpoint;
 
 import static org.apache.commons.lang3.StringUtils.trimToNull;
 import static org.opencastproject.external.common.ApiVersion.VERSION_1_11_0;
-import static org.opencastproject.external.common.ApiVersion.VERSION_1_12_0;
 import static org.opencastproject.external.common.ApiVersion.VERSION_1_1_0;
 import static org.opencastproject.external.common.ApiVersion.VERSION_1_4_0;
 import static org.opencastproject.external.common.ApiVersion.VERSION_1_7_0;
@@ -1329,7 +1328,8 @@ public class EventsEndpoint implements ManagedService {
       try {
         Optional<MetadataList> metadata = getEventMetadata(event);
         if (metadata.isPresent()) {
-          json.add("metadata", MetadataJson.listToJson(metadata.get(), true));
+          boolean includeListprovider = !requestedVersion.isSmallerThan(ApiVersion.VERSION_1_12_0);
+          json.add("metadata", MetadataJson.listToJson(metadata.get(), true, includeListprovider));
         }
       } catch (Exception e) {
         logger.error("Unable to get metadata for event '{}'", event.getIdentifier(), e);
@@ -1577,8 +1577,9 @@ public class EventsEndpoint implements ManagedService {
         if (collection != null) {
           convertStartDateTimeToApiV1(collection);
         }
-
-        return ApiResponseBuilder.Json.ok(requestedVersion, MetadataJson.listToJson(actualList, withOrderedText));
+        boolean includeListprovider = !requestedVersion.isSmallerThan(ApiVersion.VERSION_1_12_0);
+        return ApiResponseBuilder.Json.ok(requestedVersion, MetadataJson.listToJson(actualList, withOrderedText,
+            includeListprovider));
       }
       else {
         return ApiResponseBuilder.notFound("Cannot find an event with id '%s'.", id);
@@ -1666,6 +1667,7 @@ public class EventsEndpoint implements ManagedService {
 
   private Response getEventMetadataByType(String id, String type, ApiVersion requestedVersion) throws Exception {
     Optional<Event> eventOpt = indexService.getEvent(id, elasticsearchIndex);
+
     if (eventOpt.isPresent()) {
       Event event = eventOpt.get();
       Optional<MediaPackageElementFlavor> flavor = getFlavor(type);
@@ -1673,6 +1675,8 @@ public class EventsEndpoint implements ManagedService {
         return R.badRequest(
                 String.format("Unable to parse type '%s' as a flavor so unable to find the matching catalog.", type));
       }
+
+      boolean includeListprovider = !requestedVersion.isSmallerThan(ApiVersion.VERSION_1_12_0);
       // Try the main catalog first as we load it from the index.
       EventCatalogUIAdapter eventCatalogUIAdapter = indexService.getCommonEventCatalogUIAdapter();
       if (flavor.get().equals(eventCatalogUIAdapter.getFlavor())) {
@@ -1681,7 +1685,8 @@ public class EventsEndpoint implements ManagedService {
         ExternalMetadataUtils.changeSubjectToSubjects(collection);
         ExternalMetadataUtils.removeCollectionList(collection);
         convertStartDateTimeToApiV1(collection);
-        return ApiResponseBuilder.Json.ok(requestedVersion, MetadataJson.collectionToJson(collection, false));
+        return ApiResponseBuilder.Json.ok(requestedVersion, MetadataJson.collectionToJson(collection, false,
+            includeListprovider));
       }
       // Try the other catalogs
       List<EventCatalogUIAdapter> catalogUIAdapters = getEventCatalogUIAdapters();
@@ -1693,7 +1698,8 @@ public class EventsEndpoint implements ManagedService {
             DublinCoreMetadataCollection fields = catalogUIAdapter.getFields(mediaPackage);
             ExternalMetadataUtils.removeCollectionList(fields);
             convertStartDateTimeToApiV1(fields);
-            return ApiResponseBuilder.Json.ok(requestedVersion, MetadataJson.collectionToJson(fields, false));
+            return ApiResponseBuilder.Json.ok(requestedVersion, MetadataJson.collectionToJson(fields, false,
+                includeListprovider));
           }
         }
       }

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/GroupsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/GroupsEndpoint.java
@@ -92,7 +92,8 @@ import javax.ws.rs.core.Response;
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_0_0, ApiMediaType.VERSION_1_1_0, ApiMediaType.VERSION_1_2_0,
             ApiMediaType.VERSION_1_3_0, ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0,
             ApiMediaType.VERSION_1_6_0, ApiMediaType.VERSION_1_7_0, ApiMediaType.VERSION_1_8_0,
-            ApiMediaType.VERSION_1_9_0, ApiMediaType.VERSION_1_10_0, ApiMediaType.VERSION_1_11_0 })
+            ApiMediaType.VERSION_1_9_0, ApiMediaType.VERSION_1_10_0, ApiMediaType.VERSION_1_11_0,
+            ApiMediaType.VERSION_1_12_0 })
 @RestService(
     name = "externalapigroups",
     title = "External API Groups Service",

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/ListProviderEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/ListProviderEndpoint.java
@@ -55,7 +55,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 
 @Path("/api/listproviders")
-@Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_10_0, ApiMediaType.VERSION_1_11_0 })
+@Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_10_0, ApiMediaType.VERSION_1_11_0, ApiMediaType.VERSION_1_12_0 })
 @RestService(
         name = "externalapilistproviders",
         title = "External API List Providers Service",

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/PlaylistsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/PlaylistsEndpoint.java
@@ -85,7 +85,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 
 @Path("/api/playlists")
-@Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_11_0 })
+@Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_11_0, ApiMediaType.VERSION_1_12_0 })
 @RestService(
     name = "externalapiplaylists",
     title = "External API Playlists Service",
@@ -138,7 +138,6 @@ public class PlaylistsEndpoint {
 
   @GET
   @Path("{id}")
-  @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_11_0 })
   @RestQuery(
       name = "playlist",
       description = "Get a playlist.",
@@ -172,7 +171,6 @@ public class PlaylistsEndpoint {
   }
 
   @GET
-  @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_11_0 })
   @Path("")
   @RestQuery(
       name = "playlists",
@@ -232,7 +230,6 @@ public class PlaylistsEndpoint {
   }
 
   @POST
-  @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_11_0 })
   @Path("")
   @RestQuery(
       name = "create",
@@ -271,7 +268,6 @@ public class PlaylistsEndpoint {
   }
 
   @PUT
-  @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_11_0 })
   @Path("{id}")
   @RestQuery(
       name = "update",
@@ -306,7 +302,6 @@ public class PlaylistsEndpoint {
   }
 
   @DELETE
-  @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_11_0 })
   @Path("{id}")
   @RestQuery(
       name = "remove",

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SecurityEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SecurityEndpoint.java
@@ -68,7 +68,8 @@ import javax.ws.rs.core.Response;
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_0_0, ApiMediaType.VERSION_1_1_0, ApiMediaType.VERSION_1_2_0,
             ApiMediaType.VERSION_1_3_0, ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0,
             ApiMediaType.VERSION_1_6_0, ApiMediaType.VERSION_1_7_0, ApiMediaType.VERSION_1_8_0,
-            ApiMediaType.VERSION_1_9_0, ApiMediaType.VERSION_1_10_0, ApiMediaType.VERSION_1_11_0 })
+            ApiMediaType.VERSION_1_9_0, ApiMediaType.VERSION_1_10_0, ApiMediaType.VERSION_1_11_0,
+            ApiMediaType.VERSION_1_12_0 })
 @RestService(
     name = "externalapisecurity",
     title = "External API Security Service",

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
@@ -131,7 +131,8 @@ import javax.ws.rs.core.Response.Status;
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_0_0, ApiMediaType.VERSION_1_1_0, ApiMediaType.VERSION_1_2_0,
             ApiMediaType.VERSION_1_3_0, ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0,
             ApiMediaType.VERSION_1_6_0, ApiMediaType.VERSION_1_7_0, ApiMediaType.VERSION_1_8_0,
-            ApiMediaType.VERSION_1_9_0, ApiMediaType.VERSION_1_10_0, ApiMediaType.VERSION_1_11_0 })
+            ApiMediaType.VERSION_1_9_0, ApiMediaType.VERSION_1_10_0, ApiMediaType.VERSION_1_11_0,
+            ApiMediaType.VERSION_1_12_0 })
 @RestService(
     name = "externalapiseries",
     title = "External API Series Service",

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
@@ -553,7 +553,9 @@ public class SeriesEndpoint {
     DublinCoreMetadataCollection collection = getSeriesMetadata(optSeries.get());
     ExternalMetadataUtils.changeSubjectToSubjects(collection);
     metadataList.add(indexService.getCommonSeriesCatalogUIAdapter(), collection);
-    return ApiResponseBuilder.Json.ok(requestedVersion, MetadataJson.listToJson(metadataList, false));
+    boolean includeListprovider = !requestedVersion.isSmallerThan(ApiVersion.VERSION_1_12_0);
+    return ApiResponseBuilder.Json.ok(requestedVersion, MetadataJson.listToJson(metadataList, false,
+        includeListprovider));
   }
 
   private Response getMetadataByType(String id, String type, ApiVersion requestedVersion) throws SearchIndexException {
@@ -563,11 +565,13 @@ public class SeriesEndpoint {
       return ApiResponseBuilder.notFound("Cannot find a series with id '%s'.", id);
     }
 
+    boolean includeListprovider = !requestedVersion.isSmallerThan(ApiVersion.VERSION_1_12_0);
     // Try the main catalog first as we load it from the index.
     if (typeMatchesSeriesCatalogUIAdapter(type, indexService.getCommonSeriesCatalogUIAdapter())) {
       DublinCoreMetadataCollection collection = getSeriesMetadata(optSeries.get());
       ExternalMetadataUtils.changeSubjectToSubjects(collection);
-      return ApiResponseBuilder.Json.ok(requestedVersion, MetadataJson.collectionToJson(collection, false));
+      return ApiResponseBuilder.Json.ok(requestedVersion, MetadataJson.collectionToJson(collection, false,
+          includeListprovider));
     }
 
     // Try the other catalogs
@@ -579,7 +583,7 @@ public class SeriesEndpoint {
         final Optional<DublinCoreMetadataCollection> optSeriesMetadata = adapter.getFields(id);
         if (optSeriesMetadata.isPresent()) {
           return ApiResponseBuilder.Json.ok(requestedVersion, MetadataJson.collectionToJson(optSeriesMetadata.get(),
-              true));
+              true, includeListprovider));
         }
       }
     }
@@ -1001,7 +1005,10 @@ public class SeriesEndpoint {
           throws UnauthorizedException, NotFoundException, SearchIndexException {
     try {
       MetadataList metadataList = indexService.updateAllSeriesMetadata(seriesID, metadataJSON, elasticsearchIndex);
-      return ApiResponseBuilder.Json.ok(acceptHeader, MetadataJson.listToJson(metadataList, true));
+      final ApiVersion requestedVersion = ApiMediaType.parse(acceptHeader).getVersion();
+      boolean includeListprovider = !requestedVersion.isSmallerThan(ApiVersion.VERSION_1_12_0);
+      return ApiResponseBuilder.Json.ok(acceptHeader, MetadataJson.listToJson(metadataList, true,
+          includeListprovider));
     } catch (IllegalArgumentException e) {
       logger.debug("Unable to update series '{}' with metadata '{}'", seriesID, metadataJSON, e);
       return RestUtil.R.badRequest(e.getMessage());

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/StatisticsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/StatisticsEndpoint.java
@@ -83,7 +83,8 @@ import javax.ws.rs.core.Response;
 @Path("/api/statistics")
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_3_0, ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0,
             ApiMediaType.VERSION_1_6_0, ApiMediaType.VERSION_1_7_0, ApiMediaType.VERSION_1_8_0,
-            ApiMediaType.VERSION_1_9_0, ApiMediaType.VERSION_1_10_0, ApiMediaType.VERSION_1_11_0 })
+            ApiMediaType.VERSION_1_9_0, ApiMediaType.VERSION_1_10_0, ApiMediaType.VERSION_1_11_0,
+            ApiMediaType.VERSION_1_12_0 })
 @RestService(
     name = "externalapistatistics",
     title = "External API Statistics Endpoint",

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowDefinitionsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowDefinitionsEndpoint.java
@@ -77,7 +77,8 @@ import javax.ws.rs.core.Response;
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_1_0, ApiMediaType.VERSION_1_2_0, ApiMediaType.VERSION_1_3_0,
             ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0, ApiMediaType.VERSION_1_6_0,
             ApiMediaType.VERSION_1_7_0, ApiMediaType.VERSION_1_8_0,
-            ApiMediaType.VERSION_1_9_0, ApiMediaType.VERSION_1_10_0, ApiMediaType.VERSION_1_11_0 })
+            ApiMediaType.VERSION_1_9_0, ApiMediaType.VERSION_1_10_0, ApiMediaType.VERSION_1_11_0,
+            ApiMediaType.VERSION_1_12_0 })
 @RestService(
     name = "externalapiworkflowdefinitions",
     title = "External API Workflow Definitions Service",

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowsEndpoint.java
@@ -93,7 +93,7 @@ import javax.ws.rs.core.Response;
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_1_0, ApiMediaType.VERSION_1_2_0, ApiMediaType.VERSION_1_3_0,
             ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0, ApiMediaType.VERSION_1_6_0,
             ApiMediaType.VERSION_1_7_0, ApiMediaType.VERSION_1_8_0, ApiMediaType.VERSION_1_9_0,
-            ApiMediaType.VERSION_1_10_0, ApiMediaType.VERSION_1_11_0 })
+            ApiMediaType.VERSION_1_10_0, ApiMediaType.VERSION_1_11_0, ApiMediaType.VERSION_1_12_0 })
 @RestService(name = "externalapiworkflowinstances", title = "External API Workflow Instances Service", notes = {},
              abstractText = "Provides resources and operations related to the workflow instances")
 @Component(

--- a/modules/external-api/src/test/java/org/opencastproject/external/common/ApiMediaTypeTest.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/common/ApiMediaTypeTest.java
@@ -29,24 +29,24 @@ public class ApiMediaTypeTest {
   @Test
   public void testDefaultVersionAndFormat() throws Exception {
     ApiMediaType type = ApiMediaType.parse("*/*");
-    assertEquals(ApiVersion.VERSION_1_11_0, type.getVersion());
+    assertEquals(ApiVersion.VERSION_1_12_0, type.getVersion());
     assertEquals(ApiFormat.JSON, type.getFormat());
-    assertEquals("application/v1.11.0+json", type.toExternalForm());
+    assertEquals("application/v1.12.0+json", type.toExternalForm());
 
     type = ApiMediaType.parse("application/*");
-    assertEquals(ApiVersion.VERSION_1_11_0, type.getVersion());
+    assertEquals(ApiVersion.VERSION_1_12_0, type.getVersion());
     assertEquals(ApiFormat.JSON, type.getFormat());
-    assertEquals("application/v1.11.0+json", type.toExternalForm());
+    assertEquals("application/v1.12.0+json", type.toExternalForm());
 
     type = ApiMediaType.parse("application/json");
-    assertEquals(ApiVersion.VERSION_1_11_0, type.getVersion());
+    assertEquals(ApiVersion.VERSION_1_12_0, type.getVersion());
     assertEquals(ApiFormat.JSON, type.getFormat());
-    assertEquals("application/v1.11.0+json", type.toExternalForm());
+    assertEquals("application/v1.12.0+json", type.toExternalForm());
 
     type = ApiMediaType.parse(null);
-    assertEquals(ApiVersion.VERSION_1_11_0, type.getVersion());
+    assertEquals(ApiVersion.VERSION_1_12_0, type.getVersion());
     assertEquals(ApiFormat.JSON, type.getFormat());
-    assertEquals("application/v1.11.0+json", type.toExternalForm());
+    assertEquals("application/v1.12.0+json", type.toExternalForm());
   }
 
   @Test
@@ -110,6 +110,11 @@ public class ApiMediaTypeTest {
     assertEquals(ApiVersion.VERSION_1_11_0, type.getVersion());
     assertEquals(ApiFormat.JSON, type.getFormat());
     assertEquals("application/v1.11.0+json", type.toExternalForm());
+
+    type = ApiMediaType.parse("application/v1.12.0+json");
+    assertEquals(ApiVersion.VERSION_1_12_0, type.getVersion());
+    assertEquals(ApiFormat.JSON, type.getFormat());
+    assertEquals("application/v1.12.0+json", type.toExternalForm());
   }
 
   @Test(expected = ApiMediaTypeException.class)

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/BaseEndpointTest.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/BaseEndpointTest.java
@@ -60,7 +60,7 @@ public class BaseEndpointTest {
 
     JSONObject json = (JSONObject) parser.parse(response);
     assertEquals("https://api.opencast.org", json.get("url"));
-    assertEquals("v1.11.0", json.get("version"));
+    assertEquals("v1.12.0", json.get("version"));
   }
 
   /** Test case for {@link BaseEndpoint#getUserInfo()} */
@@ -121,7 +121,7 @@ public class BaseEndpointTest {
 
     JSONObject json = (JSONObject) parser.parse(response);
     JSONArray version = (JSONArray) json.get("versions");
-    assertEquals("v1.11.0", json.get("default"));
+    assertEquals("v1.12.0", json.get("default"));
     assertTrue(version.contains("v1.0.0"));
     assertTrue(version.contains("v1.1.0"));
     assertTrue(version.contains("v1.2.0"));
@@ -134,7 +134,8 @@ public class BaseEndpointTest {
     assertTrue(version.contains("v1.9.0"));
     assertTrue(version.contains("v1.10.0"));
     assertTrue(version.contains("v1.11.0"));
-    assertEquals(12, version.size());
+    assertTrue(version.contains("v1.12.0"));
+    assertEquals(13, version.size());
   }
 
   /** Test case for {@link BaseEndpoint#getVersionDefault()} */
@@ -144,7 +145,7 @@ public class BaseEndpointTest {
             .asString();
 
     JSONObject json = (JSONObject) parser.parse(response);
-    assertEquals("v1.11.0", json.get("default"));
+    assertEquals("v1.12.0", json.get("default"));
   }
 
 }

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/EventsEndpointTest.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/EventsEndpointTest.java
@@ -129,7 +129,7 @@ public class EventsEndpointTest {
     given().multiPart("metadata", jsonString).pathParam("event_id", eventId).expect().statusCode(SC_NO_CONTENT)
             .when().post(env.host("{event_id}"));
     MetadataList actualMetadataList = TestEventsEndpoint.getCapturedMetadataList1().getValue();
-    assertThat(MetadataJson.listToJson(actualMetadataList, true).toString(),
+    assertThat(MetadataJson.listToJson(actualMetadataList, true, true).toString(),
         SameJSONAs.sameJSONAs(expectedJson).allowingAnyArrayOrdering());
   }
 
@@ -151,7 +151,7 @@ public class EventsEndpointTest {
             .expect().statusCode(SC_NO_CONTENT).when().put(env.host("{event_id}/metadata"));
     MetadataList actualMetadataList = TestEventsEndpoint.getCapturedMetadataList2().getValue();
     assertThat(MetadataJson.collectionToJson(
-            actualMetadataList.getMetadataByFlavor("dublincore/episode"), true).toString(),
+            actualMetadataList.getMetadataByFlavor("dublincore/episode"), true, true).toString(),
             SameJSONAs.sameJSONAs(expectedJson).allowingAnyArrayOrdering());
   }
 

--- a/modules/external-api/src/test/resources/event-metadata-expected.json
+++ b/modules/external-api/src/test/resources/event-metadata-expected.json
@@ -33,7 +33,8 @@
         "label": "EVENTS.EVENTS.DETAILS.METADATA.LANGUAGE",
         "type": "text",
         "value": "",
-        "required": false
+        "required": false,
+        "listprovider": "LANGUAGES"
       },
       {
         "readOnly": false,
@@ -49,7 +50,8 @@
         "label": "EVENTS.EVENTS.DETAILS.METADATA.LICENSE",
         "type": "text",
         "value": "",
-        "required": false
+        "required": false,
+        "listprovider": "LICENSES"
       },
       {
         "readOnly": false,
@@ -57,7 +59,8 @@
         "label": "EVENTS.EVENTS.DETAILS.METADATA.SERIES",
         "type": "text",
         "value": "",
-        "required": false
+        "required": false,
+        "listprovider": "SERIES"
       },
       {
         "readOnly": false,
@@ -65,7 +68,8 @@
         "label": "EVENTS.EVENTS.DETAILS.METADATA.PRESENTERS",
         "type": "mixed_text",
         "value": [],
-        "required": false
+        "required": false,
+        "listprovider": "CONTRIBUTORS"
       },
       {
         "readOnly": false,
@@ -73,7 +77,8 @@
         "label": "EVENTS.EVENTS.DETAILS.METADATA.CONTRIBUTORS",
         "type": "mixed_text",
         "value": [],
-        "required": false
+        "required": false,
+        "listprovider":"CONTRIBUTORS"
       },
       {
         "readOnly": false,

--- a/modules/external-api/src/test/resources/event-metadata-update-expected.json
+++ b/modules/external-api/src/test/resources/event-metadata-update-expected.json
@@ -29,7 +29,8 @@
     "label": "EVENTS.EVENTS.DETAILS.METADATA.LANGUAGE",
     "type": "text",
     "value": "",
-    "required": false
+    "required": false,
+    "listprovider": "LANGUAGES"
   },
   {
     "readOnly": false,
@@ -45,7 +46,8 @@
     "label": "EVENTS.EVENTS.DETAILS.METADATA.LICENSE",
     "type": "text",
     "value": "",
-    "required": false
+    "required": false,
+    "listprovider": "LICENSES"
   },
   {
     "readOnly": false,
@@ -53,7 +55,8 @@
     "label": "EVENTS.EVENTS.DETAILS.METADATA.SERIES",
     "type": "text",
     "value": "",
-    "required": false
+    "required": false,
+    "listprovider": "SERIES"
   },
   {
     "readOnly": false,
@@ -61,7 +64,8 @@
     "label": "EVENTS.EVENTS.DETAILS.METADATA.PRESENTERS",
     "type": "mixed_text",
     "value": [],
-    "required": false
+    "required": false,
+    "listprovider": "CONTRIBUTORS"
   },
   {
     "readOnly": false,
@@ -69,7 +73,8 @@
     "label": "EVENTS.EVENTS.DETAILS.METADATA.CONTRIBUTORS",
     "type": "mixed_text",
     "value": [],
-    "required": false
+    "required": false,
+    "listprovider":"CONTRIBUTORS"
   },
   {
     "readOnly": false,

--- a/modules/external-api/src/test/resources/event-update-expected.json
+++ b/modules/external-api/src/test/resources/event-update-expected.json
@@ -33,7 +33,8 @@
         "label": "EVENTS.EVENTS.DETAILS.METADATA.LANGUAGE",
         "type": "text",
         "value": "",
-        "required": false
+        "required": false,
+        "listprovider": "LANGUAGES"
       },
       {
         "readOnly": false,
@@ -49,7 +50,8 @@
         "label": "EVENTS.EVENTS.DETAILS.METADATA.LICENSE",
         "type": "text",
         "value": "",
-        "required": false
+        "required": false,
+        "listprovider": "LICENSES"
       },
       {
         "readOnly": false,
@@ -57,7 +59,8 @@
         "label": "EVENTS.EVENTS.DETAILS.METADATA.SERIES",
         "type": "text",
         "value": "",
-        "required": false
+        "required": false,
+        "listprovider": "SERIES"
       },
       {
         "readOnly": false,
@@ -65,7 +68,8 @@
         "label": "EVENTS.EVENTS.DETAILS.METADATA.PRESENTERS",
         "type": "mixed_text",
         "value": [],
-        "required": false
+        "required": false,
+        "listprovider": "CONTRIBUTORS"
       },
       {
         "readOnly": false,
@@ -73,7 +77,8 @@
         "label": "EVENTS.EVENTS.DETAILS.METADATA.CONTRIBUTORS",
         "type": "mixed_text",
         "value": [],
-        "required": false
+        "required": false,
+        "listprovider": "CONTRIBUTORS"
       },
       {
         "readOnly": false,

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -1348,7 +1348,7 @@ public class IndexServiceImpl implements IndexService {
           updateWorkflowInstance(instance);
         } catch (WorkflowException e) {
           throw new IndexServiceException("Unable to update workflow event " + id + " with metadata "
-              + RestUtils.getJsonStringSilent(MetadataJson.listToJson(metadataList, true)), e);
+              + RestUtils.getJsonStringSilent(MetadataJson.listToJson(metadataList, true, false)), e);
         }
         break;
       case ARCHIVE:
@@ -1362,7 +1362,7 @@ public class IndexServiceImpl implements IndexService {
               Optional.of(mediaPackage), Optional.empty(), Optional.empty());
         } catch (SchedulerException e) {
           throw new IndexServiceException("Unable to update scheduled event " + id + " with metadata "
-              + RestUtils.getJsonStringSilent(MetadataJson.listToJson(metadataList, true)), e);
+              + RestUtils.getJsonStringSilent(MetadataJson.listToJson(metadataList, true, false)), e);
         }
         break;
       default:

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/catalog/adapter/EventCatalogUIAdapterTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/catalog/adapter/EventCatalogUIAdapterTest.java
@@ -155,7 +155,7 @@ public class EventCatalogUIAdapterTest {
 
     DublinCoreMetadataCollection abstractMetadata = configurationDublinCoreCatalogUIAdapter.getFields(mediapackage);
     assertThat(eventJson, SameJSONAs.sameJSONAs(RestUtils.getJsonString(MetadataJson.collectionToJson(abstractMetadata,
-            true)))
+            true, false)))
             .allowingAnyArrayOrdering());
   }
 

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/catalog/adapter/MetadataFieldTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/catalog/adapter/MetadataFieldTest.java
@@ -119,7 +119,8 @@ public class MetadataFieldTest {
             .getResource("/catalog-adapter/text/text-with-different-values.json"), StandardCharsets.UTF_8);
     assertThat(
             withDifferentValuesJson,
-            SameJSONAs.sameJSONAs(RestUtils.getJsonString(MetadataJson.fieldToJson(textField, true))));
+            SameJSONAs.sameJSONAs(RestUtils.getJsonString(MetadataJson.fieldToJson(textField, true,
+                true))));
   }
 
 
@@ -191,7 +192,8 @@ public class MetadataFieldTest {
             StringUtils.isNotBlank(dateTimePattern) ? dateTimePattern : null,
             null);
     dateField1.setValue(testDate);
-    assertThat(dateJson, SameJSONAs.sameJSONAs(RestUtils.getJsonString(MetadataJson.fieldToJson(dateField1, true))));
+    assertThat(dateJson, SameJSONAs.sameJSONAs(RestUtils.getJsonString(MetadataJson.fieldToJson(dateField1, true,
+        true))));
   }
 
   @Test
@@ -228,7 +230,7 @@ public class MetadataFieldTest {
     String expectedJSON = gson.toJson(jsonMap);
 
     assertThat(expectedJSON, SameJSONAs.sameJSONAs(RestUtils.getJsonString(MetadataJson.fieldToJson(dateField1,
-        true))));
+        true, true))));
   }
 
   @Test
@@ -252,7 +254,8 @@ public class MetadataFieldTest {
             null,
             StringUtils.isNotBlank(datePattern) ? datePattern : null,
             null);
-    assertThat(dateJson, SameJSONAs.sameJSONAs(RestUtils.getJsonString(MetadataJson.fieldToJson(dateField1, true))));
+    assertThat(dateJson, SameJSONAs.sameJSONAs(RestUtils.getJsonString(MetadataJson.fieldToJson(dateField1, true,
+        true))));
   }
 
   @Test
@@ -277,7 +280,7 @@ public class MetadataFieldTest {
             null,
             null);
     assertThat(emptyValueJson, SameJSONAs.sameJSONAs(RestUtils.getJsonString(
-            MetadataJson.fieldToJson(emptyValueTextField, true))));
+            MetadataJson.fieldToJson(emptyValueTextField, true, true))));
   }
 
   @Test
@@ -304,7 +307,7 @@ public class MetadataFieldTest {
             null);
     textField.setValue(textValue);
     assertThat(withValueJson, SameJSONAs.sameJSONAs(RestUtils.getJsonString(MetadataJson.fieldToJson(textField,
-        true))));
+        true, true))));
   }
 
   @Test
@@ -330,7 +333,8 @@ public class MetadataFieldTest {
             null);
     assertThat(
             withCollectionJson,
-            SameJSONAs.sameJSONAs(RestUtils.getJsonString(MetadataJson.fieldToJson(textFieldWithCollection, true))));
+            SameJSONAs.sameJSONAs(RestUtils.getJsonString(MetadataJson.fieldToJson(textFieldWithCollection, true,
+                true))));
   }
 
   @Test
@@ -356,7 +360,8 @@ public class MetadataFieldTest {
             null);
     assertThat(
             withCollectionIDJson,
-            SameJSONAs.sameJSONAs(RestUtils.getJsonString(MetadataJson.fieldToJson(textFieldWithCollectionID, true))));
+            SameJSONAs.sameJSONAs(RestUtils.getJsonString(MetadataJson.fieldToJson(textFieldWithCollectionID, true,
+                true))));
   }
 
   @Test
@@ -383,6 +388,7 @@ public class MetadataFieldTest {
     textLongField.setValue("This is the text value");
     assertThat(
             withCollectionIDJson,
-            SameJSONAs.sameJSONAs(RestUtils.getJsonString(MetadataJson.fieldToJson(textLongField, true))));
+            SameJSONAs.sameJSONAs(RestUtils.getJsonString(MetadataJson.fieldToJson(textLongField, true,
+                true))));
   }
 }

--- a/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
+++ b/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
@@ -466,7 +466,7 @@ public class LtiServiceImpl implements LtiService {
     if (wfState != null && WorkflowUtil.isActive(WorkflowInstance.WorkflowState.valueOf(wfState))) {
       metadataList.setLocked(MetadataList.Locked.WORKFLOW_RUNNING);
     }
-    return new Gson().toJson(MetadataJson.listToJson(metadataList, true));
+    return new Gson().toJson(MetadataJson.listToJson(metadataList, true, false));
   }
 
   @Override
@@ -511,7 +511,7 @@ public class LtiServiceImpl implements LtiService {
 
       metadataList.add(this.indexService.getCommonEventCatalogUIAdapter(), collection);
     }
-    return new Gson().toJson(MetadataJson.listToJson(metadataList, true));
+    return new Gson().toJson(MetadataJson.listToJson(metadataList, true, false));
   }
 
   @Override


### PR DESCRIPTION
A while ago we stopped returning collections for metadata fields with listproviders attached from the External API to improve performance. However, that means that an external application has no way to map a value for one of those fields to its "human-readable value", meaning what the Admin UI would show you, or show a selection of alternative values.

By including what listprovider is attached to that metadata field (an information we already have internally), the application could fetch the collection itself from the listproviders service if it wants to, without impacting performance for the External API.

Since this adds an attribute to the output data, this counts up the API version as well.

Example data:
```
  {
    "identifier": "0a81278e-2865-484c-adcf-c0f6d407ca51",
    "metadata": [
      {
        "flavor": "dublincore/episode-extended",
        "title": "EVENTS.EVENTS.DETAILS.CATALOG.EPISODE",
        "fields": [
          {
            "translatable": false,
            "readOnly": false,
            "id": "faculty",
            "label": "Fachbereich",
            "type": "text",
            "value": "FACULTY1",
            "required": true,
            "listprovider": "FACULTIES" <- new!
          }
        ]
      }
  }
```
