### PR TITLE
security-jwt and userdirectory module patch

### DIFF
--- a/modules/security-jwt/src/main/java/org/opencastproject/security/jwt/DynamicLoginHandler.java
+++ b/modules/security-jwt/src/main/java/org/opencastproject/security/jwt/DynamicLoginHandler.java
@@ -54,6 +54,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -165,20 +166,30 @@ public class DynamicLoginHandler implements InitializingBean, JWTLoginHandler {
       CachedJWT cachedJwt = cache.getIfPresent(signature);
 
       if (cachedJwt == null) {
+        logger.debug("JWT cache miss for signature {}, validating token", abbreviateSignature(signature));
+
         // JWT hasn't been cached before, so validate all claims
         SignedJWT jwt = decodeAndValidate(token);
         String username = extractUsername(jwt);
+        boolean invalidateUserDirectory = true;
 
         try {
           if (userDetailsService.loadUserByUsername(username) != null) {
-            existingUserLogin(username, jwt);
+            invalidateUserDirectory = existingUserLogin(username, jwt);
           }
         } catch (UsernameNotFoundException e) {
           newUserLogin(username, jwt);
         }
 
-        userDirectoryService.invalidate(username);
+        if (invalidateUserDirectory) {
+          logger.debug("Invalidating user directory caches for JWT user '{}'", username);
+          userDirectoryService.invalidate(username);
+        } else {
+          logger.debug("Skipping user directory invalidation for JWT user '{}' since effective user data is unchanged",
+              username);
+        }
         cache.put(jwt.getSignature().toString(), new CachedJWT(jwt, username));
+        logger.debug("Cached validated JWT signature {} for user '{}'", abbreviateSignature(signature), username);
         return username;
       } else {
         // JWT has been cached before, so only check if it has expired
@@ -186,7 +197,8 @@ public class DynamicLoginHandler implements InitializingBean, JWTLoginHandler {
           cache.invalidate(signature);
           throw new JOSEException("JWT token is not valid anymore");
         }
-        logger.debug("Using decoded and validated JWT from cache");
+        logger.debug("Using validated JWT from cache for user '{}' and signature {}", cachedJwt.getUsername(),
+            abbreviateSignature(signature));
         return cachedJwt.getUsername();
       }
     } catch (ParseException | JOSEException exception) {
@@ -390,7 +402,7 @@ public class DynamicLoginHandler implements InitializingBean, JWTLoginHandler {
     JpaUserReference userReference = new JpaUserReference(username, extractName(jwt), extractEmail(jwt), MECH_JWT,
         new Date(), fromOrganization(securityService.getOrganization()), extractRoles(jwt));
 
-    logger.debug("JWT user '{}' logged in for the first time", username);
+    logger.debug("JWT user '{}' logged in for the first time, creating a new user reference", username);
     userReferenceProvider.addUserReference(userReference, MECH_JWT);
   }
 
@@ -400,8 +412,11 @@ public class DynamicLoginHandler implements InitializingBean, JWTLoginHandler {
    * @param username The username.
    * @param jwt The decoded JWT.
    */
-  public void existingUserLogin(String username, SignedJWT jwt) throws ParseException {
+  public boolean existingUserLogin(String username, SignedJWT jwt) throws ParseException {
     Organization organization = securityService.getOrganization();
+    String name = extractName(jwt);
+    String email = extractEmail(jwt);
+    Set<JpaRole> roles = extractRoles(jwt);
 
     // Load the user reference
     JpaUserReference userReference = userReferenceProvider.findUserReference(username, organization.getId());
@@ -409,14 +424,50 @@ public class DynamicLoginHandler implements InitializingBean, JWTLoginHandler {
       throw new UsernameNotFoundException("User reference '" + username + "' was not found");
     }
 
+    boolean changed = userReferenceChanged(userReference, name, email, roles);
+    String changedFields = changed ? describeUserReferenceChanges(userReference, name, email, roles) : "";
     // Update the reference
-    userReference.setName(extractName(jwt));
-    userReference.setEmail(extractEmail(jwt));
+    userReference.setName(name);
+    userReference.setEmail(email);
     userReference.setLastLogin(new Date());
-    userReference.setRoles(extractRoles(jwt));
+    userReference.setRoles(roles);
 
-    logger.debug("JWT user '{}' logged in", username);
+    if (changed) {
+      logger.debug("JWT user '{}' logged in with updated user data ({}), refreshing merged user caches", username,
+          changedFields);
+    } else {
+      logger.debug("JWT user '{}' logged in with unchanged name, email, and roles", username);
+    }
     userReferenceProvider.updateUserReference(userReference);
+    return changed;
+  }
+
+  private boolean userReferenceChanged(JpaUserReference userReference, String name, String email, Set<JpaRole> roles) {
+    return !Objects.equals(userReference.getName(), name)
+        || !Objects.equals(userReference.getEmail(), email)
+        || !Objects.equals(userReference.getRoles(), roles);
+  }
+
+  private String describeUserReferenceChanges(JpaUserReference userReference, String name, String email,
+      Set<JpaRole> roles) {
+    List<String> changedFields = new ArrayList<>();
+    if (!Objects.equals(userReference.getName(), name)) {
+      changedFields.add("name");
+    }
+    if (!Objects.equals(userReference.getEmail(), email)) {
+      changedFields.add("email");
+    }
+    if (!Objects.equals(userReference.getRoles(), roles)) {
+      changedFields.add("roles");
+    }
+    return String.join(", ", changedFields);
+  }
+
+  private String abbreviateSignature(String signature) {
+    if (signature == null || signature.length() <= 12) {
+      return signature;
+    }
+    return signature.substring(0, 12) + "...";
   }
 
   /**

--- a/modules/security-jwt/src/test/java/org/opencastproject/security/jwt/JWTGenerator.java
+++ b/modules/security-jwt/src/test/java/org/opencastproject/security/jwt/JWTGenerator.java
@@ -21,6 +21,9 @@
 
 package org.opencastproject.security.jwt;
 
+import org.opencastproject.security.impl.jpa.JpaOrganization;
+import org.opencastproject.security.impl.jpa.JpaRole;
+
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
@@ -35,7 +38,9 @@ import com.nimbusds.jwt.SignedJWT;
 
 import java.security.NoSuchAlgorithmException;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Helper class generating data for the tests.
@@ -78,18 +83,24 @@ public final class JWTGenerator {
   }
 
   public String generateValidSymmetricJWT() throws JOSEException {
-    return generateValidJWT(getSymmetricSigner(), getSymmetricAlgorithm(), 60 * 60 * 1000);
+    return generateValidJWT(getSymmetricSigner(), getSymmetricAlgorithm(), name, email, roles, 60 * 60 * 1000);
   }
 
   public String generateValidSymmetricJWT(int expiresInMillis) throws JOSEException {
-    return generateValidJWT(getSymmetricSigner(), getSymmetricAlgorithm(), expiresInMillis);
+    return generateValidJWT(getSymmetricSigner(), getSymmetricAlgorithm(), name, email, roles, expiresInMillis);
+  }
+
+  public String generateValidSymmetricJWT(String name, String email, List<String> roles, int expiresInMillis)
+          throws JOSEException {
+    return generateValidJWT(getSymmetricSigner(), getSymmetricAlgorithm(), name, email, roles, expiresInMillis);
   }
 
   public String generateValidAsymmetricJWT() throws JOSEException {
-    return generateValidJWT(getAsymmetricSigner(), getAsymmetricAlgorithm(), 60 * 60 * 1000);
+    return generateValidJWT(getAsymmetricSigner(), getAsymmetricAlgorithm(), name, email, roles, 60 * 60 * 1000);
   }
 
-  private String generateValidJWT(JWSSigner signer, JWSAlgorithm algorithm, int expiresInMillis) throws JOSEException {
+  private String generateValidJWT(JWSSigner signer, JWSAlgorithm algorithm, String name, String email,
+      List<String> roles, int expiresInMillis) throws JOSEException {
     JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
         .issuer(issuer)
         .audience(clientId)
@@ -221,6 +232,25 @@ public final class JWTGenerator {
 
   public String getUsername() {
     return username;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public Set<JpaRole> getJpaRoles(JpaOrganization organization) {
+    Set<JpaRole> mappedRoles = new HashSet<>();
+    mappedRoles.add(new JpaRole("ROLE_JWT_USER", organization));
+    mappedRoles.add(new JpaRole("ROLE_JWT_USER_" + username, organization));
+    mappedRoles.add(new JpaRole("ROLE_GROUP_JWT_TRAINER", organization));
+    for (String role : roles) {
+      mappedRoles.add(new JpaRole(role, organization));
+    }
+    return mappedRoles;
   }
 
 }

--- a/modules/security-jwt/src/test/java/org/opencastproject/security/jwt/JWTLoginTest.java
+++ b/modules/security-jwt/src/test/java/org/opencastproject/security/jwt/JWTLoginTest.java
@@ -25,14 +25,18 @@ import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.reset;
+import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 
 import org.opencastproject.security.api.DefaultOrganization;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UserDirectoryService;
+import org.opencastproject.security.impl.jpa.JpaOrganization;
 import org.opencastproject.security.impl.jpa.JpaUserReference;
 import org.opencastproject.userdirectory.api.UserReferenceProvider;
 
@@ -46,6 +50,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 import java.security.NoSuchAlgorithmException;
+import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -59,6 +64,7 @@ import javax.servlet.http.HttpServletRequest;
 public abstract class JWTLoginTest {
 
   protected UserReferenceProvider userReferenceProvider;
+  protected UserDirectoryService userDirectoryService;
   protected JWTGenerator generator;
   protected TestAbstractPreAuthenticatedProcessingFilter authFilter;
   protected DynamicLoginHandler loginHandler;
@@ -73,7 +79,11 @@ public abstract class JWTLoginTest {
 
     // Prepare login handler
     loginHandler = new DynamicLoginHandler();
-    loginHandler.setUserDirectoryService(createNiceMock(UserDirectoryService.class));
+    userDirectoryService = createMock(UserDirectoryService.class);
+    userDirectoryService.invalidate(anyString());
+    expectLastCall().anyTimes();
+    replay(userDirectoryService);
+    loginHandler.setUserDirectoryService(userDirectoryService);
     loginHandler.setUsernameMapping(generator.getUsernameMapping());
     loginHandler.setNameMapping(generator.getNameMapping());
     loginHandler.setEmailMapping(generator.getEmailMapping());
@@ -82,16 +92,22 @@ public abstract class JWTLoginTest {
     loginHandler.setSecret(generator.getSecret());
     loginHandler.setClaimConstraints(generator.generateValidClaimConstraints());
 
+    DefaultOrganization defaultOrganization = new DefaultOrganization();
     SecurityService securityService = createNiceMock(SecurityService.class);
     expect(securityService.getOrganization())
-        .andReturn(new DefaultOrganization())
+        .andReturn(defaultOrganization)
         .atLeastOnce();
     replay(securityService);
     loginHandler.setSecurityService(securityService);
 
+    JpaOrganization jpaOrganization = new JpaOrganization(defaultOrganization.getId(), defaultOrganization.getName(),
+        defaultOrganization.getServers(), defaultOrganization.getAdminRole(), defaultOrganization.getAnonymousRole(),
+        defaultOrganization.getProperties());
+    JpaUserReference existingUserReference = new JpaUserReference(generator.getUsername(), generator.getName(),
+        generator.getEmail(), "jwt", new Date(), jpaOrganization, generator.getJpaRoles(jpaOrganization));
     userReferenceProvider = createNiceMock(UserReferenceProvider.class);
     expect(userReferenceProvider.findUserReference(anyString(), anyString()))
-        .andReturn(createNiceMock(JpaUserReference.class))
+        .andReturn(existingUserReference)
         .atLeastOnce();
     replay(userReferenceProvider);
     loginHandler.setUserReferenceProvider(userReferenceProvider);
@@ -186,6 +202,45 @@ public abstract class JWTLoginTest {
         mockRequest(expiringJwt)
     );
     assertNull(username);
+  }
+
+  @Test
+  public void testRefreshedTokenWithSameUserDataDoesNotInvalidateUserDirectory() throws JOSEException {
+    String firstJwt = generator.generateValidSymmetricJWT(60 * 60 * 1000);
+    String refreshedJwt = generator.generateValidSymmetricJWT(60 * 60 * 1000 + 1000);
+
+    assertNotEquals(firstJwt, refreshedJwt);
+
+    Object username = authFilter.getPreAuthenticatedPrincipal(mockRequest(firstJwt));
+    assertEquals(generator.getUsername(), username);
+
+    reset(userDirectoryService);
+    replay(userDirectoryService);
+
+    username = authFilter.getPreAuthenticatedPrincipal(mockRequest(refreshedJwt));
+    assertEquals(generator.getUsername(), username);
+    verify(userDirectoryService);
+  }
+
+  @Test
+  public void testRefreshedTokenWithChangedUserDataInvalidatesUserDirectory() throws JOSEException {
+    String firstJwt = generator.generateValidSymmetricJWT(60 * 60 * 1000);
+    String refreshedJwt = generator.generateValidSymmetricJWT("John Refresh", "john.refresh@example.org",
+        List.of("member@example.org", "trainer@example.org"), 60 * 60 * 1000 + 1000);
+
+    assertNotEquals(firstJwt, refreshedJwt);
+
+    Object username = authFilter.getPreAuthenticatedPrincipal(mockRequest(firstJwt));
+    assertEquals(generator.getUsername(), username);
+
+    reset(userDirectoryService);
+    userDirectoryService.invalidate(generator.getUsername());
+    expectLastCall().once();
+    replay(userDirectoryService);
+
+    username = authFilter.getPreAuthenticatedPrincipal(mockRequest(refreshedJwt));
+    assertEquals(generator.getUsername(), username);
+    verify(userDirectoryService);
   }
 
   @Test

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
@@ -527,6 +527,10 @@ public class UserAndRoleDirectoryServiceImpl implements UserDirectoryService, Us
 
   @Override
   public void invalidate(String userName) {
+    if (logger.isDebugEnabled()) {
+      logger.debug("Invalidating user '{}' from {} user provider(s): {}", userName, userProviders.size(),
+          userProviders.stream().map(UserProvider::getName).collect(Collectors.joining(", ")));
+    }
     for (UserProvider userProvider : userProviders) {
       userProvider.invalidate(userName);
     }


### PR DESCRIPTION
Related to [https://github.com/opencast/opencast/issues/7483](https://github.com/opencast/opencast/issues/7483)

This changes security-jwt so refreshed JWTs no longer cause unnecessary user-directory cache invalidation.

  Before this change, a refreshed OIDC access token was treated as a JWT cache miss because the token signature changed. On that path, DynamicLoginHandler always called
  userDirectoryService.invalidate(username), which cleared the cached entry across all user providers, including userdirectory-moodle. In setups where access tokens are refreshed
  regularly, that meant Moodle was queried again and again for the same user even when nothing about the user had actually changed.

  With this patch, refreshed JWTs are still validated normally, but user-directory invalidation only happens when the effective JWT-derived user data has changed. For existing users, we
  now compare the current reference against the incoming name, email, and roles. If those values are unchanged, the user reference is updated as needed, but the user-directory caches are
  left intact. If they did change, the invalidate still happens so the updated user state is reflected correctly.

  I also added debug logging around:

  - JWT cache hits and misses
  - whether user-directory invalidation is performed or skipped
  - which effective user fields changed
  - which user providers are being invalidated

  This should make it much easier to understand future cache behavior in installations that use token refresh heavily.

  In short, this fixes repeated Moodle cache eviction caused by normal JWT refresh cycles, while preserving the existing behavior for real user-data changes.
  
  