### PR TITLE
Add missing modules to jacoco pom

### DIFF
--- a/modules/jacoco-reports/pom.xml
+++ b/modules/jacoco-reports/pom.xml
@@ -309,6 +309,11 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-engage-paella-player-8</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-engage-ui</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -439,6 +444,16 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-list-providers-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-list-providers-impl</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-live-schedule-api</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -470,6 +485,11 @@
     <dependency>
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-lti-service-remote</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-matrix-notification-workflowoperation</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -775,6 +795,11 @@
     <dependency>
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-statistics-provider-influx</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-statistics-provider-matomo</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
This PR adds the modules which are currently missing from the OC 20/21 jacoco reports pom

Without these the reports don't *fail*, but they're also incomplete.  There is a workflow which checks for their existance, but it only runs on pushes, so I don't know that anyone has noticed yet.

### How to test this patch

`./.github/check-jacoco-deps.sh`

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] ~explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch~
* [ ] ~include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)~
