### PR TITLE
Editor - Thumbnails in backend

### DIFF
--- a/etc/workflows/partial-publish.yaml
+++ b/etc/workflows/partial-publish.yaml
@@ -57,7 +57,7 @@ operations:
 
   # Encode to engage player preview images
   - id: image
-    if: NOT ${presentation/thumbnail_edited}
+    if: (NOT ${presentation/thumbnail_edited}) AND (NOT ${presentation_thumbnail_time_set})
     exception-handler-workflow: partial-error
     description: Creating player preview image for presentation video
     configurations:
@@ -66,6 +66,18 @@ operations:
       - target-tags: engage-download
       - encoding-profile: player-preview.http
       - time: 3
+
+  # Encode to engage player preview image but with timestamp from editor
+  - id: image
+    if: (NOT ${presentation/thumbnail_edited}) AND ${presentation_thumbnail_time_set}
+    exception-handler-workflow: partial-error
+    description: Creating player preview image for presentation video from editor timestamp
+    configurations:
+      - source-flavor: presentation/source
+      - target-flavor: presentation/player+preview
+      - target-tags: engage-download
+      - encoding-profile: player-preview.http
+      - time: ${presentation_thumbnail_time}
 
   - id: tag
     if: ${presentation/thumbnail_edited}
@@ -77,7 +89,7 @@ operations:
 
   # Create a cover image
   - id: image
-    if: NOT ${presenter/thumbnail_edited}
+    if: (NOT ${presenter/thumbnail_edited}) AND (NOT ${presenter_thumbnail_time_set})
     exception-handler-workflow: partial-error
     description: Creating player preview image for presenter video
     configurations:
@@ -86,6 +98,18 @@ operations:
       - target-tags: engage-download
       - encoding-profile: player-preview.http
       - time: 3
+
+  # Create a cover image but with timestamp from editor
+  - id: image
+    if: (NOT ${presenter/thumbnail_edited}) AND ${presenter_thumbnail_time_set}
+    exception-handler-workflow: partial-error
+    description: Creating player preview image for presenter video from editor timestamp
+    configurations:
+      - source-flavor: presenter/source
+      - target-flavor: presenter/player+preview
+      - target-tags: engage-download
+      - encoding-profile: player-preview.http
+      - time: ${presenter_thumbnail_time}
 
   - id: cover-image
     if: NOT (${presenter_work_video} OR ${presentation_work_video} OR ${presentation/thumbnail_edited}) AND (${presenter_work_audio} OR ${presentation_work_audio})

--- a/etc/workflows/partial-publish.yaml
+++ b/etc/workflows/partial-publish.yaml
@@ -69,7 +69,7 @@ operations:
 
   # Encode to engage player preview image but with timestamp from editor
   - id: image
-    if: (NOT ${presentation/thumbnail_edited}) AND ${presentation_thumbnail_time_set}
+    if: ${presentation_thumbnail_time_set}
     exception-handler-workflow: partial-error
     description: Creating player preview image for presentation video from editor timestamp
     configurations:
@@ -80,7 +80,7 @@ operations:
       - time: ${presentation_thumbnail_time}
 
   - id: tag
-    if: ${presentation/thumbnail_edited}
+    if: ${presentation/thumbnail_edited} AND (NOT ${presentation_thumbnail_time_set})
     exception-handler-workflow: partial-error
     description: Prepare thumbnail for publication
     configurations:
@@ -101,7 +101,7 @@ operations:
 
   # Create a cover image but with timestamp from editor
   - id: image
-    if: (NOT ${presenter/thumbnail_edited}) AND ${presenter_thumbnail_time_set}
+    if: ${presenter_thumbnail_time_set}
     exception-handler-workflow: partial-error
     description: Creating player preview image for presenter video from editor timestamp
     configurations:
@@ -123,7 +123,7 @@ operations:
       - target-tags: archive, engage-download
 
   - id: tag
-    if: ${presenter/thumbnail_edited}
+    if: ${presenter/thumbnail_edited} AND (NOT ${presenter_thumbnail_time_set})
     exception-handler-workflow: partial-error
     description: Prepare thumbnail for publication
     configurations:
@@ -243,7 +243,7 @@ operations:
     exception-handler-workflow: partial-error
     description: Publishing to Opencast Media Module
     configurations:
-      - download-source-flavors: dublincore/*,security/*
+      - download-source-flavors: dublincore/*,security/*,textboxes/source,quizzes/source
       - download-source-tags: engage-download
       - streaming-source-tags: engage-streaming
       - check-availability: false

--- a/etc/workflows/partial-publish.yaml
+++ b/etc/workflows/partial-publish.yaml
@@ -73,11 +73,11 @@ operations:
     exception-handler-workflow: partial-error
     description: Creating player preview image for presentation video from editor timestamp
     configurations:
-      - source-flavor: presentation/source
+      - source-flavor: ${presentation_thumbnail_time_flavor}
       - target-flavor: presentation/player+preview
       - target-tags: engage-download
       - encoding-profile: player-preview.http
-      - time: ${presentation_thumbnail_time}
+      - time: ${presentation_thumbnail_time_time}
 
   - id: tag
     if: ${presentation/thumbnail_edited} AND (NOT ${presentation_thumbnail_time_set})
@@ -105,11 +105,11 @@ operations:
     exception-handler-workflow: partial-error
     description: Creating player preview image for presenter video from editor timestamp
     configurations:
-      - source-flavor: presenter/source
+      - source-flavor: ${presenter_thumbnail_time_flavor}
       - target-flavor: presenter/player+preview
       - target-tags: engage-download
       - encoding-profile: player-preview.http
-      - time: ${presenter_thumbnail_time}
+      - time: ${presenter_thumbnail_time_time}
 
   - id: cover-image
     if: NOT (${presenter_work_video} OR ${presentation_work_video} OR ${presentation/thumbnail_edited}) AND (${presenter_work_audio} OR ${presentation_work_audio})

--- a/etc/workflows/partial-publish.yaml
+++ b/etc/workflows/partial-publish.yaml
@@ -243,7 +243,7 @@ operations:
     exception-handler-workflow: partial-error
     description: Publishing to Opencast Media Module
     configurations:
-      - download-source-flavors: dublincore/*,security/*,textboxes/source,quizzes/source
+      - download-source-flavors: dublincore/*,security/*
       - download-source-tags: engage-download
       - streaming-source-tags: engage-streaming
       - check-availability: false

--- a/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/ThumbnailTime.java
+++ b/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/ThumbnailTime.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.opencastproject.editor.api;
+
+public class ThumbnailTime {
+  private String time;
+  private String flavorType;
+
+  public String getTime() {
+    return time;
+  }
+
+  public void setTime(String time) {
+    this.time = time;
+  }
+
+  public String getFlavorType() {
+    return flavorType;
+  }
+
+  public void setFlavorType(String flavorType) {
+    this.flavorType = flavorType;
+  }
+}

--- a/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/TrackData.java
+++ b/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/TrackData.java
@@ -39,6 +39,7 @@ public final class TrackData {
   private final String id;
   private final String thumbnailUri;
   private final int thumbnailPriority;
+  private final String thumbnailTime;
 
   public MediaPackageElementFlavor getFlavor() {
     if (flavor == null) {
@@ -48,7 +49,8 @@ public final class TrackData {
   }
 
   public TrackData(final String flavorType, final String flavorSubtype, final TrackSubData audio,
-          final TrackSubData video, String uri, String id, String thumbnailUri, int thumbnailPriority) {
+          final TrackSubData video, String uri, String id, String thumbnailUri, int thumbnailPriority,
+          final String thumbnailTime) {
     this.flavor = new MediaPackageElementFlavor(flavorType, flavorSubtype);
     this.audio = audio;
     this.video = video;
@@ -56,6 +58,7 @@ public final class TrackData {
     this.id = id;
     this.thumbnailUri = thumbnailUri;
     this.thumbnailPriority = thumbnailPriority;
+    this.thumbnailTime = thumbnailTime;
   }
 
   public TrackSubData getAudio() {
@@ -72,4 +75,8 @@ public final class TrackData {
 
   public String getThumbnailURI() {
     return this.thumbnailUri; }
+
+  public String getThumbnailTime() {
+    return thumbnailTime;
+  }
 }

--- a/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/TrackData.java
+++ b/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/TrackData.java
@@ -39,7 +39,7 @@ public final class TrackData {
   private final String id;
   private final String thumbnailUri;
   private final int thumbnailPriority;
-  private final String thumbnailTime;
+  private final ThumbnailTime thumbnailTime;
 
   public MediaPackageElementFlavor getFlavor() {
     if (flavor == null) {
@@ -50,7 +50,7 @@ public final class TrackData {
 
   public TrackData(final String flavorType, final String flavorSubtype, final TrackSubData audio,
           final TrackSubData video, String uri, String id, String thumbnailUri, int thumbnailPriority,
-          final String thumbnailTime) {
+          final ThumbnailTime thumbnailTime) {
     this.flavor = new MediaPackageElementFlavor(flavorType, flavorSubtype);
     this.audio = audio;
     this.video = video;
@@ -76,7 +76,7 @@ public final class TrackData {
   public String getThumbnailURI() {
     return this.thumbnailUri; }
 
-  public String getThumbnailTime() {
+  public ThumbnailTime getThumbnailTime() {
     return thumbnailTime;
   }
 }

--- a/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
+++ b/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
@@ -638,6 +638,22 @@ public class EditorServiceImpl implements EditorService {
               getThumbnailSubtype());
       String uri = track.getThumbnailURI();
 
+      // If thumbnail times, add workflow properties and be done
+      String time = track.getThumbnailTime();
+      if (time != null) {
+        WorkflowPropertiesUtil
+            .storeProperty(assetManager, mediaPackage,
+                flavor.getType() + "_thumbnail_time_set", "true");
+        WorkflowPropertiesUtil
+            .storeProperty(assetManager, mediaPackage,
+                flavor.getType() + "_thumbnail_time", time);
+        continue;
+      } else {
+        WorkflowPropertiesUtil
+            .storeProperty(assetManager, mediaPackage,
+                flavor.getType() + "_thumbnail_time_set", "false");
+      }
+
       // If no uri, what do?
       if (uri == null || uri.isEmpty()) {
         continue;
@@ -979,6 +995,18 @@ public class EditorServiceImpl implements EditorService {
             .map(property -> tuple(property.getA()[1], property.getA()[2]))
             .collect(Collectors.toSet());
 
+    final Map<String, String> thumbnailTimes = latestWfProperties.entrySet()
+        .stream()
+        .map(property -> tuple(property.getKey().split("_"), property.getValue()))
+        .filter(property -> property.getA().length == 3)
+        .filter(property -> property.getA()[1].equals("thumbnail"))
+        .filter(property -> property.getA()[2].equals("time"))
+        .map(property -> tuple(property.getA()[0], property.getB()))
+        .collect(Collectors.toMap(
+            property -> property.getA(),
+            property -> property.getB()
+        ));
+
     List<Track> trackList = Arrays.stream(internalPub.getTracks()).filter(this::elementHasPreviewTag)
             .collect(Collectors.toList());
     if (trackList.isEmpty()) {
@@ -1060,7 +1088,7 @@ public class EditorServiceImpl implements EditorService {
       }
 
       return new TrackData(track.getFlavor().getType(), track.getFlavor().getSubtype(), audio, video, uri,
-          track.getIdentifier(), thumbnailURI, priority);
+          track.getIdentifier(), thumbnailURI, priority, thumbnailTimes.get(track.getFlavor().getType()));
     }).collect(Collectors.toList());
 
     List<String> waveformList = Arrays.stream(internalPub.getAttachments())

--- a/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
+++ b/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
@@ -35,6 +35,7 @@ import org.opencastproject.editor.api.EditorServiceException;
 import org.opencastproject.editor.api.ErrorStatus;
 import org.opencastproject.editor.api.LockData;
 import org.opencastproject.editor.api.SegmentData;
+import org.opencastproject.editor.api.ThumbnailTime;
 import org.opencastproject.editor.api.TrackData;
 import org.opencastproject.editor.api.TrackSubData;
 import org.opencastproject.editor.api.WorkflowData;
@@ -639,7 +640,7 @@ public class EditorServiceImpl implements EditorService {
       String uri = track.getThumbnailURI();
 
       // If thumbnail times, add workflow properties and be done
-      String time = track.getThumbnailTime();
+      var time = track.getThumbnailTime();
       if (time != null) {
         // Remove old thumbnails
         Arrays.stream(mediaPackage.getElementsByFlavor(flavor)).forEach(mediaPackage::remove);
@@ -649,7 +650,10 @@ public class EditorServiceImpl implements EditorService {
                 flavor.getType() + "_thumbnail_time_set", "true");
         WorkflowPropertiesUtil
             .storeProperty(assetManager, mediaPackage,
-                flavor.getType() + "_thumbnail_time", time);
+                flavor.getType() + "_thumbnail_time_time", time.getTime());
+        WorkflowPropertiesUtil
+            .storeProperty(assetManager, mediaPackage,
+                flavor.getType() + "_thumbnail_time_flavor", time.getFlavorType() + "/source");
         continue;
       } else {
         WorkflowPropertiesUtil
@@ -998,17 +1002,24 @@ public class EditorServiceImpl implements EditorService {
             .map(property -> tuple(property.getA()[1], property.getA()[2]))
             .collect(Collectors.toSet());
 
-    final Map<String, String> thumbnailTimes = latestWfProperties.entrySet()
-        .stream()
-        .map(property -> tuple(property.getKey().split("_"), property.getValue()))
-        .filter(property -> property.getA().length == 3)
-        .filter(property -> property.getA()[1].equals("thumbnail"))
-        .filter(property -> property.getA()[2].equals("time"))
-        .map(property -> tuple(property.getA()[0], property.getB()))
-        .collect(Collectors.toMap(
-            property -> property.getA(),
-            property -> property.getB()
-        ));
+    Map<String, ThumbnailTime> thumbnailTimes = new HashMap<>();
+    latestWfProperties.forEach((key, value) -> {
+      String[] parts = key.split("_");
+      if (parts.length == 4
+          && "thumbnail".equals(parts[1])
+          && "time".equals(parts[2])
+          && ("time".equals(parts[3]) || "flavor".equals(parts[3]))
+      ) {
+
+        ThumbnailTime tt = thumbnailTimes.computeIfAbsent(parts[0], k -> new ThumbnailTime());
+
+        if (parts.length == 4 && "time".equals(parts[3])) {
+          tt.setTime(value);
+        } else if (parts.length == 4 && "flavor".equals(parts[3])) {
+          tt.setFlavorType(value.split("/")[0]);
+        }
+      }
+    });
 
     List<Track> trackList = Arrays.stream(internalPub.getTracks()).filter(this::elementHasPreviewTag)
             .collect(Collectors.toList());

--- a/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
+++ b/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
@@ -641,6 +641,9 @@ public class EditorServiceImpl implements EditorService {
       // If thumbnail times, add workflow properties and be done
       String time = track.getThumbnailTime();
       if (time != null) {
+        // Remove old thumbnails
+        Arrays.stream(mediaPackage.getElementsByFlavor(flavor)).forEach(mediaPackage::remove);
+
         WorkflowPropertiesUtil
             .storeProperty(assetManager, mediaPackage,
                 flavor.getType() + "_thumbnail_time_set", "true");


### PR DESCRIPTION
The backend part of "Thumbnails in backend".

We can now get time stamps for generating thumbnails instead of just thumbnails. Thumbnail timestamps are added to the workflow properties, so that the workflows may use them to generate appropriate thumbnails. To that end, this also includes workflow changes.

Frontend PR: https://github.com/opencast/editor/pull/1708

### How to test this patch

Should be tested together with the frontend PR. If you are using other workflows than the default ones, you'll want to adapt them and test them too.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
