### PR TITLE
Add admin ui endpoint for users to self update

### DIFF
--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -146,6 +146,7 @@
     <sec:intercept-url pattern="/admin-ng/series/*/theme" method="PUT" access="ROLE_ADMIN, ROLE_UI_SERIES_DETAILS_THEMES_EDIT" />
     <sec:intercept-url pattern="/admin-ng/themes/*" method="PUT" access="ROLE_ADMIN, ROLE_UI_THEMES_EDIT" />
     <sec:intercept-url pattern="/admin-ng/users/*" method="PUT" access="ROLE_ADMIN, ROLE_UI_USERS_EDIT" />
+    <sec:intercept-url pattern="/admin-ng/users/password/*" method="PUT" access="ROLE_ADMIN, ROLE_ADMIN_UI" />
     <sec:intercept-url pattern="/admin-ng/user-settings/signature/*" method="PUT" access="ROLE_ADMIN, ROLE_ADMIN_UI" />
     <sec:intercept-url pattern="/admin-ng/user-settings/setting/*" method="PUT" access="ROLE_ADMIN, ROLE_ADMIN_UI" />
     <sec:intercept-url pattern="/admin-ng/adopter/**" method="PUT" access="ROLE_ADMIN" />

--- a/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/UsersEndpoint.java
+++ b/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/UsersEndpoint.java
@@ -506,6 +506,49 @@ public class UsersEndpoint {
     }
   }
 
+  @PUT
+  @Path("self")
+  @RestQuery(
+      name = "selfUpdate",
+      description = "Allow the user to update their own user data. Currently only changing password is allowed",
+      returnDescription = "Status ok",
+      restParameters = {
+          @RestParameter(description = "The password.", isRequired = false, name = "password", type = STRING),
+      },
+      responses = {
+          @RestResponse(responseCode = SC_OK, description = "User password has been updated."),
+          @RestResponse(responseCode = SC_FORBIDDEN, description = "Not enough permissions to change password."),
+          @RestResponse(responseCode = SC_BAD_REQUEST, description = "Invalid data provided.")
+      })
+  public Response selfUpdatePassword(@FormParam("password") String password) {
+
+    User currentUser = securityService.getUser();
+    if (!currentUser.isManageable()) {
+      return Response.status(Response.Status.FORBIDDEN).build();
+    }
+
+    User user = jpaUserAndRoleProvider.loadUser(currentUser.getUsername());
+    if (user == null) {
+      return Response.status(Response.Status.FORBIDDEN).build();
+    }
+
+    try {
+      jpaUserAndRoleProvider.updateUser(new JpaUser(user.getUsername(), password,
+          (JpaOrganization) user.getOrganization(), user.getName(), user.getEmail(), jpaUserAndRoleProvider.getName(),
+          true, user.getRoles()
+          .stream()
+          .map(role -> new JpaRole(role.getName(), (JpaOrganization) user.getOrganization(), role.getDescription(),
+              role.getType()))
+          .collect(Collectors.toSet())));
+      userDirectoryService.invalidate(user.getUsername());
+      return Response.status(SC_OK).build();
+    } catch (UnauthorizedException ex) {
+      return Response.status(Response.Status.FORBIDDEN).build();
+    } catch (NotFoundException e) {
+      return Response.serverError().build();
+    }
+  }
+
   @DELETE
   @Path("{username}.json")
   @RestQuery(


### PR DESCRIPTION
Adds a new users endpoint to the admin ui. It should allow users to update their own user data, without requiring rights to be able to edit *all* user data.
For now, this only allows users to change their own password, as that is all that the admin ui requires right now.

### How to test this patch

Test this together with the frontend patch https://github.com/opencast/admin-interface/pull/1604 and various users.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
