### PR TITLE
Reenable Access by Episode ID

### DIFF
--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -1,5 +1,12 @@
 # Opencast 18: Release Notes
 
+## Opencast 18.next
+
+This release contains a fix for
+(Episode ID Roles)[https://docs.opencast.org/r/18.x/admin/#configuration/episode-id-roles/#episode-id-roles], which
+were broken in earlier 18.x releases.  Adopters affected by this issue should either reindex their search index or
+republish their recordings.  If you do not use episode id roles then this can safely be ignored.
+
 ## Opencast 18.5
 
 This release includes some minor fixes, as well as an improvement that makes the download of static files easier.[[#7213](https://github.com/opencast/opencast/pull/7213)]

--- a/docs/guides/admin/docs/upgrade.md
+++ b/docs/guides/admin/docs/upgrade.md
@@ -107,3 +107,8 @@ ACLs if you haven't used this feature before. **If this feature was already enab
 If it was not enabled before upgrading, you can start the rebuild by calling the `/index/rebuild/AssetManager/ACL` and
 `/index/rebuild/Search` endpoints. These endpoints will reindex the event ACLs in both the AssetManager index and the
 Search index. For more information, see [here](configuration/episode-id-roles.md).
+
+[[#7477](https://github.com/opencast/opencast/pull/7477)] a fix applied in 18.6 re-enabled
+(Episode ID Roles)[https://docs.opencast.org/r/18.x/admin/#configuration/episode-id-roles/#episode-id-roles].  If your
+site uses these roles, a reindex of the search index or republishing the affected events will resolve the issue.  This
+can be safely ignored if your site does not use episode id roles.

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
@@ -88,6 +88,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -371,6 +372,9 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
             new AccessControlEntry(getEpisodeRoleId(mediaPackageId, action), action, true));
       }
     }
+
+    AccessControlList customRoles = new AccessControlList(new ArrayList<>(customEntries));
+    acl = customRoles.merge(acl);
 
     return acl;
   }


### PR DESCRIPTION
This PR re-enables episode ID roles.  This was accidentally lost in c750e970b32b827527d845e81a38fa86a5027679.

### How to test this patch

Process a video, ensure a user with `ROLE_EPISODE_$episodeId_READ` can read it.  If the video was previously published then a reindex/republish will be required.

This needs to be in 18.x since it affects 18.x and is a feature which is otherwise not usable.

Fixes #7333


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] ~include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)~
