### PR TITLE
Automatically update the git submodules

### DIFF
--- a/.github/workflows/maint-submodule-update.yml
+++ b/.github/workflows/maint-submodule-update.yml
@@ -1,0 +1,39 @@
+name: Maintenance » Auto-update git submodules
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 1 * * *' #1AM UTC, before the QA boxes reboot, but after everyone's done for the day
+
+jobs:
+  update-git-submodules:
+    name: update git submodules
+    runs-on: ubuntu-latest
+    if: github.repository == 'opencast/opencast'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - name: prepare git
+        run: |
+          git config --global user.email 'update-bot@opencast.org'
+          git config --global user.name 'Update Bot'
+
+      - name: prepare github ssh key
+        env:
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+        run: |
+          install -dm 700 ~/.ssh/
+          echo "${DEPLOY_KEY}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+      - name: update the submodules locally
+        run: |
+          git submodule update --remote --recursive
+
+      - name: Committing changes
+        run: |
+          git commit -a -m "Updating submodules" || true
+          git push origin 


### PR DESCRIPTION
This PR automatically pulls in whatever updates are available for each submodule once per day, and automatically pushes them.

This PR replaces:
https://github.com/opencast/admin-interface/pull/1588
https://github.com/opencast/editor/pull/1698
https://github.com/opencast/studio/pull/1316

This PR should go into 18 since it's still active and has submodules.

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] ~include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)~
