### PR TITLE
Disable PMD in site reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1540,16 +1540,16 @@
           </reportSet>
         </reportSets>
       </plugin>
-      <plugin>
+      <!--<plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
         <configuration>
           <aggregate>true</aggregate>
-          <!--<includeTests>true</includeTests>-->
+          <!- -<includeTests>true</includeTests>- ->
           <typeResolution>true</typeResolution>
           <targetJdk>${java.release}</targetJdk>
         </configuration>
-      </plugin>
+      </plugin>-->
     </plugins>
   </reporting>
   <repositories>


### PR DESCRIPTION
This PR disables PMD reports during the site build (they were already disabled during the normal build).  These reports seem to take a *very* long time to generate - I'm seeing site build times cut in **half** when I test locally.  This should speed up results for PRs especially.

Going into 18.x since it makes life easier and does not affect end users at all.

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] ~include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)~
