### PR TITLE
Document submodule usage

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,5 +24,6 @@ reviewed and merged.
 * [ ] include migration scripts and documentation, if appropriate
 * [ ] pass automated tests
 * [ ] have a clean commit history
+* [ ] does not incorrectly update the submodules
 * [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
 * [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch

--- a/docs/guides/developer/docs/participate/development-process.md
+++ b/docs/guides/developer/docs/participate/development-process.md
@@ -291,6 +291,70 @@ For example, a pull request may be merged into `r/7.x`, `r/7.x` will then be mer
 exists, `r/8.x` and from there into `develop`. That way patches bubble through all newer versions and finally end up in
 `develop`.
 
+Git Submodules
+--------------
+
+Starting in the `r/18.x` branch we changed how we work with submodules.  Prior to this change `admin-ui-interface`,
+`editor`, and `studio` were fetched as release tarballs at build time by Maven.  This came with a
+ [number of drawbacks](https://github.com/orgs/opencast/discussions/7277), which is part of why we have replaced those
+modules with [git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules).  Submodules are a complex topic,
+but for an Opencast developer they should be relatively simple to manage.
+
+### Initial clone
+
+We all clone `opencast/opencast`, but now there is a suggested additional step to run before cloning:
+
+    git config submodule.recurse true
+
+What this does is tell git that when you check a branch out, that *all* submodules should also check out the appropriate
+revisions specfied in their respective submodule directories.  If you do not do this, then you will need to manually
+run `git submodule update --init --recursive --remote` every time you change branches.  Failure to run this manual step
+does not cause issues, as long as you do not incorrectly commit the wrong submodule hash.
+
+### Updating to a version with submodules
+
+Even if you applied the change above, when you first checkout (or update) a branch to a version which contains
+submodules, those submodules will not automatically clone.  This requires an additional step:
+
+    git submodule update --init --recursive
+
+This step initiates a clone for each submodule, and then checks out the correct versions.
+
+### Manually updating the subproject's commit
+
+Rarely, you may want to locally update the hash of a submodule.  This is accomplished by running the same command as
+above with the addition of `--remote`.  In addition if you only want to update to the latest in the release branch:
+
+    git submodule update --init --remote modules/SUBMODULE_NAME
+
+If you want a specific hash then the command is slightly different.  First enter the submodule's directory, then check
+out the revision you want, fetching a repo update if needed
+
+    cd module/SUBMODULE_NAME
+    git fetch origin -> Remember, origin here is the submodule's repository
+    git checkout HASH/BRANCH
+
+A word of warning:  It is generally better to merge in the release branch you are working from rather than updating
+the hash in your branch directly.  If you absolutely must update the submodule, only do the ones you need specifically,
+and if you commit those changes do them in a separate commit from the rest of your work.  A branch with a changed
+target will almost certainly have conflicts when filed as a PR because git is diffing only the target hashes, with no
+concept of the commit tree, or whether commit A is a child commit of commit B.  In *most* cases, you do not want to
+commit the changed hash, even if you need it for development.  In this case, avoid committing the X submodule so your
+change will not persist.
+
+### Working with older, non-submoduled versions
+
+Git does not nicely handle switching back and forth between non-submoduled versions (ie, earlier 18.x and 19.x, or 17.x
+and older).  It's technically possible, but requires manually removing files from disk *every time youi switch between
+branches*.  In general, we suggest working on older versions in a separate clone.
+
+### Why working directly on a submodule is a bad idea
+
+If you are working directly on one of the submodules (eg: fixing a bug) you should be working in an entirely separate
+clone of *only* that submodule.  While technically possible, working in the `opencast/opencast` clone's copy of the
+submodule can lead to very confusing situations which are easily avoided if you instead work on the code in a separate
+clone and treat the nested submodule from the main codebase as a black box.
+
 
 Release Process
 ---------------

--- a/docs/guides/developer/docs/participate/release-manager.md
+++ b/docs/guides/developer/docs/participate/release-manager.md
@@ -95,7 +95,12 @@ Example on how to create the Opencast 7 release branch:
 3. Create and push the new release branch:
 
         git checkout -b r/7.x
+        git submodule foreach git checkout -b r/7.x
+        sed -i 's#branch = develop#branch = r/7.x#g' .gitmodules
+        git add .gitmodules
+        git commit -m "Updating .gitmodules to point at the r/7.x"
         git push <remote> r/7.x
+        git submodule foreach git push <remote> r/7.x
 
 4. That is it for the release branch. Now update the versions in `develop` in preparation for the next release:
 
@@ -105,13 +110,17 @@ Example on how to create the Opencast 7 release branch:
 5. Have a look at the changes. Make sure that nothing else was modified:
 
         git diff
-        git status | grep modified: | grep -v pom.xml   # this should have no output
+        git status | grep modified: | grep -v pom.xml | grep -v "modified content"  # this should have no output
 
 6. If everything looks fine, commit the changes and push it to the community repository:
 
+        git submodule foreach git add pom.xml
+        git submodule foreach git commit -s -m 'Bumping pom.xml Version Nnumbers'
         git add $(git status | grep 'modified:.*pom.xml' | awk '{print $2;}')
+        git add $(git submodule | cut -f 2 -d " ")
         git commit -s -m 'Bumping pom.xml Version Numbers'
         git push <remote> develop
+        git submodule foreach git push origin develop
 
 
 ### Status of Translations
@@ -283,6 +292,7 @@ The following steps outline the necessary steps for cutting the final release:
 3. Switch to a new branch to create the release (name does not really matter):
 
         git checkout -b tmp-16.0
+        git submodule foreach git checkout -b tmp-16.0
 
 4. Make the version changes for the release:
 
@@ -292,16 +302,21 @@ The following steps outline the necessary steps for cutting the final release:
 
         git diff
         # The following command should yield no output:
-        git status | grep modified: | grep -v pom.xml
+        git status | grep modified: | grep -v pom.xml | grep -v "modified content"
 
 6. Commit the changes and create a release tag:
 
+        git submodule foreach git add pom.xml
+        git submodule foreach git commit -S -m 'Opencast 16.0'
+        git submodule foreach git tag -s 16.0 -m 'Opencast 16.0'
         git add $(git status | grep 'modified:.*pom.xml' | awk '{print $2;}')
+        git add $(git submodule | cut -f 2 -d " ")
         git commit -S -m 'Opencast 16.0'
         git tag -s 16.0 -m 'Opencast 16.0'
 
 7. Push the tag to the community repository (you can remove the branch afterwards):
 
+        git submodule foreach git push origin 16.0
         git push <remote> 16.0
 
 8. Check the “Create new release” GitHub Actions workflow.


### PR DESCRIPTION
This PR documents how to deal with submodules as an Opencast developer, and release manager.  This needs to be in 18 since the submodules are going into 18 with #7509 

Part of #7220 

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
