### PR TITLE
Drop use of proxy_cookie_path for setting cookie flags

### DIFF
--- a/docs/guides/admin/docs/configuration/https/nginx.md
+++ b/docs/guides/admin/docs/configuration/https/nginx.md
@@ -114,13 +114,10 @@ http {
 
             # Make sure to serve cookies only via secure connections.
             proxy_cookie_flags ~ secure httponly;
-            # When using Nginx <1.19.3 replace the above 'proxy_cookie_flags' line
-            # with the (uncommented) 'proxy_cookie_path' line below.
-            #proxy_cookie_path / "/; HTTPOnly; Secure";
 
             # Depending on your integration, you may also want to allow cookies
             # to be used on other sites. In that case, use this instead:
-            #proxy_cookie_path / "/; HTTPOnly; Secure; SameSite=None";
+            #proxy_cookie_flags ~ secure httponly samesite=none;
 
             # Do not buffer responses
             proxy_buffering         off;


### PR DESCRIPTION
This is a follow up of #2942 and fully drops the use of `proxy_cookie_path` in the nginx configuration for the purpose of setting cookie flags. Instead, the `proxy_cookie_flags` option should be used that was added in nginx v1.19.3.

Fixes #2135

### How to test this patch

Check if the cookie flags are set if configured in nginx.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
