### PR TITLE
Modify targets of opencast.service unit file

### DIFF
--- a/docs/scripts/service/opencast.service
+++ b/docs/scripts/service/opencast.service
@@ -2,8 +2,10 @@
 Description=Opencast
 Documentation=https://docs.opencast.org
 
+Wants=network-online.target
+
 After=local-fs.target
-After=network.target
+After=network-online.target
 After=remote-fs.target
 
 [Service]


### PR DESCRIPTION
Currently the unit only checks for network.target. This only indicates that the network stack has been started. It doesn't indicate whether network interfaces are configured or a network connection is established.

When the database and Elasticsearch are running on different servers, you want to be able to communicate with them. systemd offers a target for that case: `network-online.target`.

`After=` only affects ordering. To make sure a network connection is established, either `Wants=` or `Requires=` is needed as well. This commit choses `Wants=` as weak depencency - this way, Opencast can still start if `network-online.target` fails and is independend of that target.

See also https://systemd.io/NETWORK_ONLINE/

### How to test this patch

Update the systemd unit file, reload the daemon via `systemctl daemon-reload` and restart `opencast.service`