### PR TITLE
Fix missed subtitle-timeshift configuration key

### DIFF
--- a/etc/workflows/partial-theming.yaml
+++ b/etc/workflows/partial-theming.yaml
@@ -119,7 +119,7 @@ operations:
     configurations:
       - subtitle-source-flavor: chapters/trimmed
       - target-flavor: chapters/shifted
-      - video-source-flavor: branding/bumper
+      - video-source-flavors: branding/bumper
 
   - id: tag
     if: NOT ${theme_bumper_active}


### PR DESCRIPTION
With #6901, the subtitle-timeshift configuration key `video-source-flavor` changed to `video-source-flavors` in Opencast 19. While one occurance got adjusted in `partial-theming.yaml`, a second one was missed and is still using the old config key.

Since that behavior got introduced in OC 19, it should also target that branch and be picked/merged to newer versions afterwards
