### PR TITLE
Add possibility to upload audio-only as presentation track

### DIFF
--- a/etc/workflows/partial-preview.yaml
+++ b/etc/workflows/partial-preview.yaml
@@ -58,7 +58,7 @@ operations:
       - time: 50%
 
   - id: cover-image
-    if: NOT (${presenter_source_video} OR ${presentation_source_video})
+    if: NOT (${presenter_source_video} OR ${presentation_source_video}) AND ${presenter_source_audio}
     description: Create a cover image for audio-only files
     configurations:
       - stylesheet: file://${karaf.etc}/branding/coverimage.xsl
@@ -66,28 +66,55 @@ operations:
       - height: 1080
       - target-flavor: presenter/image+work
 
+  - id: cover-image
+    if: NOT (${presenter_source_video} OR ${presentation_source_video}) AND ${presentation_source_audio}
+    description: Create a cover image for audio-only files
+    configurations:
+      - stylesheet: file://${karaf.etc}/branding/coverimage.xsl
+      - width: 1920
+      - height: 1080
+      - target-flavor: 'presentation/image+work'
+
   - id: image-to-video
-    if: NOT (${presenter_source_video} OR ${presentation_source_video})
+    if: NOT (${presenter_source_video} OR ${presentation_source_video}) AND ${presenter_source_audio}
     description: Composite
     configurations:
-      - source-flavor: presenter/image+work
-      - target-flavor: '*/video+work'
+      - source-flavor: 'presenter/image+work'
+      - target-flavor: 'presenter/video+work'
       - duration: ${presenter_source_duration}
       - profile: image-movie.work
 
+  - id: image-to-video
+    if: NOT (${presenter_source_video} OR ${presentation_source_video}) AND ${presentation_source_audio}
+    description: Composite
+    configurations:
+      - source-flavor: 'presentation/image+work'
+      - target-flavor: 'presentation/video+work'
+      - duration: ${presentation_source_duration}
+      - profile: image-movie.work
+
   - id: prepare-av
-    if: NOT (${presenter_source_video} OR ${presentation_source_video})
+    if: NOT (${presenter_source_video} OR ${presentation_source_video}) AND ${presenter_source_audio}
     description: Preparing presenter audio and video work versions
     configurations:
-      - source-flavor: presenter/video+work
-      - target-flavor: presenter/preview
+      - source-flavor: 'presenter/video+work'
+      - target-flavor: 'presenter/preview'
+      - rewrite: false
+      - audio-muxing-source-flavors: '*/source'
+
+  - id: prepare-av
+    if: NOT (${presenter_source_video} OR ${presentation_source_video}) AND ${presentation_source_audio}
+    description: Preparing presenter audio and video work versions
+    configurations:
+      - source-flavor: 'presentation/video+work'
+      - target-flavor: 'presentation/preview'
       - rewrite: false
       - audio-muxing-source-flavors: '*/source'
 
   - id: tag
     description: Tagging media package elements
     configurations:
-      - source-flavors: presenter/preview
+      - source-flavors: 'presenter/preview, presentation/preview'
       - target-tags: preview
       - copy: false
 


### PR DESCRIPTION
This PR adds the necessary operations to be able to upload and process audio-files that were uploaded as a `presentation` track. This aims to fix https://github.com/opencast/opencast/issues/7379 . 

### How to test this patch

Upload a audio file with the `presentation` flavor and see if it is processed correctly. 

**Note:**  There currently appears to be an issue with playback of audio-only files in Paella Player 8, as such streams are not being detected. This is unrelated to this PR and likely needs to be fixed in the paella8 repository. For now, please test using Paella Player 7.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
