### PR TITLE
Correct and expand configuration panel json documentation

### DIFF
--- a/docs/guides/admin/docs/configuration/liveschedule.md
+++ b/docs/guides/admin/docs/configuration/liveschedule.md
@@ -150,18 +150,20 @@ The LiveScheduleService will generate a media package with two live tracks havin
 
 When scheduling a live event via the admin UI, the workflow needs to have the _publishLive_ configuration set to true
 (this is already included in the sample workflows).
-If not using the sample Opencast workflows, add to the `<configuration_panel_json>`:
+If not using the sample Opencast workflows, add to the `configuration_panel_json`:
 
-```
-        <fieldset>
-          <legend>Publish live stream:</legend>
-          <ul>
-            <li>
-              <input id="publishLive" name="publishLive" type="checkbox" class="configField" value="false" />
-              <label for="publishLive">Add live event to Opencast Media Module</label>
-            </li>
-          </ul>
-        </fieldset>
+```json
+  {
+    "legend": "Publish live stream",
+    "fieldset": [
+      {
+        "type": "checkbox",
+        "name": "publishLive",
+        "label": "Add live event to Opencast Media Module",
+        "value": false
+      }
+    ]
+  }
 ```
 
 And to the _defaults_ operation:

--- a/docs/guides/admin/docs/configuration/workflow.md
+++ b/docs/guides/admin/docs/configuration/workflow.md
@@ -259,17 +259,18 @@ selection will be used to replace the `${someaction}` variable in the workflow.
 The configuration panel json is an array of objects with these properties:
 - legend - title for the fieldset (optional)
 - fieldset - and array of user inputs
+- description - additional information (optional)
 
 The `fieldset` object can contain these properties:
-- type - input type, `checkbox|radiobox|text|number|datetime`
-- name - the variable name that will available to the workflow
+- type - input type, `checkbox|radio|text|number|datetime`
+- name - the variable name that will be available to the workflow
 - label - the text displayed for this input
-- value - the intial value for this variable, if not defined some type will create a sensible default. Each input type uses different value types:
+- value - the initial value for this variable, if not defined some type will create a sensible default. Each input type uses different value types:
   - checkbox - `true|false`
   - radio - `"option"`, see options below
   - text - `"any string"`
   - number - `any number`, see min and max below
-  - datetime - `"YY-MM-DDTHH:MM:SS"`
+  - datetime-local - `"YY-MM-DDTHH:MM:SS"`
 - min - define lower value limits for type `number`
 - max - define upper value limits for type `number`
 - options - define values for type `radio`

--- a/docs/guides/admin/docs/configuration/workflow.md
+++ b/docs/guides/admin/docs/configuration/workflow.md
@@ -239,20 +239,50 @@ The attribute `if` specifies the execution condition in means of the operation o
 evaluates to true. You can find more details on conditional execution in the next section.
 
 Once the operation is configured to accept a variable, we need to describe how to gather the value from the
-administrative user. The `<configuration_panel_json>` element of a workflow definitions describes this user interface
+administrative user. The `configuration_panel_json` element of a workflow definitions describes this user interface
 snippet.  A simple configuration panel could look like this:
 
     configuration_panel_json: |-
-      <input id="someaction" name="someaction" type="checkbox" value="true" />
-      <label for="someaction">Execute some operation?</label>
+      [{
+        "fieldset": [{
+          "type": "checkbox",
+          "name": "someaction",
+          "label": "Execute some operation?",
+          "value": true
+        }]
+      }]
 
 
-The checkbox in this `<configuration_panel_json>` will now be displayed in the administrative tools, and the user's
+The checkbox in this `configuration_panel_json` will now be displayed in the administrative tools, and the user's
 selection will be used to replace the `${someaction}` variable in the workflow.
+
+The configuration panel json is an array of objects with these properties:
+- legend - title for the fieldset (optional)
+- fieldset - and array of user inputs
+
+The `fieldset` object can contain these properties:
+- type - input type, `checkbox|radiobox|text|number|datetime`
+- name - the variable name that will available to the workflow
+- label - the text displayed for this input
+- value - the intial value for this variable, if not defined some type will create a sensible default. Each input type uses different value types:
+  - checkbox - `true|false`
+  - radio - `"option"`, see options below
+  - text - `"any string"`
+  - number - `any number`, see min and max below
+  - datetime - `"YY-MM-DDTHH:MM:SS"`
+- min - define lower value limits for type `number`
+- max - define upper value limits for type `number`
+- options - define values for type `radio`
+  - label - display name
+  - value - option value
 
 This input can also be sent by capture agents, using the ingest endpoints. Please note that capture agents usually do
 not load the configuration panel. Hence defaults set in the user interface will not apply to ingests. To circumvent
 this, the [defaults operation](../workflowoperationhandlers/defaults-woh.md) can be used.
+
+NOTE: The old `configuration_panel` element defined the user input using HTML but is ignored by the new Admin UI. The
+old Admin UI was removed completely in v17.x and you will need to rewrite user input as JSON if updating from an earlier
+version.
 
 ## Organisation Properties
 
@@ -373,6 +403,11 @@ As an alternative to YAML workflow configuration files, it is possible to use XM
   <state-mappings>
     <state-mapping state=""></state-mapping>
   </state-mappings>
+
+  <!-- User Input -->
+  <configuration_panel_json>
+    ...
+  </configuration_panel_json>
 
   <!-- Operations -->
   <operations>

--- a/docs/guides/admin/docs/workflowoperationhandlers/send-email-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/send-email-woh.md
@@ -14,8 +14,8 @@ The email body, if not specified by body or body-template-file, will consist of 
 `<Recording Title> (<Mediapackage ID>)`.
 
 Freemarker templates can be used in the following fields to allow replacement with values obtained from the workflow or
-media package: to, cc, bcc, subject, and body. If body-template-file is specified, the operation will use a Freemarker 
-template file located in `<config_dir>/etc/email` to generate the email body. A more in deep explanation of how to use 
+media package: to, cc, bcc, subject, and body. If body-template-file is specified, the operation will use a Freemarker
+template file located in `<config_dir>/etc/email` to generate the email body. A more in deep explanation of how to use
 Freemarker variables can be found in the [Appendix](#appendix-freemarker-variable-usage-guide).
 
 Usernames can be provided in `to`, `cc`, or `bcc` in lieu of email addresses so that the user directory is searched
@@ -121,7 +121,7 @@ In your email template:
 
 Use `${catalogs['FLAVOR']['FIELD']}`
 
-Deprecation notice: Opencast versions before 13 used `${catalogs['SUBFLAVOR']['FIELD']}` for `dublincore/SUBFLAVOR` 
+Deprecation notice: Opencast versions before 13 used `${catalogs['SUBFLAVOR']['FIELD']}` for `dublincore/SUBFLAVOR`
 catalogs. This syntax is still accepted but deprecation. Future versions might remove support.
 
 #### Examples
@@ -214,51 +214,19 @@ Email address entered via admin UI as a workflow configuration parameter:
 
 Workflow Configuration Panel:
 
-```yaml
-  configuration_panel_json: |-
-    <!-- Add after the other configuration fields (Holds, Archive, etc) -->
-    <fieldset>
-      <legend>Notification</legend>
-      <ul class="oc-ui-form-list">
-        <li class="ui-helper-clearfix">
-          <label class="scheduler-label">
-            <span class="color-red">* </span><span id="i18n_email_label">Email Address</span>:
-          </label>
-          <span id="emailconfig">
-            <input id="emailAddress" name="emailAddress" type="text" class="configField"
-                    value="my-email-account@my-email-domain.org"/>
-          </span>
-        </li>
-      </ul>
-    </fieldset>
-
-    <script type="text/javascript">
-
-      // Add email variable
-      var emailAddress = $('input#emailAddress');
-
-      // Register email configuration property
-      ocWorkflowPanel.registerComponents = function(components){
-        /* components with keys that begin with 'org.opencastproject.workflow.config' will be passed
-          * into the workflow. The component's nodeKey must match the components array key.
-          *
-          * Example:'org.opencastproject.workflow.config.myProperty' will be available at ${my.property}
-          */
-        // After the other components (Hold, Archive, etc), add:
-        components['org.opencastproject.workflow.config.emailAddress'] = new ocAdmin.Component(
-          ['emailAddress'],
-          {key: 'org.opencastproject.workflow.config.emailAddress'},
-          {getValue: function(){ return this.fields.emailAddress.value;}
-          });
-
-          //etc...
+After the other configuration fields (Holds, Archive, etc) add to the `configuration_panel_json`:
+```json
+  {
+    "legend": "Notification",
+    "fieldset": [
+      {
+        "type": "text",
+        "name": "emailAddresses",
+        "label": "Email Address",
+        "value": "my-email-account@my-email-domain.org"
       }
-      ocWorkflowPanel.setComponentValues = function(values, components){
-        // After the other components (Hold, Archive, etc), add:
-        components['org.opencastproject.workflow.config.emailAddress'].setValue(
-          values['org.opencastproject.workflow.config.emailAddress']);
-      }
-    </script>
+    ]
+  }
 ```
 
 ### Example 4
@@ -360,13 +328,13 @@ Requires the user account to have a valid email address.
 Appendix: Freemarker Variable Usage Guide
 ---------------------------
 
-Freemarker is a powerful template engine that allows you to embed dynamic content in your templates. 
-One of the key features is its ability to handle variables. This guide will walk you through the basics of using 
+Freemarker is a powerful template engine that allows you to embed dynamic content in your templates.
+One of the key features is its ability to handle variables. This guide will walk you through the basics of using
 variables in Freemarker templates.
 
 ### Declaring Variables
 
-In Freemarker, you don't explicitly declare variables. You usually pass them from your application code to the template. 
+In Freemarker, you don't explicitly declare variables. You usually pass them from your application code to the template.
 However, you can also set local variables using the `<#assign>` directive:
 
 ```freemarker
@@ -488,5 +456,5 @@ You can define reusable pieces of code using `<#macro>`:
 <@greet name="John"/>
 ```
 
-This guide provides a quick overview of how to use variables in Freemarker. For more advanced topics and complete 
+This guide provides a quick overview of how to use variables in Freemarker. For more advanced topics and complete
 documentation, you can refer to the [official Freemarker documentation](https://freemarker.apache.org/docs/).

--- a/docs/guides/developer/docs/architecture/api/workflow-api.md
+++ b/docs/guides/developer/docs/architecture/api/workflow-api.md
@@ -62,7 +62,7 @@ Field                 | Type                                                    
 `title`               | [`string`](types.md#basic)                                 | The title of this workflow instance
 `description`         | [`string`](types.md#basic)                                 | The description of this workflow instance
 `tags`                | [`array[string]`](types.md#array)                          | The (potentially empty) list of workflow tags of this workflow instance
-`configuration_panel` | [`string`](types.md#basic)                                 | The configuration panel of this workflow instance
+`configuration`       | [`string`](types.md#basic)                                 | The configuration of this workflow instance
 `operations`          | [`array[operation_instance]`](types.md#operation_instance) | The list of operations of this workflow instance
 
 `400 (BAD REQUEST)`: The request is invalid or inconsistent.<br/>
@@ -89,7 +89,7 @@ Field                 | Type                                                    
 `title`               | [`string`](types.md#basic)                                 | The title of this workflow instance
 `description`         | [`string`](types.md#basic)                                 | The description of this workflow instance
 `tags`                | [`array[string]`](types.md#array)                          | The (potentially empty) list of workflow tags of this workflow instance
-`configuration_panel` | [`string`](types.md#basic)                                 | The configuration panel of this workflow instance
+`configuration`       | [`string`](types.md#basic)                                 | The configuration of this workflow instance
 `operations`          | [`array[operation_instance]`](types.md#operation_instance) | The list of operations of this workflow instance
 
 `403 (FORBIDDEN)`: The user doesn't have the rights to make this request.<br/>
@@ -274,10 +274,11 @@ Sort Criteria       | Description
 This request additionally supports the following query string parameters to include additional information directly in
 the response:
 
-Query String Parameter     | Type                        | Description
-:--------------------------|:----------------------------|:-----------
-`withoperations`           | [`boolean`](types.md#basic) | Whether the workflow operations should be included in the response
-`withconfigurationpanel`   | [`boolean`](types.md#basic) | Whether the workflow configuration panel should be included in the response
+Query String Parameter      | Type                        | Description
+:---------------------------|:----------------------------|:-----------
+`withoperations`            | [`boolean`](types.md#basic) | Whether the workflow operations should be included in the response
+`withconfigurationpaneljson`| [`boolean`](types.md#basic) | Whether the workflow configuration panel in JSON should be included in the response
+`withconfigurationpanel`    | [`boolean`](types.md#basic) | Whether the workflow configuration panel should be included in the response
 
 __Sample request__
 
@@ -290,14 +291,15 @@ __Response__
 `200 (OK)`: A (potentially empty) list of workflow definitions is returned. The list is represented as JSON array where
 each element is a JSON object with the following fields:
 
-Field                 | Type                                                           | Description
-:---------------------|:---------------------------------------------------------------|:-----------
-`identifier`          | [`string`](types.md#basic)                                     | The unique identifier of this workflow definition
-`title`               | [`string`](types.md#basic)                                     | The title of this workflow definition
-`description`         | [`string`](types.md#basic)                                     | The description of this workflow definition
-`tags`                | [`array[string]`](types.md#array)                              | The (potentially empty) list of workflow tags of this workflow definition
-`configuration_panel` | [`string`](types.md#basic)                                     | The configuration panel of this workflow definition
-`operations`          | [`array[operation_definition]`](types.md#operation_definition) | The list of operations of this workflow definition
+Field                      | Type                                                           | Description
+:--------------------------|:---------------------------------------------------------------|:-----------
+`identifier`               | [`string`](types.md#basic)                                     | The unique identifier of this workflow definition
+`title`                    | [`string`](types.md#basic)                                     | The title of this workflow definition
+`description`              | [`string`](types.md#basic)                                     | The description of this workflow definition
+`tags`                     | [`array[string]`](types.md#array)                              | The (potentially empty) list of workflow tags of this workflow definition
+`configuration_panel_json` | [`string`](types.md#basic)                                     | The configuration panel defined JSON of this workflow definition
+`configuration_panel`      | [`string`](types.md#basic)                                     | The configuration panel of this workflow definition
+`operations`               | [`array[operation_definition]`](types.md#operation_definition) | The list of operations of this workflow definition
 
 `400 (BAD REQUEST)`: The request is invalid or inconsistent.
 
@@ -313,7 +315,7 @@ __Example__
       "schedule",
       "upload"
     ],
-    "configuration_panel": "\n    \n      <div id=\"workflow-configuration\">\n        <fieldset>\n          <legend>Add a comment that the recording needs:</legend>\n          <ul>\n            <li>\n              <input id=\"comment\" name=\"comment\" type=\"checkbox\" class=\"configField\" value=\"true\" />\n              <label for=\"comment\">Review / Cutting</label>\n            </li>\n          </ul>\n        </fieldset>\n        <fieldset>\n          <legend>Immediately distribute the recording to:</legend>\n          <ul>\n            <li>\n              <input id=\"publishToMediaModule\" name=\"publishToMediaModule\" type=\"checkbox\" class=\"configField\" value=\"true\" checked=checked />\n              <label for=\"publishToMediaModule\">Opencast Media Module</label>\n            </li>\n            <li>\n              <input id=\"publishToOaiPmh\" name=\"publishToOaiPmh\" type=\"checkbox\" class=\"configField\" value=\"true\" checked=checked />\n              <label for=\"publishToOaiPmh\">Default OAI-PMH Repository</label>\n            </li>\n          </ul>\n        </fieldset>\n        <fieldset>\n          <legend>Publish live stream:</legend>\n          <ul>\n            <li>\n              <input id=\"publishLive\" name=\"publishLive\" type=\"checkbox\" class=\"configField\" value=\"false\" />\n              <label for=\"publishLive\">Add live event to Opencast Media Module</label>\n            </li>\n          </ul>\n        </fieldset>\n      </div>\n    \n  ",
+    "configuration_panel_json": "[{\n  \"fieldset\": [\n    {\n      \"type\": \"checkbox\",\n      \"name\": \"straightToPublishing\",\n      \"label\": \"Straight to publishing\",\n      \"value\": true\n    }\n  ]\n}]",
     "operations": [
       {
         "id": "defaults",
@@ -389,7 +391,7 @@ __Example__
     "schedule",
     "upload"
   ],
-  "configuration_panel": "\n    \n      <div id=\"workflow-configuration\">\n        <fieldset>\n          <legend>Add a comment that the recording needs:</legend>\n          <ul>\n            <li>\n              <input id=\"comment\" name=\"comment\" type=\"checkbox\" class=\"configField\" value=\"true\" />\n              <label for=\"comment\">Review / Cutting</label>\n            </li>\n          </ul>\n        </fieldset>\n        <fieldset>\n          <legend>Immediately distribute the recording to:</legend>\n          <ul>\n            <li>\n              <input id=\"publishToMediaModule\" name=\"publishToMediaModule\" type=\"checkbox\" class=\"configField\" value=\"true\" checked=checked />\n              <label for=\"publishToMediaModule\">Opencast Media Module</label>\n            </li>\n            <li>\n              <input id=\"publishToOaiPmh\" name=\"publishToOaiPmh\" type=\"checkbox\" class=\"configField\" value=\"true\" checked=checked />\n              <label for=\"publishToOaiPmh\">Default OAI-PMH Repository</label>\n            </li>\n          </ul>\n        </fieldset>\n        <fieldset>\n          <legend>Publish live stream:</legend>\n          <ul>\n            <li>\n              <input id=\"publishLive\" name=\"publishLive\" type=\"checkbox\" class=\"configField\" value=\"false\" />\n              <label for=\"publishLive\">Add live event to Opencast Media Module</label>\n            </li>\n          </ul>\n        </fieldset>\n      </div>\n    \n  ",
+  "configuration_panel_json": "[{\n  \"fieldset\": [\n    {\n      \"type\": \"checkbox\",\n      \"name\": \"straightToPublishing\",\n      \"label\": \"Straight to publishing\",\n      \"value\": true\n    }\n  ]\n}]",
   "operations": [
     {
       "id": "defaults",


### PR DESCRIPTION
Docs mentioning `configuration_panel_json` still referred to old `configuration_panel` HTML. Also no actual docs for `configuration_panel_json`.

PR against legacy as the docs have been incorrect since v17.x

### How to test this patch

Read it 

### AI Usage
N/A


