### PR TITLE
Revert #6292 with updated Pax web

### DIFF
--- a/etc/org.ops4j.pax.web.cfg
+++ b/etc/org.ops4j.pax.web.cfg
@@ -29,8 +29,5 @@ org.osgi.service.http.enabled=true
 # Prevent cookie from being accessed by client side scripts, default false
 org.ops4j.pax.web.session.cookie.httpOnly=true
 
-# Timeout for user sessions in seconds
-# Note: This is seconds, not minutes due to a bug in Pax Web:
-# https://github.com/opencast/opencast/issues/6260
-# 14400 seconds = 240 minutes = 4 hours
-org.ops4j.pax.web.session.timeout=14400
+# Timeout for user sessions in minutes
+org.ops4j.pax.web.session.timeout=240


### PR DESCRIPTION
The session timeout is again correctly set in minutes instead of seconds. This therefore reverts #6292.

Fixes #6295

### How to test this patch

Log into the Admin UI and close the tab again. Come back before/after the set timeout and see if you need to log in again.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
