### PR TITLE
Remove unused(?) waveform operation

### DIFF
--- a/etc/workflows/partial-preview.yaml
+++ b/etc/workflows/partial-preview.yaml
@@ -30,6 +30,19 @@ operations:
       - encoding-profile: mp4-preview.http
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  # Audio waveform
+
+  # Create the waveform.
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  - id: waveform
+    exception-handler-workflow: partial-error
+    description: Generating waveform
+    configurations:
+      - source-flavor: '*/source'
+      - target-flavor: '*/waveform'
+      - target-tags: preview
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   # Track previews
 
   # Create track previews for video editor stream selection feature
@@ -77,17 +90,6 @@ operations:
       - source-flavors: presenter/preview
       - target-tags: preview
       - copy: false
-
-  - id: waveform
-    fail-on-error: false
-    description: Generating audio preview waveform
-    configurations:
-      - source-flavor: '*/source'
-      - target-flavor: '*/audio+preview'
-      - target-tags: preview
-      - min-width: 688
-      - max-width: 688
-      - height: 58
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   # Silence detection

--- a/etc/workflows/partial-preview.yaml
+++ b/etc/workflows/partial-preview.yaml
@@ -30,19 +30,6 @@ operations:
       - encoding-profile: mp4-preview.http
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  # Audio waveform
-
-  # Create the waveform.
-  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  - id: waveform
-    exception-handler-workflow: partial-error
-    description: Generating waveform
-    configurations:
-      - source-flavor: '*/source'
-      - target-flavor: '*/waveform'
-      - target-tags: preview
-
-  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   # Track previews
 
   # Create track previews for video editor stream selection feature


### PR DESCRIPTION
The `partial-preview` workflow contains two waveform operations. While the second one is used in the editor, I was unable to find any use for the first.

If anyone knows why it was added, please let me know. Otherwise, I suggest removing it.

### How to test this patch

Just upload a video using the default workflow and see if everything works as expected and the generated waveform still shows up in the editor. 

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
