### PR TITLE
Automate Changelog Generation

### DIFF
--- a/.github/changelog/admin-interface.json
+++ b/.github/changelog/admin-interface.json
@@ -40,9 +40,9 @@
       "on_property": "mergedAt"
     },
     "template": "#{{CHANGELOG}}\n\n<details>\n<summary>Uncategorized</summary>\n\n#{{UNCATEGORIZED}}\n</details>",
-    "pr_template": "- #{{TITLE}}\n   - PR: ##{{NUMBER}}",
+    "pr_template": "- opencast/admin-interface##{{NUMBER}} - #{{TITLE}}",
     "empty_template": "- no changes",
     "trim_values": false,
     "max_tags_to_fetch": 200,
-    "max_pull_requests": 200
+    "max_pull_requests": 500
 }

--- a/.github/changelog/admin-interface.json
+++ b/.github/changelog/admin-interface.json
@@ -1,0 +1,48 @@
+{
+    "categories": [
+      {
+        "title": "### 🚀 Features",
+        "labels": [
+          "type:enhancement"
+        ]
+      },
+      {
+        "title": "### 🐛 Fixes",
+        "labels": [
+          "type:bug"
+        ]
+      },
+      {
+        "empty_content": "- no matching PRs",
+        "title": "### Accessibility",
+        "labels": [
+          "type:usability",
+          "type:accessibility",
+          "type:visual-clarity"
+        ]
+      },
+      {
+        "key": "security",
+        "title": "### Security",
+        "labels": [
+          "type:security"
+        ]
+      },
+      {
+        "title": "### Dependencies",
+        "labels": [
+          "type:dependencies"
+        ]
+      }
+    ],
+    "sort": {
+      "order": "ASC",
+      "on_property": "mergedAt"
+    },
+    "template": "#{{CHANGELOG}}\n\n<details>\n<summary>Uncategorized</summary>\n\n#{{UNCATEGORIZED}}\n</details>",
+    "pr_template": "- #{{TITLE}}\n   - PR: ##{{NUMBER}}",
+    "empty_template": "- no changes",
+    "trim_values": false,
+    "max_tags_to_fetch": 200,
+    "max_pull_requests": 200
+}

--- a/.github/changelog/editor.json
+++ b/.github/changelog/editor.json
@@ -1,0 +1,49 @@
+{
+    "categories": [
+      {
+        "title": "### 🚀 Features",
+        "labels": [
+          "type:enhancement",
+          "type:feature"
+        ]
+      },
+      {
+        "title": "### 🐛 Fixes",
+        "labels": [
+          "type:bug"
+        ]
+      },
+      {
+        "empty_content": "- no matching PRs",
+        "title": "### Accessibility",
+        "labels": [
+          "type:usability",
+          "type:accessibility",
+          "type:visual-clarity"
+        ]
+      },
+      {
+        "key": "security",
+        "title": "### Security",
+        "labels": [
+          "type:security"
+        ]
+      },
+      {
+        "title": "### Dependencies",
+        "labels": [
+          "type:dependencies"
+        ]
+      }
+    ],
+    "sort": {
+      "order": "ASC",
+      "on_property": "mergedAt"
+    },
+    "template": "#{{CHANGELOG}}\n\n<details>\n<summary>Uncategorized</summary>\n\n#{{UNCATEGORIZED}}\n</details>",
+    "pr_template": "- #{{TITLE}}\n   - PR: ##{{NUMBER}}",
+    "empty_template": "- no changes",
+    "trim_values": false,
+    "max_tags_to_fetch": 200,
+    "max_pull_requests": 200
+}

--- a/.github/changelog/editor.json
+++ b/.github/changelog/editor.json
@@ -41,9 +41,9 @@
       "on_property": "mergedAt"
     },
     "template": "#{{CHANGELOG}}\n\n<details>\n<summary>Uncategorized</summary>\n\n#{{UNCATEGORIZED}}\n</details>",
-    "pr_template": "- #{{TITLE}}\n   - PR: ##{{NUMBER}}",
+    "pr_template": "- opencast/editor##{{NUMBER}} - #{{TITLE}}",
     "empty_template": "- no changes",
     "trim_values": false,
     "max_tags_to_fetch": 200,
-    "max_pull_requests": 200
+    "max_pull_requests": 500
 }

--- a/.github/changelog/opencast.json
+++ b/.github/changelog/opencast.json
@@ -1,0 +1,65 @@
+{
+    "categories": [
+      {
+        "title": "### 🚀 Features, Enhancements, and API changes",
+        "labels": [
+          "feature", 
+          "enhancement"
+        ]
+      },
+      {
+        "title": "### 🐛 Fixes",
+        "labels": [
+          "bug"
+        ]
+      },
+      {
+        "key": "security",
+        "title": "### Security",
+        "labels": [
+          "security"
+        ]
+      },
+      {
+        "title": "### Tests and Performance",
+        "labels": [
+          "performance",
+          "tests"
+        ]
+      },
+      {
+        "title": "### Submodule",
+        "labels": [
+          "admin-ui",
+          "editor",
+          "studio"
+        ]
+      },
+      {
+        "title": "### Maintenance",
+        "labels": [
+          "maintenance",
+          "configuration",
+          "documentation",
+          "packaging",
+          "javascript"
+        ]
+      },
+      {
+        "title": "### Dependencies",
+        "labels": [
+          "dependencies"
+        ]
+      }
+    ],
+    "sort": {
+      "order": "ASC",
+      "on_property": "mergedAt"
+    },
+    "template": "#{{CHANGELOG}}\n\n<details>\n<summary>Uncategorized</summary>\n\n#{{UNCATEGORIZED}}\n</details>",
+    "pr_template": "- #{{TITLE}}\n   - PR: ##{{NUMBER}}",
+    "empty_template": "- no changes",
+    "trim_values": false,
+    "max_tags_to_fetch": 200,
+    "max_pull_requests": 500
+}

--- a/.github/changelog/opencast.json
+++ b/.github/changelog/opencast.json
@@ -57,7 +57,7 @@
       "on_property": "mergedAt"
     },
     "template": "#{{CHANGELOG}}\n\n<details>\n<summary>Uncategorized</summary>\n\n#{{UNCATEGORIZED}}\n</details>",
-    "pr_template": "- #{{TITLE}}\n   - PR: ##{{NUMBER}}",
+    "pr_template": "- ##{{NUMBER}} - #{{TITLE}}",
     "empty_template": "- no changes",
     "trim_values": false,
     "max_tags_to_fetch": 200,

--- a/.github/changelog/studio.json
+++ b/.github/changelog/studio.json
@@ -1,0 +1,40 @@
+{
+    "categories": [
+      {
+        "title": "### 🚀 Features",
+        "labels": ["type:new-feature"]
+      },
+      {
+        "title": "### 🐛 Fixes",
+        "labels": ["type:bug"]
+      },
+      {
+        "empty_content": "- no matching PRs",
+        "title": "### Accessibility",
+        "labels": ["type:usability", "type:accessibility", "type:visual-clarity"]
+      },
+      {
+        "key": "security",
+        "title": "### Security",
+        "labels": ["type:security"]
+      },
+      {
+        "title": "### Dependencies",
+        "labels": ["type:dependencies"]
+      },
+      {
+        "title": "### Everything Else",
+        "exclude_labels": ["type:new-feature", "type:bug", "type:usability", "type:accessibility", "type:visual-clarity", "type:security", "type:dependencies"]
+      }
+    ],
+    "sort": {
+      "order": "ASC",
+      "on_property": "mergedAt"
+    },
+    "template": "#{{CHANGELOG}}\n\n<details>\n<summary>Uncategorized</summary>\n\n#{{UNCATEGORIZED}}\n</details>",
+    "pr_template": "- #{{TITLE}}\n   - PR: ##{{NUMBER}}",
+    "empty_template": "- no changes",
+    "trim_values": false,
+    "max_tags_to_fetch": 200,
+    "max_pull_requests": 200
+}

--- a/.github/changelog/studio.json
+++ b/.github/changelog/studio.json
@@ -32,9 +32,9 @@
       "on_property": "mergedAt"
     },
     "template": "#{{CHANGELOG}}\n\n<details>\n<summary>Uncategorized</summary>\n\n#{{UNCATEGORIZED}}\n</details>",
-    "pr_template": "- #{{TITLE}}\n   - PR: ##{{NUMBER}}",
+    "pr_template": "- opencast/studio##{{NUMBER}} - #{{TITLE}}",
     "empty_template": "- no changes",
     "trim_values": false,
     "max_tags_to_fetch": 200,
-    "max_pull_requests": 200
+    "max_pull_requests": 500
 }

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -50,6 +50,42 @@ jobs:
           echo "VERSION_MAIN=$GITHUB_REF"     | sed 's_refs/tags/\([0-9]*\).\([0-9]*\)$_\1_' >> $GITHUB_OUTPUT
           echo "VERSION_COMBINED=$GITHUB_REF" | sed 's_refs/tags/\([0-9]*\).\([0-9]*\)$_\1\2_' >> $GITHUB_OUTPUT
 
+      - name: changelog
+        id: opencast_changelog
+        uses: mikepenz/release-changelog-builder-action@348e88fab4c37338b1e803ceb2d4a7a5db6c0833 #6.2.2
+        with:
+          configuration: ".github/changelog/opencast.json"
+          owner: opencast
+          repo: opencast
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: changelog
+        id: admin_changelog
+        uses: mikepenz/release-changelog-builder-action@348e88fab4c37338b1e803ceb2d4a7a5db6c0833 #6.2.2
+        with:
+          configuration: ".github/changelog/admin-interface.json"
+          owner: opencast
+          repo: admin-interface
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: changelog
+        id: editor_changelog
+        uses: mikepenz/release-changelog-builder-action@348e88fab4c37338b1e803ceb2d4a7a5db6c0833 #6.2.2
+        with:
+          configuration: ".github/changelog/editor.json"
+          owner: opencast
+          repo: editor
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: changelog
+        id: studio_changelog
+        uses: mikepenz/release-changelog-builder-action@348e88fab4c37338b1e803ceb2d4a7a5db6c0833 #6.2.2
+        with:
+          configuration: ".github/changelog/studio.json"
+          owner: opencast
+          repo: studio
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: create new release
         uses: softprops/action-gh-release@v2
         with:
@@ -57,8 +93,14 @@ jobs:
           fail_on_unmatched_files: true
           name: Opencast ${{ steps.get_version.outputs.VERSION }}
           body: |
-            This is an Opencast ${{ steps.get_version.outputs.VERSION_MAIN }} release.
-            For further information, please take a look at:
+            # Opencast Core changes
+            ${{ steps.opencast_changelog.outputs.changelog }}
 
-            - [Release notes](https://docs.opencast.org/r/${{ steps.get_version.outputs.VERSION_MAIN }}.x/admin/#releasenotes/#opencast-${{ steps.get_version.outputs.VERSION_COMBINED }})
-            - [Changelog](https://docs.opencast.org/r/${{ steps.get_version.outputs.VERSION_MAIN }}.x/admin/#changelog/opencast-${{ steps.get_version.outputs.VERSION_MAIN }})
+            # Admin Interface submodule changes
+            ${{ steps.admin_changelog.outputs.changelog }}
+
+            # Editor submodules changes
+            ${{ steps.editor_changelog.outputs.changelog }}
+
+            # Studio submodule changes
+            ${{ steps.studio_changelog.outputs.changelog }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -50,6 +50,20 @@ jobs:
           echo "VERSION_MAIN=$GITHUB_REF"     | sed 's_refs/tags/\([0-9]*\).\([0-9]*\)$_\1_' >> $GITHUB_OUTPUT
           echo "VERSION_COMBINED=$GITHUB_REF" | sed 's_refs/tags/\([0-9]*\).\([0-9]*\)$_\1\2_' >> $GITHUB_OUTPUT
 
+      - name: Get the last tag version
+        id: get_last_version
+        run: |
+          #If this not an N.0 release
+          # Uses string comparison here because bash doesn't like 0.6 -ne 0
+          # complains about integer expressions being expected
+          if [ "$(echo ${{ steps.get_version.outputs.VERSION }} % 1 | bc)" != "0" ]; then
+            echo "LAST_VERSION=$( echo ${{ steps.get_version.outputs.VERSION }} - 0.1 | bc)"
+            echo "LAST_VERSION=$( echo ${{ steps.get_version.outputs.VERSION }} - 0.1 | bc)" >> $GITHUB_OUTPUT
+          else
+            echo "LAST_VERSION=$( echo ${{ steps.get_version.outputs.VERSION }} - 1 | bc)"
+            echo "LAST_VERSION=$( echo ${{ steps.get_version.outputs.VERSION }} - 1 | bc)" >> $GITHUB_OUTPUT
+          fi
+
       - name: changelog
         id: opencast_changelog
         uses: mikepenz/release-changelog-builder-action@348e88fab4c37338b1e803ceb2d4a7a5db6c0833 #6.2.2
@@ -57,6 +71,7 @@ jobs:
           configuration: ".github/changelog/opencast.json"
           owner: opencast
           repo: opencast
+          fromTag: ${{ steps.get_last_version.outputs.LAST_VERSION }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: changelog
@@ -66,6 +81,7 @@ jobs:
           configuration: ".github/changelog/admin-interface.json"
           owner: opencast
           repo: admin-interface
+          fromTag: ${{ steps.get_last_version.outputs.LAST_VERSION }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: changelog
@@ -75,6 +91,7 @@ jobs:
           configuration: ".github/changelog/editor.json"
           owner: opencast
           repo: editor
+          fromTag: ${{ steps.get_last_version.outputs.LAST_VERSION }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: changelog
@@ -84,6 +101,7 @@ jobs:
           configuration: ".github/changelog/studio.json"
           owner: opencast
           repo: studio
+          fromTag: ${{ steps.get_last_version.outputs.LAST_VERSION }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: create new release


### PR DESCRIPTION
This pull request automates our changelog generation using GHA tooling.  This tooling recurses into the submodules, capturing the changes there which are currently missed.

An example of what gets generated: https://github.com/gregorydlogan/opencast/releases/tag/19.6, which is actually the *19.4->19.5* changeset that I've manually hacked in so that we have a renderable example.

This PR will also add label enforcement to our PRs to power the changelog categories.

This should go into 19.x since there are still 19.x releases forthcoming, and not having complete a changelog sucks.

TODO:
- Discuss if this format is acceptable with the committers
- Decide if we want to scrape the output into our own docs (ie, docs.opencast.org).  I'm in favour of this since we should really have our changelog in our docs, not in someone else's tooling.
  - Implement this scraping, if approved.
- Update the RM docs
- Remove the old script from helper script repo to reduce confusion

### How to test this patch

Take a look at the changes I made to the actual 19.6 tag in repository, then push you own to your repository.

### AI Usage

N/A

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] ~include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)~
