### PR TITLE
Improvements for Deletion

### DIFF
--- a/docs/guides/admin/docs/releasenotes/delete-workflow
+++ b/docs/guides/admin/docs/releasenotes/delete-workflow
@@ -1,0 +1,2 @@
+Community delete workflow including default configuration value has been renamed to "retract-for-deletion" to avoid
+confusion.

--- a/docs/guides/admin/docs/workflowoperationhandlers/snapshot-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/snapshot-woh.md
@@ -18,6 +18,7 @@ Parameter Table
 |source-tags       |text            |Comma separated list of tags. Specifies which media should be the source of a snapshot.|
 |source-flavors    |presenter/source|Comma separated list of flavors. Specifies which media should be the source of a snapshot.|
 
+If neither tags nor flavors are configured, all elements of the media package are included.
 
 Operation Example
 -----------------

--- a/etc/org.opencastproject.adminui.impl.AdminUIConfiguration.cfg
+++ b/etc/org.opencastproject.adminui.impl.AdminUIConfiguration.cfg
@@ -13,8 +13,8 @@
 
 # ID of the workflow used to unpublish events when deleting.
 #
-# Default: delete
-# retract.workflow.id=delete
+# Default: retract-for-deletion
+# retract.workflow.id=retract-for-deletion
 
 # List of role prefixes for lenient managedAcl matching
 # If a managedAcl does not contain any roles with a role prefix, the acl it is matched against will also not contain

--- a/etc/org.opencastproject.external.endpoint.EventsEndpoint.cfg
+++ b/etc/org.opencastproject.external.endpoint.EventsEndpoint.cfg
@@ -27,4 +27,4 @@ property.startTime.pattern=HH:mm
 property.startTime.order=10
 
 # ID of the workflow used to retract published events before deleting them
-retract.workflow.id=delete
+retract.workflow.id=retract-for-deletion

--- a/etc/workflows/delete.yaml
+++ b/etc/workflows/delete.yaml
@@ -1,5 +1,5 @@
-id: delete
-title: Delete
+id: retract-for-deletion
+title: Retract for Deletion
 tags:
   - delete
 description: |-

--- a/etc/workflows/delete.yaml
+++ b/etc/workflows/delete.yaml
@@ -24,6 +24,8 @@ operations:
   - id: snapshot
     exception-handler-workflow: partial-error
     description: Archiving state of retracted recording
+    configurations:
+      - source-tags: nonexisting-tag # only update publication info
 
   - id: cleanup
     fail-on-error: false

--- a/modules/admin-service/src/main/java/org/opencastproject/adminui/impl/AdminUIConfiguration.java
+++ b/modules/admin-service/src/main/java/org/opencastproject/adminui/impl/AdminUIConfiguration.java
@@ -50,7 +50,7 @@ public class AdminUIConfiguration {
   private static final String OPT_MATCH_MANAGED_ACL_ROLE_PREFIXES = "match.managed.acl.role.prefixes";
 
   private static final String DEFAULT_PREVIEW_SUBTYPE = "preview";
-  private static final String DEFAULT_RETRACT_WORKFLOW_ID = "delete";
+  private static final String DEFAULT_RETRACT_WORKFLOW_ID = "retract-for-deletion";
   private static final String DEFAULT_MATCH_MANAGED_ACL_ROLE_PREFIXES = "";
 
   private String previewSubtype = DEFAULT_PREVIEW_SUBTYPE;

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PartialRetractEngageWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PartialRetractEngageWorkflowOperationHandler.java
@@ -22,7 +22,6 @@
 package org.opencastproject.workflow.handler.distribution;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.opencastproject.workflow.handler.distribution.EngagePublicationChannel.CHANNEL_ID;
 
 import org.opencastproject.distribution.api.DownloadDistributionService;
 import org.opencastproject.distribution.api.StreamingDistributionService;
@@ -32,7 +31,6 @@ import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElement;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.mediapackage.MediaPackageException;
-import org.opencastproject.mediapackage.Publication;
 import org.opencastproject.mediapackage.selector.SimpleElementSelector;
 import org.opencastproject.search.api.SearchException;
 import org.opencastproject.search.api.SearchService;
@@ -185,16 +183,6 @@ public class PartialRetractEngageWorkflowOperationHandler extends RetractEngageW
         throw new WorkflowOperationException(e);
       }
     }
-  }
-
-  private Publication findPublicationElement(MediaPackage mediaPackage) throws WorkflowOperationException {
-    for (Publication element  : mediaPackage.getPublications()) {
-      if (CHANNEL_ID.equals(element.getChannel())) {
-        logger.debug("Found the publication element");
-        return element;
-      }
-    }
-    throw new WorkflowOperationException("Unable to find publication element!");
   }
 
   /** Media package must meet these criteria in order to be published. */

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/RetractEngageWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/RetractEngageWorkflowOperationHandler.java
@@ -32,6 +32,7 @@ import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElement;
 import org.opencastproject.mediapackage.Publication;
 import org.opencastproject.search.api.SearchService;
+import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
@@ -160,50 +161,57 @@ public class RetractEngageWorkflowOperationHandler extends AbstractWorkflowOpera
   public WorkflowOperationResult start(WorkflowInstance workflowInstance, JobContext context)
           throws WorkflowOperationException {
     MediaPackage mediaPackage = workflowInstance.getMediaPackage();
-    List<Job> jobs;
     try {
-      MediaPackage searchMediaPackage = null;
-      try {
-        searchMediaPackage = searchService.get(mediaPackage.getIdentifier().toString());
-      } catch (NotFoundException e) {
-        logger.info("The search service doesn't know media package {}", mediaPackage);
-        return createResult(mediaPackage, Action.SKIP);
+      if (removeFromEngage(mediaPackage.getIdentifier().toString()) || removeFromArchive(mediaPackage)) {
+        return createResult(mediaPackage, Action.CONTINUE);
       }
-      logger.info("Retracting media package {} from download/streaming distribution channel", searchMediaPackage);
-      var retractElementIds = Arrays.stream(searchMediaPackage.getElements())
-          .map(MediaPackageElement::getIdentifier)
-          .collect(Collectors.toSet());
-      jobs = retractElements(retractElementIds, searchMediaPackage);
-
-      // Wait for retraction to finish
-      if (!waitForStatus(jobs.toArray(new Job[0])).isSuccess()) {
-        throw new WorkflowOperationException("One of the download/streaming retract job did not complete successfully");
-      }
-
-      logger.debug("Retraction operation complete");
-
-      logger.info("Removing media package {} from the search index", mediaPackage);
-      Job deleteFromSearch = searchService.delete(mediaPackage.getIdentifier().toString());
-      if (!waitForStatus(deleteFromSearch).isSuccess()) {
-        throw new WorkflowOperationException("Removing media package from search did not complete successfully");
-      }
-
-      logger.debug("Remove from search operation complete");
-
-      // Remove publication element
-      logger.info("Removing engage publication element from media package {}", mediaPackage);
-      Publication[] publications = mediaPackage.getPublications();
-      for (Publication publication : publications) {
-        if (CHANNEL_ID.equals(publication.getChannel())) {
-          mediaPackage.remove(publication);
-          logger.debug("Remove engage publication element '{}' complete", publication);
-        }
-      }
-
-      return createResult(mediaPackage, Action.CONTINUE);
-    } catch (Throwable t) {
+      return createResult(mediaPackage, Action.SKIP);
+    }
+    catch (Throwable t) {
       throw new WorkflowOperationException(t);
     }
   }
 
+  private boolean removeFromEngage(String mpId) throws UnauthorizedException, NotFoundException,
+          WorkflowOperationException, DistributionException {
+    MediaPackage searchMediaPackage;
+    try {
+      searchMediaPackage = searchService.get(mpId);
+    } catch (NotFoundException e) {
+      logger.info("The search service doesn't know media package {}", mpId);
+      return false;
+    }
+
+    logger.info("Retracting media package {} from download/streaming distribution channel", searchMediaPackage);
+    var retractElementIds = Arrays.stream(searchMediaPackage.getElements())
+        .map(MediaPackageElement::getIdentifier)
+        .collect(Collectors.toSet());
+    List<Job> jobs = retractElements(retractElementIds, searchMediaPackage);
+    if (!waitForStatus(jobs.toArray(new Job[0])).isSuccess()) {
+      throw new WorkflowOperationException("One of the download/streaming retract job did not complete successfully");
+    }
+    logger.debug("Retraction operation complete");
+
+    logger.info("Removing media package {} from the search index", mpId);
+    Job deleteFromSearch = searchService.delete(mpId);
+    if (!waitForStatus(deleteFromSearch).isSuccess()) {
+      throw new WorkflowOperationException("Removing media package from search did not complete successfully");
+    }
+    logger.debug("Remove from search operation complete");
+    return true;
+  }
+
+  private boolean removeFromArchive(MediaPackage mediaPackage) {
+    // Remove publication element
+    logger.info("Removing engage publication element from media package {}", mediaPackage);
+    Publication[] publications = mediaPackage.getPublications();
+    for (Publication publication : publications) {
+      if (CHANNEL_ID.equals(publication.getChannel())) {
+        mediaPackage.remove(publication);
+        logger.debug("Remove engage publication element '{}' complete", publication);
+        return true;
+      }
+    }
+    return false;
+  }
 }

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -226,7 +226,7 @@ public class EventsEndpoint implements ManagedService {
   private static final String RETRACT_WORKFLOW = "retract.workflow.id";
 
   /** Default ID of the workflow used to retract published events */
-  private static final String DEFAULT_RETRACT_WORKFLOW = "delete";
+  private static final String DEFAULT_RETRACT_WORKFLOW = "retract-for-deletion";
 
   /** The logging facility */
   private static final Logger logger = LoggerFactory.getLogger(EventsEndpoint.class);

--- a/modules/graphql/src/main/resources/OSGI-INF/configurator/graphql.json
+++ b/modules/graphql/src/main/resources/OSGI-INF/configurator/graphql.json
@@ -3,7 +3,7 @@
   ":configurator:symbolic-name" : "org.opencastproject.graphql.config",
   "org.opencastproject.graphql": {
     "event.preview.subtype:String": "preview",
-    "event.retract.workflow.id:String": "delete"
+    "event.retract.workflow.id:String": "retract-for-deletion"
   },
   "org.opencastproject.graphql.execution.ExecutionService": {
     "execution.max.query.complexity:Integer": 1000,

--- a/modules/security-jwt/pom.xml
+++ b/modules/security-jwt/pom.xml
@@ -43,10 +43,6 @@
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
-      <artifactId>spring-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
       <artifactId>spring-expression</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
How it started: Trying to delete an event.
How it's going: ...

The main problem was that the snapshot in the delete workflow failed bc assets were missing on disk and could not be hardlinked to. Since we want to delete anyway, we don't need to include them in this snapshot imo. 

Then deletion got stuck running the workflow bc the AssetManager had not been properly updated and still thought the engage publication existed, but retraction was skipped bc the mediapackage was no longer in search.

The rest is small docs changes and a duplicate dependency in a pom. **However**, this also renames the delete-workflow to `retract-for-deletion` to avoid confusion bc the delete workflow doesn't actually delete the event. This might be controversial. Thoughts?