### PR TITLE
Add config option to filter available roles in admin ui dropdowns

### DIFF
--- a/etc/listproviders/acl.default.create.properties
+++ b/etc/listproviders/acl.default.create.properties
@@ -43,4 +43,4 @@ list.name=ACL.DEFAULTS
 # role dropdowns. Can be useful if you have a category of roles that makes working with the access policy tab
 # tedious, but that you need to keep around for other reasons.
 # Default: No prefixes
-#display_role_filter_prefixes=ROLE_GROUP_
+#display_role_filter_blacklist_prefixes=ROLE_GROUP_

--- a/etc/listproviders/acl.default.create.properties
+++ b/etc/listproviders/acl.default.create.properties
@@ -38,3 +38,9 @@ list.name=ACL.DEFAULTS
 # Example: ROLE_AAI_USER_,ROLE_ADMIN
 # Default: None
 #keep_on_template_switch_role_prefixes=ROLE_USER_
+
+# List of comma separated prefixes. If a role matches one of the given prefixes, it will not appear in the select
+# role dropdowns. Can be useful if you have a category of roles that makes working with the access policy tab
+# tedious, but that you need to keep around for other reasons.
+# Default: No prefixes
+#display_role_filter_prefixes=ROLE_GROUP_


### PR DESCRIPTION
More specifically the dropdowns in the access policy tab in the details modals. Allows you to effectively remove catgories of roles (like ROLE_GROUP) from the dropdowns to make them more usable.

*This just adds an additional configuration option, so it won't break anything, but also won't do anything without the associated frontend changes: https://github.com/opencast/admin-interface/pull/1561

### How to test this patch

Enable the configuration option and test with a frontend that has the necessary patch.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
