### PR TITLE
Service error states incorrectly cleared

### DIFF
--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -2212,25 +2212,23 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
         }
       }
 
-      // This is the first job with this signature failing on any service
-      else {
-        // Set the current service to WARNING state
-        if (currentService.getServiceState() == NORMAL) {
-          logger.info("State set to WARNING for current service {} on host {}", currentService.getServiceType(),
-                  currentService.getHost());
-          currentService.setServiceState(WARNING, job.toJob().getSignature());
-          updateServiceState(currentService);
-        }
-
-        // The current service already is in WARNING state and max attempts is reached
-        else if (errorStatesEnabled && !noErrorStateServiceTypes.contains(currentService.getServiceType())
-                && getHistorySize(currentService) >= maxAttemptsBeforeErrorState) {
-          logger.info("State set to ERROR for current service {} on host {}", currentService.getServiceType(),
-                  currentService.getHost());
-          currentService.setServiceState(ERROR, job.toJob().getSignature());
-          updateServiceState(currentService);
-        }
+      // Set the current service to WARNING state
+      if (currentService.getServiceState() == NORMAL) {
+        logger.info("State set to WARNING for current service {} on host {}", currentService.getServiceType(),
+                currentService.getHost());
+        currentService.setServiceState(WARNING, job.toJob().getSignature());
+        updateServiceState(currentService);
       }
+
+      // The current service already is in WARNING state and max attempts is reached
+      else if (errorStatesEnabled && !noErrorStateServiceTypes.contains(currentService.getServiceType())
+              && getHistorySize(currentService) >= maxAttemptsBeforeErrorState) {
+        logger.info("State set to ERROR for current service {} on host {}", currentService.getServiceType(),
+                currentService.getHost());
+        currentService.setServiceState(ERROR, job.toJob().getSignature());
+        updateServiceState(currentService);
+      }
+
     }
 
     // Job is finished without failure

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -218,7 +218,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
 
   /** Number of failed jobs on a service before to set it in error state. -1 will disable error states completely. */
   protected int maxAttemptsBeforeErrorState = DEFAULT_MAX_ATTEMPTS_BEFORE_ERROR_STATE;
-  private boolean errorStatesEnabled = DEFAULT_ERROR_STATES_ENABLED;
+  protected boolean errorStatesEnabled = DEFAULT_ERROR_STATES_ENABLED;
 
   /** Services for which error state is disabled */
   private List<String> noErrorStateServiceTypes = new ArrayList<>();

--- a/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistrationTest.java
+++ b/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistrationTest.java
@@ -335,6 +335,124 @@ public class ServiceRegistrationTest {
   }
 
   @Test
+  public void testScenarioManyJobsManyServicesWithoutErrorStates() throws Exception {
+    Job job1Try1 = serviceRegistry.createJob(regType1Localhost.getHost(),
+        regType1Localhost.getServiceType(), OPERATION_NAME_1, null, null, true, null);
+    Job job1Try2 = serviceRegistry.createJob(regType1Localhost.getHost(),
+        regType1Localhost.getServiceType(), OPERATION_NAME_1, null, null, true, null);
+    Job job1Try3 = serviceRegistry.createJob(regType1Localhost.getHost(),
+        regType1Localhost.getServiceType(), OPERATION_NAME_1, null, null, true, null);
+    Job job1Try4 = serviceRegistry.createJob(regType1Localhost.getHost(),
+        regType1Localhost.getServiceType(), OPERATION_NAME_1, null, null, true, null);
+    List<String> list = new ArrayList<String>();
+    list.add("test");
+    Job job2Try1 = serviceRegistry.createJob(regType1Localhost.getHost(),
+        regType1Localhost.getServiceType(), OPERATION_NAME_2, list, null, true, null);
+    Job job2Try2 = serviceRegistry.createJob(regType1Localhost.getHost(),
+        regType1Localhost.getServiceType(), OPERATION_NAME_2, list, null, true, null);
+    Job job2Try3 = serviceRegistry.createJob(regType1Localhost.getHost(),
+        regType1Localhost.getServiceType(), OPERATION_NAME_2, list, null, true, null);
+    serviceRegistry.maxAttemptsBeforeErrorState = 0;
+    // With https://github.com/opencast/opencast/pull/7450, we disabled error states by default
+    // This doesn't change the default, but we're explicitly doing this so that it's clear what SR internal state is
+    serviceRegistry.errorStatesEnabled = false;
+    ServiceRegistrationJpaImpl updatedService1;
+    ServiceRegistrationJpaImpl updatedService2;
+    ServiceRegistrationJpaImpl updatedService3;
+
+    // 1st try for job 1, failed on localhost
+    job1Try1.setStatus(Status.FAILED);
+    job1Try1.setJobType(regType1Localhost.getServiceType());
+    job1Try1.setProcessingHost(regType1Localhost.getHost());
+    job1Try1 = serviceRegistry.updateJob(job1Try1);
+    updatedService1 = getUpdatedService(regType1Localhost);
+    updatedService2 = getUpdatedService(regType1Remotehost1);
+    updatedService3 = getUpdatedService(regType1Remotehost2);
+    Assert.assertEquals(ServiceState.WARNING, updatedService1.getServiceState());
+    Assert.assertEquals(ServiceState.NORMAL, updatedService2.getServiceState());
+    Assert.assertEquals(ServiceState.NORMAL, updatedService3.getServiceState());
+    Assert.assertEquals(0, updatedService1.getErrorStateTrigger());
+
+    // 1st try for job 2, failed on localhost
+    job2Try1.setStatus(Status.FAILED);
+    job2Try1.setJobType(regType1Localhost.getServiceType());
+    job2Try1.setProcessingHost(regType1Localhost.getHost());
+    serviceRegistry.updateJob(job2Try1);
+    updatedService1 = getUpdatedService(regType1Localhost);
+    updatedService2 = getUpdatedService(regType1Remotehost1);
+    updatedService3 = getUpdatedService(regType1Remotehost2);
+    Assert.assertEquals(ServiceState.WARNING, updatedService1.getServiceState());
+    Assert.assertEquals(ServiceState.NORMAL, updatedService2.getServiceState());
+    Assert.assertEquals(ServiceState.NORMAL, updatedService3.getServiceState());
+
+    // 2nd try for job 1, failed on remotehost1
+    job1Try2.setStatus(Status.FAILED);
+    job1Try2.setJobType(regType1Remotehost1.getServiceType());
+    job1Try2.setProcessingHost(regType1Remotehost1.getHost());
+    serviceRegistry.updateJob(job1Try2);
+    updatedService1 = getUpdatedService(regType1Localhost);
+    updatedService2 = getUpdatedService(regType1Remotehost1);
+    updatedService3 = getUpdatedService(regType1Remotehost2);
+    Assert.assertEquals(ServiceState.NORMAL, updatedService1.getServiceState());
+    Assert.assertEquals(ServiceState.WARNING, updatedService2.getServiceState());
+    Assert.assertEquals(ServiceState.NORMAL, updatedService3.getServiceState());
+    updatedService2.getWarningStateTrigger();
+    Assert.assertEquals(0, updatedService2.getErrorStateTrigger());
+
+    // 2nd try for job 2, failed on remotehost1
+    job2Try2.setStatus(Status.FINISHED);
+    job2Try2.setJobType(regType1Remotehost1.getServiceType());
+    job2Try2.setProcessingHost(regType1Remotehost1.getHost());
+    serviceRegistry.updateJob(job2Try2);
+    updatedService1 = getUpdatedService(regType1Localhost);
+    updatedService2 = getUpdatedService(regType1Remotehost1);
+    updatedService3 = getUpdatedService(regType1Remotehost2);
+    Assert.assertEquals(ServiceState.NORMAL, updatedService1.getServiceState());
+    Assert.assertEquals(ServiceState.NORMAL, updatedService2.getServiceState());
+    Assert.assertEquals(ServiceState.NORMAL, updatedService3.getServiceState());
+    Assert.assertEquals(0, updatedService2.getErrorStateTrigger());
+
+    // 3rd try for job 1, failed on remotehost2
+    job1Try3.setStatus(Status.FINISHED);
+    job1Try3.setJobType(regType1Remotehost2.getServiceType());
+    job1Try3.setProcessingHost(regType1Remotehost2.getHost());
+    serviceRegistry.updateJob(job1Try3);
+    updatedService1 = getUpdatedService(regType1Localhost);
+    updatedService2 = getUpdatedService(regType1Remotehost1);
+    updatedService3 = getUpdatedService(regType1Remotehost2);
+    Assert.assertEquals(ServiceState.NORMAL, updatedService1.getServiceState());
+    Assert.assertEquals(ServiceState.NORMAL, updatedService2.getServiceState());
+    Assert.assertEquals(ServiceState.NORMAL, updatedService3.getServiceState());
+    Assert.assertEquals(0, updatedService3.getWarningStateTrigger());
+    Assert.assertEquals(0, updatedService2.getErrorStateTrigger());
+
+    // 3rd try for job2, failed on remotehost2
+    job2Try3.setStatus(Status.FAILED);
+    job2Try3.setJobType(regType1Remotehost2.getServiceType());
+    job2Try3.setProcessingHost(regType1Remotehost2.getHost());
+    serviceRegistry.updateJob(job2Try3);
+    updatedService1 = getUpdatedService(regType1Localhost);
+    updatedService2 = getUpdatedService(regType1Remotehost1);
+    updatedService3 = getUpdatedService(regType1Remotehost2);
+    Assert.assertEquals(ServiceState.NORMAL, updatedService1.getServiceState());
+    Assert.assertEquals(ServiceState.NORMAL, updatedService2.getServiceState());
+    Assert.assertEquals(ServiceState.WARNING, updatedService3.getServiceState());
+
+    // 4rd try for job1, failed on remotehost2
+    job1Try4.setStatus(Status.FAILED);
+    job1Try4.setJobType(regType1Remotehost2.getServiceType());
+    job1Try4.setProcessingHost(regType1Remotehost2.getHost());
+    serviceRegistry.updateJob(job1Try4);
+    updatedService1 = getUpdatedService(regType1Localhost);
+    updatedService2 = getUpdatedService(regType1Remotehost1);
+    updatedService3 = getUpdatedService(regType1Remotehost2);
+    Assert.assertEquals(ServiceState.NORMAL, updatedService1.getServiceState());
+    Assert.assertEquals(ServiceState.NORMAL, updatedService2.getServiceState());
+    Assert.assertEquals(ServiceState.WARNING, updatedService3.getServiceState());
+
+  }
+
+  @Test
   public void testScenarioOneJobManyServices() throws Exception {
     Job jobTry1 = serviceRegistry.createJob(regType1Localhost.getHost(),
             regType1Localhost.getServiceType(), OPERATION_NAME_1, null, null, true, null);

--- a/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistrationTest.java
+++ b/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistrationTest.java
@@ -218,7 +218,7 @@ public class ServiceRegistrationTest {
   }
 
   @Test
-  public void testScenarioManyJobsManyServices() throws Exception {
+  public void testScenarioManyJobsManyServicesWithErrorStates() throws Exception {
     Job job1Try1 = serviceRegistry.createJob(regType1Localhost.getHost(),
             regType1Localhost.getServiceType(), OPERATION_NAME_1, null, null, true, null);
     Job job1Try2 = serviceRegistry.createJob(regType1Localhost.getHost(),
@@ -236,6 +236,8 @@ public class ServiceRegistrationTest {
     Job job2Try3 = serviceRegistry.createJob(regType1Localhost.getHost(),
             regType1Localhost.getServiceType(), OPERATION_NAME_2, list, null, true, null);
     serviceRegistry.maxAttemptsBeforeErrorState = 0;
+    // With https://github.com/opencast/opencast/pull/7450, we disabled error states by default, so re-enable them
+    serviceRegistry.errorStatesEnabled = true;
     ServiceRegistrationJpaImpl updatedService1;
     ServiceRegistrationJpaImpl updatedService2;
     ServiceRegistrationJpaImpl updatedService3;

--- a/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistrationTest.java
+++ b/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistrationTest.java
@@ -318,7 +318,7 @@ public class ServiceRegistrationTest {
     updatedService3 = getUpdatedService(regType1Remotehost2);
     Assert.assertEquals(ServiceState.WARNING, updatedService1.getServiceState());
     Assert.assertEquals(ServiceState.NORMAL, updatedService2.getServiceState());
-    Assert.assertEquals(ServiceState.NORMAL, updatedService3.getServiceState());
+    Assert.assertEquals(ServiceState.WARNING, updatedService3.getServiceState());
 
     // 4rd try for job1, failed on remotehost2
     job1Try4.setStatus(Status.FAILED);
@@ -330,7 +330,7 @@ public class ServiceRegistrationTest {
     updatedService3 = getUpdatedService(regType1Remotehost2);
     Assert.assertEquals(ServiceState.NORMAL, updatedService1.getServiceState());
     Assert.assertEquals(ServiceState.NORMAL, updatedService2.getServiceState());
-    Assert.assertEquals(ServiceState.NORMAL, updatedService3.getServiceState());
+    Assert.assertEquals(ServiceState.ERROR, updatedService3.getServiceState());
 
   }
 
@@ -484,8 +484,8 @@ public class ServiceRegistrationTest {
     updatedService1 = getUpdatedService(regType1Localhost);
     updatedService2 = getUpdatedService(regType1Remotehost1);
     Assert.assertEquals(ServiceState.NORMAL, updatedService1.getServiceState());
-    Assert.assertEquals(ServiceState.NORMAL, updatedService2.getServiceState());
-    Assert.assertEquals(0, updatedService2.getWarningStateTrigger());
+    Assert.assertEquals(ServiceState.WARNING, updatedService2.getServiceState());
+    Assert.assertNotEquals(0, updatedService2.getWarningStateTrigger());
     Assert.assertEquals(0, updatedService2.getErrorStateTrigger());
 
     // 3rd try, failed on remotehost2


### PR DESCRIPTION
This started with a dive trying to resolve the random CI errors people are seeing like
```
ServiceRegistrationTest.testScenarioManyJobsManyServices:264 expected:<ERROR> but was:<WARNING>
```
which turn out to be caused by https://github.com/opencast/opencast/pull/7450

This led to a discovery that:
a) The tests are *wrong*
b) The code is ***also** wrong*
c) None of this should have been working at all.

With that in mind, this is a breakdown of the current commits

* 823cd897a9 Exposing error states setting, and flipping it *on* for the existing test.  This fixes the race condition.  Worryingly, this test should not have been working at all given the configuration.  We have ERROR states disabled by default, so the SR should never put services in ERROR...
* 33fe584300 Adding test for disabled error states, which won't work because things are broken
* 63118bbeb1 Correcting the logic around when to step services towards/away from ERROR.  The commit message here contains the updated pseudocode which is probably relevant for reviewers.
* d03241ea7e Amended tests

I have put this against `r/19.x` since it affects that branch, but I'm also not opposed to putting this in 20 instead.

### How to test this patch

The unit tests should pass.  However, the unit tests *also* previously passed, most of the time.  This is clearly not the best metric.


### AI Usage

N/A

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
