### PR TITLE
Remove unused `YouTubeKey.scopes` enum entry

### DIFF
--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeKey.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeKey.java
@@ -28,7 +28,6 @@ package org.opencastproject.publication.youtube;
  */
 public enum YouTubeKey {
   credentialDatastore,
-  scopes,
   clientSecretsV3,
   dataStore,
   keywords,

--- a/modules/publication-service-youtube-v3/src/test/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImplTest.java
+++ b/modules/publication-service-youtube-v3/src/test/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImplTest.java
@@ -116,7 +116,6 @@ public class YouTubeV3PublicationServiceImplTest {
   private Dictionary getServiceProperties() throws IOException {
     final Properties p = new Properties();
     YouTubeUtils.put(p, YouTubeKey.credentialDatastore, "credentialDatastore");
-    YouTubeUtils.put(p, YouTubeKey.scopes, "foo");
     final String absolutePath = UnitTestUtils.getMockClientSecretsFile("clientId",
         testFolder.newFile("client-secrets-youtube-v3.json")).getAbsolutePath();
     YouTubeUtils.put(p, YouTubeKey.clientSecretsV3, absolutePath);


### PR DESCRIPTION
This slipped into #7383, but should probably be its own PR.