### PR TITLE
Remove NPM builds from site builds.

### DIFF
--- a/.github/workflows/test-opencast-site.yml
+++ b/.github/workflows/test-opencast-site.yml
@@ -83,10 +83,12 @@ jobs:
             -Dmaven.wagon.http.pool=false \
             -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
 
-        #This has to happen in a separate step or else various service classes aren't visible
+        # This has to happen in a separate step or else various service classes aren't visible
+        # The negated frontend profile here skips the npm builds which both speeds up the already painfully long build
+        # and also prevents issues related to submodules.  NPM related things don't appear in the code coverage reports anyway.
       - name: build maven site
         run: |
-          ./mvnw site -T1C -Pnone \
+          ./mvnw site -T1C -P'none,!frontend' \
             --batch-mode \
             -Dsurefire.rerunFailingTestsCount=2 \
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \


### PR DESCRIPTION
This PR removes the npm builds from the final site report build.  These are already built in the step before, and don't need to be touched again.

This prevents an issue where the site build is trying to run the npm build again, and triggering some kind of failure.  Since nothing this build is doing could affect the final Javadocs report, lets just skip building those modules!

Ideally this goes into 18, but I'm not opposed to moving it up to 19 if there is opposition.

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] ~include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)~
