### PR TITLE
Remove Paella 7 from crowdin config file

### DIFF
--- a/.crowdin.yaml
+++ b/.crowdin.yaml
@@ -9,10 +9,6 @@ files:
     translation: '/modules/engage-ui/src/main/resources/ui/language/%locale%.json'
 
   -
-    source: '/modules/engage-paella-player-7/src/i18n/en-US.json'
-    translation: '/modules/engage-paella-player-7/src/i18n/%locale%.json'
-
-  -
     source: '/modules/engage-paella-player-8/src/i18n/en-US.json'
     translation: '/modules/engage-paella-player-8/src/i18n/%locale%.json'
 


### PR DESCRIPTION
This PR removes Paella 7 from the crowdin config since the file it references no longer exists.  This resolves the current issues with the crowdin translation update workflow.

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] ~explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch~
* [ ] ~include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)~
