### PR TITLE
Update meeting room links on docs landing page

### DIFF
--- a/docs/guides/.infrastructure/index.html.j2
+++ b/docs/guides/.infrastructure/index.html.j2
@@ -142,12 +142,12 @@
 
           <h5>Dev meeting</h5>
           <p>Weekly open meeting of developers and dev-ops at
-          <a href="https://opencast.blindsidenetworks.net">meet.opencast.video</a> (room 1, p: welcome), check the calendar link for dates and times.
+          <a href="https://meet.opencast.video">meet.opencast.video</a>, check the calendar link for dates and times.
           This is where you want to be to talk technical Opencast issues with developers.</p>
 
           <h5>SysAdmin meeting</h5>
           <p>Monthly sys-admins and adopters meeting at
-          <a href="https://opencast.blindsidenetworks.net">meet.opencast.video</a> (room 1, p: welcome), check the calendar link for dates and times.
+          <a href="https://meet.opencast.video">meet.opencast.video</a>, check the calendar link for dates and times.
           The goal of this meeting is to talk about current challenges, as well as upcoming development and testing coordination.  If you run Opencast, or are thinking about doing so, this is the meeting to attend.</p>
         </div>
       </div>


### PR DESCRIPTION
This PR updates the links on docs.opencast.org to use meet.opencast.video, along with removing the parts about the room number and password

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] ~explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch~
* [ ] ~include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)~
