### PR TITLE
Fixing scale encoding profile

### DIFF
--- a/etc/encoding/opencast.properties
+++ b/etc/encoding/opencast.properties
@@ -232,7 +232,7 @@ profile.scale.fhd.framerate.fix.output = audiovisual
 profile.scale.fhd.framerate.fix.suffix = .mp4
 profile.scale.fhd.framerate.fix.ffmpeg.command = -i #{in.video.path} \
   -max_muxing_queue_size 1000 \
-  -filter:v scale=w='trunc(min(max(1920\\,in_w)\\,in_w)/2)*2':'trunc(out_w/dar/2)*2',setsar=1,fps=25 \
+  -filter:v scale='trunc(min(max(1920\\,in_w)\\,in_w)/2)*2':'trunc(out_w/dar/2)*2',setsar=1,fps=25 \
   -c:a aac -ab 128k \
   -c:v libx264 -crf 21 \
   -movflags +faststart \


### PR DESCRIPTION
This PR resolves #7614 where studio recordings (but really anything using this encoding profile) fails because ffmpeg barfs on the video filter.

I'm not confident that this is the *correct* solution, but it seems to work for me and I don't notice any other defects in testing.

This needs to go into r/18.x because otherwise all studio recordings fail at processing time by default.

Fixes #7614

<!--
Explain what this pull request does.  If this fixes a bug, also explain how to reproduce the issue.
-->

<!--
If your pull request is targeting the legacy (second oldest release branch), explain why this patch is so important that
it needs to go into the legacy and can not go just into stable or develop.
-->

### How to test this patch

Record something in studio (anything, config doesn't seem to matter here), and ensure the workflow processes through to completion.


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] ~include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)~
