### PR TITLE
Paging while we fetch the list of branches in Opencast

### DIFF
--- a/docs/guides/.infrastructure/generate-versions
+++ b/docs/guides/.infrastructure/generate-versions
@@ -9,24 +9,36 @@ from jinja2 import Template
 RELEASE_URL = 'https://api.github.com/repos/opencast/opencast/releases'
 BRANCH_URL = 'https://api.github.com/repos/opencast/opencast/branches?per_page=100'
 
+def get_release_branches(page):
+    branches = requests.get(f"{BRANCH_URL}&page={page}", headers=headers).json()
+    branch_names = map(lambda x: x['name'], branches)
+    release_branches = filter(lambda x: x.startswith('r/') and x.endswith('.x') and not x.startswith('r/1.'),
+                             branch_names)
+    return len(branches), sorted(release_branches, reverse=True, key=lambda x: float(x.strip('r/.x')))
+
 
 def main():
-    releases = requests.get(RELEASE_URL).json()
+    releases = requests.get(RELEASE_URL, headers=headers).json()
     versions = map(lambda x: float(x['tag_name']), releases)
     stable = int(max(versions))
     stable_branch = f'r/{stable}.x'
 
-    branches = requests.get(BRANCH_URL).json()
-    branch_names = map(lambda x: x['name'], branches)
-    release_branchs = filter(lambda x: x.startswith('r/') and x.endswith('.x') and not x.startswith('r/1.'),
-                             branch_names)
-    release_branchs = sorted(release_branchs, reverse=True, key=lambda x: float(x.strip('r/.x')))
+    count = 100
+    page = 1
+    release_branches = []
+    while count == 100:
+        print(f"Getting page {page}")
+        unfiltered_count, current_page = get_release_branches(page)
+        count = unfiltered_count
+        release_branches = release_branches + current_page
+        print(f"Page is {current_page}")
+        page += 1
 
     version_info = [{
         'name': 'develop',
         'branch': 'develop',
         'attribute': ''}]
-    for branch in release_branchs:
+    for branch in release_branches:
         name = branch.split('/')[-1]
         attribute = None
         if branch == stable_branch:

--- a/docs/guides/.infrastructure/generate-versions
+++ b/docs/guides/.infrastructure/generate-versions
@@ -10,7 +10,7 @@ RELEASE_URL = 'https://api.github.com/repos/opencast/opencast/releases'
 BRANCH_URL = 'https://api.github.com/repos/opencast/opencast/branches?per_page=100'
 
 def get_release_branches(page):
-    branches = requests.get(f"{BRANCH_URL}&page={page}", headers=headers).json()
+    branches = requests.get(f"{BRANCH_URL}&page={page}").json()
     branch_names = map(lambda x: x['name'], branches)
     release_branches = filter(lambda x: x.startswith('r/') and x.endswith('.x') and not x.startswith('r/1.'),
                              branch_names)
@@ -18,7 +18,7 @@ def get_release_branches(page):
 
 
 def main():
-    releases = requests.get(RELEASE_URL, headers=headers).json()
+    releases = requests.get(RELEASE_URL).json()
     versions = map(lambda x: float(x['tag_name']), releases)
     stable = int(max(versions))
     stable_branch = f'r/{stable}.x'


### PR DESCRIPTION
This was always going to break eventually since we only fetched the first 100 versions, but today we have a ton more dependabot and other branches in the main repo so it broke faster.  There does not appear to be a way to filter on GH's side, so we have to page through *all* two pages of results currently.

Without this patch docs.opencast.org only lists versions up to 16.x currently, hiding the more important later versions.

### AI Usage

N/A
### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] ~explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch~
* [ ] ~include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)~
