### PR TITLE
Make `/play` preserve query parameters

### DIFF
--- a/docs/guides/admin/docs/releasenotes/preserve-query-params-on-play-redirect.txt
+++ b/docs/guides/admin/docs/releasenotes/preserve-query-params-on-play-redirect.txt
@@ -1,0 +1,16 @@
+Preserve query parameters on `/play` redirect
+=============================================
+
+The `/play` route now passes through query parameters to the target player URL.
+This allows parameters like `jwt=...` or `t=10` to be preserved
+when redirecting to the configured player.
+
+This is particularly useful for third-party integrations
+where authentication tokens (like JWTs) or specific player settings
+need to be passed through the redirect to the actual player interface,
+while preserving the ability to configure the exact player on the Opencast side.
+
+If a parameter with the same name already exists in the configured player path,
+the value from the request will be appended, creating a multi-valued parameter.
+This behavior ensures that parameters are never lost,
+though player implementations may need to handle multiple values if they occur.

--- a/modules/engage-ui/src/main/java/org/opencastproject/engage/ui/PlayerRedirect.java
+++ b/modules/engage-ui/src/main/java/org/opencastproject/engage/ui/PlayerRedirect.java
@@ -39,12 +39,17 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
 
 /**
  * This REST endpoint redirects users to the currently configured default player, allowing the default to be changed
@@ -92,14 +97,21 @@ public class PlayerRedirect {
       },
       returnDescription = ""
   )
-  public Response redirect(@PathParam("id") String id) {
+  public Response redirect(@PathParam("id") String id, @Context UriInfo uriInfo) {
     final Organization org = securityService.getOrganization();
     final String playerPath = Objects.toString(org.getProperties().get("player"), PLAYER_DEFAULT)
             .replace("#{id}", URLEncoder.encode(id, StandardCharsets.UTF_8));
-    logger.debug("redirecting to player: {}", playerPath);
+
+    final UriBuilder uriBuilder = UriBuilder.fromUri(playerPath);
+    for (Map.Entry<String, List<String>> entry : uriInfo.getQueryParameters().entrySet()) {
+      uriBuilder.queryParam(entry.getKey(), entry.getValue().toArray());
+    }
+
+    final String finalPath = uriBuilder.build().toString();
+    logger.debug("redirecting to player: {}", finalPath);
     return Response
             .status(Response.Status.TEMPORARY_REDIRECT)
-            .header("location", playerPath)
+            .header("location", finalPath)
             .build();
   }
 }

--- a/modules/engage-ui/src/test/java/org/opencastproject/engage/ui/PlayerRedirectTest.java
+++ b/modules/engage-ui/src/test/java/org/opencastproject/engage/ui/PlayerRedirectTest.java
@@ -34,7 +34,9 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 
 public class PlayerRedirectTest extends EasyMockSupport {
 
@@ -55,9 +57,11 @@ public class PlayerRedirectTest extends EasyMockSupport {
     String eventId = "event1";
     EasyMock.expect(securityService.getOrganization()).andReturn(organization);
     EasyMock.expect(organization.getProperties()).andReturn(new HashMap<>());
+    UriInfo uriInfo = createNiceMock(UriInfo.class);
+    EasyMock.expect(uriInfo.getQueryParameters()).andReturn(new MultivaluedHashMap<>()).anyTimes();
     replayAll();
 
-    try (Response response = playerRedirect.redirect(eventId)) {
+    try (Response response = playerRedirect.redirect(eventId, uriInfo)) {
       assertEquals(Response.Status.TEMPORARY_REDIRECT.getStatusCode(), response.getStatus());
       assertEquals("/paella7/ui/watch.html?id=event1", response.getHeaderString("location"));
     }
@@ -72,9 +76,11 @@ public class PlayerRedirectTest extends EasyMockSupport {
     properties.put("player", "/custom/ui/watch.html?id=#{id}");
     EasyMock.expect(securityService.getOrganization()).andReturn(organization);
     EasyMock.expect(organization.getProperties()).andReturn(properties);
+    UriInfo uriInfo = createNiceMock(UriInfo.class);
+    EasyMock.expect(uriInfo.getQueryParameters()).andReturn(new MultivaluedHashMap<>()).anyTimes();
     replayAll();
 
-    try (Response response = playerRedirect.redirect(eventId)) {
+    try (Response response = playerRedirect.redirect(eventId, uriInfo)) {
       assertEquals(Response.Status.TEMPORARY_REDIRECT.getStatusCode(), response.getStatus());
       assertEquals("/custom/ui/watch.html?id=event2", response.getHeaderString("location"));
     }
@@ -87,9 +93,11 @@ public class PlayerRedirectTest extends EasyMockSupport {
     String eventId = "event%20with%20spaces";
     EasyMock.expect(securityService.getOrganization()).andReturn(organization);
     EasyMock.expect(organization.getProperties()).andReturn(new HashMap<>());
+    UriInfo uriInfo = createNiceMock(UriInfo.class);
+    EasyMock.expect(uriInfo.getQueryParameters()).andReturn(new MultivaluedHashMap<>()).anyTimes();
     replayAll();
 
-    try (Response response = playerRedirect.redirect(eventId)) {
+    try (Response response = playerRedirect.redirect(eventId, uriInfo)) {
       assertEquals(Response.Status.TEMPORARY_REDIRECT.getStatusCode(), response.getStatus());
       assertEquals("/paella7/ui/watch.html?id=event%2520with%2520spaces", response.getHeaderString("location"));
     }
@@ -102,12 +110,62 @@ public class PlayerRedirectTest extends EasyMockSupport {
     String eventId = "üäöß$%&/()=?!§";
     EasyMock.expect(securityService.getOrganization()).andReturn(organization);
     EasyMock.expect(organization.getProperties()).andReturn(new HashMap<>());
+    UriInfo uriInfo = createNiceMock(UriInfo.class);
+    EasyMock.expect(uriInfo.getQueryParameters()).andReturn(new MultivaluedHashMap<>()).anyTimes();
     replayAll();
 
-    try (Response response = playerRedirect.redirect(eventId)) {
+    try (Response response = playerRedirect.redirect(eventId, uriInfo)) {
       assertEquals(Response.Status.TEMPORARY_REDIRECT.getStatusCode(), response.getStatus());
       assertEquals("/paella7/ui/watch.html?id=%C3%BC%C3%A4%C3%B6%C3%9F%24%25%26%2F%28%29%3D%3F%21%C2%A7",
           response.getHeaderString("location"));
+    }
+
+    verifyAll();
+  }
+
+  @Test
+  public void shouldPreserveQueryParameters() {
+    String eventId = "event1";
+    UriInfo uriInfo = createMock(UriInfo.class);
+    MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
+    queryParams.add("t", "10");
+    queryParams.add("foo", "bar");
+    queryParams.add("id", "something-else"); // Should be ignored as 'id' is already in the target URL
+
+    EasyMock.expect(securityService.getOrganization()).andReturn(organization);
+    EasyMock.expect(organization.getProperties()).andReturn(new HashMap<>());
+    EasyMock.expect(uriInfo.getQueryParameters()).andReturn(queryParams);
+    replayAll();
+
+    try (Response response = playerRedirect.redirect(eventId, uriInfo)) {
+      assertEquals(Response.Status.TEMPORARY_REDIRECT.getStatusCode(), response.getStatus());
+      String location = response.getHeaderString("location");
+      // id=event1 should stay, and t=10, foo=bar, and id=something-else should be appended (at the end)
+      assertEquals("/paella7/ui/watch.html?id=event1&t=10&foo=bar&id=something-else", location);
+    }
+
+    verifyAll();
+  }
+
+  @Test
+  public void shouldHandleAbsoluteUrls() {
+    String eventId = "event1";
+    UriInfo uriInfo = createMock(UriInfo.class);
+    MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
+    queryParams.add("t", "10");
+
+    Map<String, String> properties = new HashMap<>();
+    properties.put("player", "https://player.example.com/watch.html?id=#{id}&partner=test");
+
+    EasyMock.expect(securityService.getOrganization()).andReturn(organization);
+    EasyMock.expect(organization.getProperties()).andReturn(properties);
+    EasyMock.expect(uriInfo.getQueryParameters()).andReturn(queryParams);
+    replayAll();
+
+    try (Response response = playerRedirect.redirect(eventId, uriInfo)) {
+      assertEquals(Response.Status.TEMPORARY_REDIRECT.getStatusCode(), response.getStatus());
+      String location = response.getHeaderString("location");
+      assertEquals("https://player.example.com/watch.html?id=event1&partner=test&t=10", location);
     }
 
     verifyAll();


### PR DESCRIPTION
They are just appended to whatever is already in the URL we are redirecting to. Nothing is overridden.

This might be interesting for the JWT-gang.

cf. https://github.com/opencast/opencast/pull/7249#issuecomment-4418721529 ff., /cc @ferishili, he's also the reason why I point this to 19.

### How to test this patch

Just publish a video, say with id `my-id`, then go to something like `/play/my-id?foo=bar`.

### AI Usage

All code was generated using `gemini-cli`, with model `gemini-3-flash-preview`.

### Your pull request should…

* [x] have a concise title
* [x] ~~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
