### PR TITLE
Only switch org if orgs are different

### DIFF
--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/RemoteUserAndOrganizationFilter.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/RemoteUserAndOrganizationFilter.java
@@ -125,7 +125,7 @@ public class RemoteUserAndOrganizationFilter implements Filter {
 
       // See if there is an organization provided in the request
       String organizationHeader = httpRequest.getHeader(ORGANIZATION_HEADER);
-      if (StringUtils.isNotBlank(organizationHeader)) {
+      if (StringUtils.isNotBlank(organizationHeader) && !organizationHeader.equals(originalOrganization.getId())) {
 
         // Organization switching is only allowed if the request is coming in with the global admin role enabled
         if (!originalUser.hasRole(GLOBAL_ADMIN_ROLE)) {

--- a/modules/kernel/src/test/java/org/opencastproject/kernel/security/RemoteUserAndOrganizationFilterTest.java
+++ b/modules/kernel/src/test/java/org/opencastproject/kernel/security/RemoteUserAndOrganizationFilterTest.java
@@ -118,7 +118,7 @@ public class RemoteUserAndOrganizationFilterTest {
     userResponder.setResponse(switchingUser);
 
     HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
-    EasyMock.expect(request.getHeader(SecurityConstants.ORGANIZATION_HEADER)).andReturn("mh_default_org").anyTimes();
+    EasyMock.expect(request.getHeader(SecurityConstants.ORGANIZATION_HEADER)).andReturn("other_org").anyTimes();
     EasyMock.replay(request);
 
     HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
@@ -146,7 +146,7 @@ public class RemoteUserAndOrganizationFilterTest {
     EasyMock.replay(securityService);
 
     HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
-    EasyMock.expect(request.getHeader(SecurityConstants.ORGANIZATION_HEADER)).andReturn("mh_default_org").anyTimes();
+    EasyMock.expect(request.getHeader(SecurityConstants.ORGANIZATION_HEADER)).andReturn("other_org").anyTimes();
     EasyMock.replay(request);
 
     HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);


### PR DESCRIPTION
As mentioned in the last Dev meeting - it doesn't make sense to throw org switching errors on a single-tenant system where the org header and the current organization are both set to `mh_default_org`.