### PR TITLE
Bug fix: hls m3u8 files rewritten but their size/checksum not updated in media package

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/mediapackage/AdaptivePlaylist.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/AdaptivePlaylist.java
@@ -626,7 +626,9 @@ public interface AdaptivePlaylist extends Track {
         newTracks.add(rep.track); // segments are unchanged
         continue;
       }
-      replaceTrackFileInPlace(rep.origMpfile, newNames);
+      File f = replaceTrackFileInPlace(rep.origMpfile, newNames);
+      rep.track.setSize(f.length());
+      rep.track.setChecksum(null);
       rep.newMpuri = rep.origMpuri;
       newTracks.add(rep.track); // add changed variants
     }
@@ -640,7 +642,9 @@ public interface AdaptivePlaylist extends Track {
       newNames.put(logName, relPath);
     }
     // on master, fix references to variant playlists
-    replaceTrackFileInPlace(master.origMpfile, newNames);
+    File f = replaceTrackFileInPlace(master.origMpfile, newNames);
+    master.track.setSize(f.length());
+    master.track.setChecksum(null);
     master.newMpuri = master.track.getURI();
     newTracks.add(master.track);
     // Update the logical names to keep referential integrity
@@ -755,7 +759,9 @@ public interface AdaptivePlaylist extends Track {
         }
         newFiles.add(destFile);
         oldTracks.add(trackRep.track);
-        Track copyTrack = (Track) trackRep.track.clone(); // get all the properties, id, etc
+        Track copyTrack = (Track) trackRep.track.clone();
+        copyTrack.setSize(destFile.length());
+        copyTrack.setChecksum(null);
         mp.add(copyTrack); // add to mp and get new elementID
         Track newTrack = replaceTrackFileInWS.apply(destFile, copyTrack);
         if (newTrack == null) {


### PR DESCRIPTION
There are some places in the code (distribution, sanitize-adaptive) where the hls m3u8 files are rewritten to update their references to the media files/variants and that changes the m3u8 file sizes and checksum. The bug was that the tracks in the media package were cloned, keeping the old size/checksum. This is probably harmless to most adopters, except us :)

To reproduce the problem:

1. Publish a recording using serverless hls
2. Get the media package from the search index
3. Compare the m3u8 track file sizes to what's in the distribution folder and verify that they don't match

What's described above doesn't really cause any problems. In our case, we had a process where we replaced the presenter in a media package, then used the sanitize-adaptive woh, then archived to S3 and, when downloading those files from S3 via the archive endpoint, they were truncated because the sizes in the assets table were incorrect.

### How to test this patch

Apply the patch and create a new media package, doing the same steps described above to reproduce the problem and verify that the m3u8 files sizes match.
