### PR TITLE
Return "bad request" for bad sort param for /admin-ng/services.json

### DIFF
--- a/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/ServicesEndpoint.java
+++ b/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/ServicesEndpoint.java
@@ -21,6 +21,7 @@
 
 package org.opencastproject.adminui.endpoint;
 
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static org.opencastproject.index.service.util.JSONUtils.safeString;
 import static org.opencastproject.util.doc.rest.RestParameter.Type.STRING;
 
@@ -30,6 +31,7 @@ import org.opencastproject.serviceregistry.api.HostRegistration;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
 import org.opencastproject.serviceregistry.api.ServiceState;
 import org.opencastproject.serviceregistry.api.ServiceStatistics;
+import org.opencastproject.util.RestUtil;
 import org.opencastproject.util.SmartIterator;
 import org.opencastproject.util.doc.rest.RestParameter;
 import org.opencastproject.util.doc.rest.RestQuery;
@@ -114,7 +116,8 @@ public class ServicesEndpoint {
       },
       responses = {
           @RestResponse(description = "Returns the list of services from Opencast",
-              responseCode = HttpServletResponse.SC_OK)
+              responseCode = HttpServletResponse.SC_OK),
+          @RestResponse(responseCode = SC_BAD_REQUEST, description = "If sorting failed")
       },
       returnDescription = "The list of services")
   public Response getServices(@QueryParam("limit") final int limit, @QueryParam("offset") final int offset,
@@ -199,7 +202,9 @@ public class ServicesEndpoint {
                   sortCriterion.getFieldName(),
                   sortCriterion.getOrder() == Order.Ascending));
         } catch (Exception ex) {
-          logger.warn("Failed to sort services collection.", ex);
+          final String msg = String.format("Failed to sort services collection with %s", sortOpt.get());
+          logger.warn(msg, ex);
+          return RestUtil.R.badRequest(msg);
         }
       }
     }


### PR DESCRIPTION
Fixes  [#1135](https://github.com/opencast/admin-interface/issues/1135)

Instead of just logging a warning about it, why don't we actually return a bad request instead. I don't think we want sorting to fail silently.

### How to test this patch

Fire some requests against the endpoint.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
