### PR TITLE
Properly detect submodule versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -393,6 +393,7 @@
           <doCheck>false</doCheck>
           <doUpdate>false</doUpdate>
           <shortRevisionLength>7</shortRevisionLength>
+          <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
         </configuration>
       </plugin>
       <!-- Attach sources for all builds -->


### PR DESCRIPTION
This PR *disables* the version check in every single module, replacing it with a single parent check.  This lets the submodules use the parent's version as their buildnumber, which is currently causing the version listing at the bottom of the admin UI to say `Opencast – built on unknown` because the module hashes don't work.

Note that we do not currently store the submodule hash in the database, so we have no way to know if the submodules have been modified.  A future PR will add support for this, but likely will only land in `develop`.

This needs to go into `r/18.x` since otherwise the UI complains :)

Related PRs:
https://github.com/opencast/admin-interface/pull/1573
https://github.com/opencast/editor/pull/1696
https://github.com/opencast/studio/pull/1314

### How to test this patch

Build Opencast and ensure that the admin UI does not say `built on unknown` at the bottom

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] ~include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)~
