### PR TITLE
Switch to https submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "modules/admin"]
 	path = modules/admin
-	url = git@github.com:opencast/admin-interface
+	url = https://github.com/opencast/admin-interface
 	branch = r/18.x
 [submodule "modules/editor"]
 	path = modules/editor
-	url = git@github.com:opencast/editor
+	url = https://github.com/opencast/editor
 	branch = r/18.x
 [submodule "modules/studio"]
 	path = modules/studio
-	url = git@github.com:opencast/studio
+	url = https://github.com/opencast/studio
 	branch = r/18.x

--- a/docs/guides/developer/docs/participate/release-manager.md
+++ b/docs/guides/developer/docs/participate/release-manager.md
@@ -80,6 +80,9 @@ release branch).
 
 Example on how to create the Opencast 7 release branch:
 
+0. Ensure that you have applied a replacement rule set up for github
+
+        git config --global url."git@github.com:opencast/".insteadOf "https://github.com/opencast/"
 
 1. Check out `develop` and make sure it has the latest state (replace `<remote>` with your remote name for the community
    repository):
@@ -276,6 +279,10 @@ needs to be done manually.
 ### Releasing
 
 The following steps outline the necessary steps for cutting the final release:
+
+0. Ensure that you have applied a replacement rule set up for github
+
+        git config --global url."git@github.com:opencast/".insteadOf "https://github.com/opencast/"
 
 0. Switch to and update your local release branch.
 


### PR DESCRIPTION
This PR switches our modules to https by default, with documentation for release managers which enables git so that you can easily push without needing passwords.

All developers should *probably* run `git submodule sync` after this has landed in all the branches since that will actually propagate the changes to your current clones.  There does not appear to be a downside to *not* running this sync though - it's the same repo regardless.

This needs to be in 18 since it affects 18's codebase, but has no user-facing changes.

Closes #7576

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] ~include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)~
