### PR TITLE
Make "Needs cutting" filter available in admin ui

### DIFF
--- a/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -86,6 +86,7 @@ import org.opencastproject.index.service.exception.UnsupportedAssetException;
 import org.opencastproject.index.service.impl.util.EventUtils;
 import org.opencastproject.index.service.resources.list.provider.EventsListProvider.Comments;
 import org.opencastproject.index.service.resources.list.provider.EventsListProvider.IsPublished;
+import org.opencastproject.index.service.resources.list.provider.EventsListProvider.NeedsCutting;
 import org.opencastproject.index.service.resources.list.query.EventListQuery;
 import org.opencastproject.index.service.resources.list.query.SeriesListQuery;
 import org.opencastproject.index.service.util.JSONUtils;
@@ -3309,6 +3310,23 @@ public abstract class AbstractEventEndpoint {
         query.withAccessControlEntry(filters.get(name), Permissions.Action.READ);
       } else if (EventListQuery.FILTER_WRITE_ACCESS_NAME.equals(name)) {
         query.withAccessControlEntry(filters.get(name), Permissions.Action.WRITE);
+      }
+      if (EventListQuery.FILTER_NEEDS_CUTTING_NAME.equals(name)) {
+        if (filters.containsKey(name)) {
+          switch (NeedsCutting.valueOf(filters.get(name))) {
+            case YES:
+              query.withNeedsCutting(true);
+              break;
+            case NO:
+              query.withNeedsCutting(false);
+              break;
+            default:
+              break;
+          }
+        } else {
+          logger.info("Query for invalid needs cutting status: {}", filters.get(name));
+          return Response.status(SC_BAD_REQUEST).build();
+        }
       }
 
       if (EventListQuery.FILTER_STARTDATE_NAME.equals(name)) {

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/event/EventQueryBuilder.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/event/EventQueryBuilder.java
@@ -276,6 +276,11 @@ public class EventQueryBuilder extends AbstractElasticsearchQueryBuilder<EventSe
       and(EventIndexSchema.TECHNICAL_PRESENTERS, query.getTechnicalPresenters());
     }
 
+    // Is published
+    if (query.getNeedsCutting() != null) {
+      and(EventIndexSchema.NEEDS_CUTTING, query.getNeedsCutting());
+    }
+
     // Text
     if (query.getTerms() != null) {
       for (SearchTerms<String> terms : query.getTerms()) {

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/event/EventSearchQuery.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/event/EventSearchQuery.java
@@ -869,6 +869,15 @@ public class EventSearchQuery extends AbstractSearchQuery {
   }
 
   /**
+   * Returns if the event needs cutting
+   *
+   * @return if the event needs cutting
+   */
+  public Boolean getNeedsCutting() {
+    return needsCutting;
+  }
+
+  /**
    * Returns the has comments status of the recording.
    *
    * @return the recording has comments status

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/EventsListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/EventsListProvider.java
@@ -59,6 +59,7 @@ public class EventsListProvider implements ResourceListProvider {
   public static final String COMMENTS = PROVIDER_PREFIX + ".COMMENTS";
   public static final String PUBLISHER = PROVIDER_PREFIX + ".PUBLISHER";
   public static final String ISPUBLISHED = PROVIDER_PREFIX + ".IS_PUBLISHED";
+  public static final String NEEDS_CUTTING = PROVIDER_PREFIX + ".NEEDS_CUTTING";
 
   public enum Comments {
     NONE, OPEN, RESOLVED;
@@ -68,8 +69,12 @@ public class EventsListProvider implements ResourceListProvider {
     YES, NO;
   }
 
+  public enum NeedsCutting {
+    YES, NO;
+  }
+
   private static final String[] NAMES = { PROVIDER_PREFIX, CONTRIBUTORS, PRESENTERS_BIBLIOGRAPHIC, PRESENTERS_TECHNICAL,
-      SUBJECT, LOCATION, PROGRESS, STATUS, COMMENTS, PUBLISHER, ISPUBLISHED };
+      SUBJECT, LOCATION, PROGRESS, STATUS, COMMENTS, PUBLISHER, ISPUBLISHED, NEEDS_CUTTING };
 
   private static final Logger logger = LoggerFactory.getLogger(EventsListProvider.class);
 
@@ -141,6 +146,10 @@ public class EventsListProvider implements ResourceListProvider {
       for (IsPublished isPublished : IsPublished.values()) {
         list.put(isPublished.toString(), "FILTERS.EVENTS.IS_PUBLISHED." + isPublished.toString());
       }
+    } else if (NEEDS_CUTTING.equals(listName)) {
+      for (NeedsCutting needsCutting : NeedsCutting.values()) {
+        list.put(needsCutting.toString(), "FILTERS.EVENTS.NEEDS_CUTTING." + needsCutting.toString());
+      }
     }
 
     return list;
@@ -148,7 +157,10 @@ public class EventsListProvider implements ResourceListProvider {
 
   @Override
   public boolean isTranslatable(String listName) {
-    return STATUS.equals(listName) || COMMENTS.equals(listName) || ISPUBLISHED.equals(listName);
+    return STATUS.equals(listName)
+        || COMMENTS.equals(listName)
+        || ISPUBLISHED.equals(listName)
+        || NEEDS_CUTTING.equals(listName);
   }
 
   @Override

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/EventListQuery.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/EventListQuery.java
@@ -96,6 +96,9 @@ public class EventListQuery extends ResourceListQueryImpl {
   public static final String FILTER_WRITE_ACCESS_NAME = "writeAccess";
   public static final String FILTER_WRITE_ACCESS_LABEL = "FILTERS.EVENTS.WRITE_ACCESS.LABEL";
 
+  public static final String FILTER_NEEDS_CUTTING_NAME = "needsCutting";
+  public static final String FILTER_NEEDS_CUTTING_LABEL = "FILTERS.EVENTS.NEEDS_CUTTING.LABEL";
+
   public EventListQuery() {
     super();
     this.availableFilters.add(createSeriesFilter(Optional.empty()));
@@ -108,6 +111,7 @@ public class EventListQuery extends ResourceListQueryImpl {
     this.availableFilters.add(createIsPublishedFilter(Optional.empty()));
     this.availableFilters.add(createReadAccessFilter(Optional.empty()));
     this.availableFilters.add(createWriteAccessFilter(Optional.empty()));
+    this.availableFilters.add(createNeedsCuttingFilter(Optional.empty()));
   }
 
   /**
@@ -484,6 +488,18 @@ public class EventListQuery extends ResourceListQueryImpl {
   public static ResourceListFilter<String> createWriteAccessFilter(Optional<String> writeAccess) {
     return FiltersUtils.generateFilter(writeAccess, FILTER_WRITE_ACCESS_NAME, FILTER_WRITE_ACCESS_LABEL,
         SourceType.FREETEXT, Optional.of("ROLES.TARGET.ACL"));
+  }
+
+  /**
+   * Create a new {@link ResourceListFilter} based on if the event has open comment that it needs cutting
+   *
+   * @param needsCutting
+   *          open comment that it needs cutting wrapped in an {@link Optional} or {@link Optional#empty()}
+   * @return a new {@link ResourceListFilter} for needs cutting
+   */
+  public static ResourceListFilter<String> createNeedsCuttingFilter(Optional<String> needsCutting) {
+    return FiltersUtils.generateFilter(needsCutting, FILTER_NEEDS_CUTTING_NAME, FILTER_NEEDS_CUTTING_LABEL,
+        SourceType.SELECT, Optional.of(EventsListProvider.NEEDS_CUTTING));
   }
 
 }


### PR DESCRIPTION
This filter allows users to filters events based on whether they need cutting or not. Events that need cutting have a red dot on the editor action icon.

"Needs cutting" is already indexed, so this works without an index rebuild.

This probably does not need to go into 19 actually. I won't mind if you want me to rebase this onto a later version.

<img width="1332" height="434" alt="Bildschirmfoto vom 2026-05-07 16-35-09" src="https://github.com/user-attachments/assets/9a44d0e4-7b31-4a95-a301-b8e8659bb8ee" />


### How to test this patch

Can be tested as is. Might need to clear your browser cache. If you want human readable text instead of translation strings you also https://github.com/opencast/admin-interface/pull/1602

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
