### PR TITLE
Fix typo in library tag in pom.xml

### DIFF
--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -108,7 +108,7 @@
           <configuration>
             <libraries>
               <library>mvn:jakarta.activation/jakarta.activation-api/1.2.1;type:=endorsed;export:=true</library>
-              <libaray>mvn:jakarta.xml.bind/jakarta.xml.bind-api/2.3.3;type:=endorsed;export:=true</libaray>
+              <library>mvn:jakarta.xml.bind/jakarta.xml.bind-api/2.3.3;type:=endorsed;export:=true</library>
               <library>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.saaj-api-1.3/2.8.0;type:=endorsed;export:=true</library>
               <library>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.activation-api-1.1/2.8.0;type:=endorsed;export:=true</library>
               <library>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.stax-api-1.2/2.8.0;type:=endorsed;export:=true</library>


### PR DESCRIPTION
Just a typo in a pom.xml

