### PR TITLE
Update node version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <junit5.version>6.0.1</junit5.version>
     <karaf.version>4.4.7</karaf.version>
     <lucene.version>8.7.0</lucene.version>
-    <node.version>v20.12.2</node.version>
+    <node.version>v24.15.0</node.version>
     <osgi.core.version>8.0.0</osgi.core.version>
     <osgi.annotation.version>8.1.0</osgi.annotation.version>
     <org.osgi.service.component.version>1.5.1</org.osgi.service.component.version>


### PR DESCRIPTION
Because of https://github.com/opencast/admin-interface/issues/1590, I started looking at the node version(s) in use across Opencast.  Currently *most* of our modules use the version defined in the main pom file.  This version is currently in maintenance mode until May 2026 (uh oh).  This PR updates to the latest current LTS, which has maintenance support into 2027.

### How to test this patch

Build Opencast and make sure all of the bits run.  Notably, this affects graphql, lti, and the runtime info tools, along with Paella.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] ~explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch~
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
