### PR TITLE
Enforce absense of ACL deny rules

### DIFF
--- a/modules/authorization-manager/src/test/java/org/opencastproject/authorization/xacml/manager/endpoint/OsgiAclServiceRestEndpointTest.java
+++ b/modules/authorization-manager/src/test/java/org/opencastproject/authorization/xacml/manager/endpoint/OsgiAclServiceRestEndpointTest.java
@@ -216,47 +216,104 @@ public class OsgiAclServiceRestEndpointTest {
 
     // GET
     // Test with existing acl Id
-    given().pathParams("aclId", publicAclId).expect().statusCode(OK).body("acl.ace[0].allow", equalTo(true))
-        .body("acl.ace[0].action", equalTo("read")).body("acl.ace[0].role", equalTo("SERIES_10_INSTRUCTOR")).when()
-        .get(host("/acl/{aclId}"));
+    given()
+        .pathParams("aclId", publicAclId)
+        .expect()
+        .statusCode(OK)
+        .body("acl.ace[0].allow", equalTo(true))
+        .body("acl.ace[0].action", equalTo("read"))
+        .body("acl.ace[0].role", equalTo("SERIES_10_INSTRUCTOR"))
+        .when().get(host("/acl/{aclId}"));
 
     // Test with false acl Id
-    given().pathParams("aclId", "reddfsdffsd").expect().statusCode(NOT_FOUND).when().get(host("/acl/{aclId}"));
+    given()
+        .pathParams("aclId", "reddfsdffsd")
+        .expect()
+        .statusCode(NOT_FOUND)
+        .when().get(host("/acl/{aclId}"));
     // Get all acls
-    given().log().all().expect().statusCode(OK).log().all().body("[0].name", equalTo("Public"))
-        .body("[0].acl.ace[0].action", equalTo("read")).body("[0].acl.ace[0].allow", equalTo(true))
-        .body("[0].acl.ace[0].role", equalTo("SERIES_10_INSTRUCTOR")).body("[1].name", equalTo("Private"))
-        .body("[1].acl.ace[0].action", equalTo("read")).body("[1].acl.ace[0].allow", equalTo(false))
-        .body("[1].acl.ace[0].role", equalTo("SERIES_10_INSTRUCTOR")).when().get(host("/acl/acls.json"));
+    given().log().all().expect().statusCode(OK).log().all()
+        .body("[0].name", equalTo("Public"))
+        .body("[0].acl.ace[0].action", equalTo("read"))
+        .body("[0].acl.ace[0].allow", equalTo(true))
+        .body("[0].acl.ace[0].role", equalTo("SERIES_10_INSTRUCTOR"))
+        .body("[1].name", equalTo("Private"))
+        .body("[1].acl.ace[0].action", equalTo("read"))
+        .body("[1].acl.ace[0].allow", equalTo(false))
+        .body("[1].acl.ace[0].role", equalTo("SERIES_10_INSTRUCTOR"))
+        .when().get(host("/acl/acls.json"));
 
     // POST
     // With a valid ACL
     String aclName = "PublicWrite";
-    Long publicAclWriteId = extractAclId(given().formParam("name", aclName).formParam("acl", publicAclWrite).expect()
-        .body("name", equalTo(aclName)).body("acl.ace[0].action", equalTo("write"))
-        .body("acl.ace[0].allow", equalTo(true)).body("acl.ace[0].role", equalTo("SERIES_10_INSTRUCTOR"))
-        .statusCode(OK).when().post(host("/acl")));
+    Long publicAclWriteId = extractAclId(
+        given()
+            .formParam("name", aclName)
+            .formParam("acl", publicAclWrite)
+            .expect()
+            .body("name", equalTo(aclName)).body("acl.ace[0].action", equalTo("write"))
+            .body("acl.ace[0].allow", equalTo(true))
+            .body("acl.ace[0].role", equalTo("SERIES_10_INSTRUCTOR"))
+            .statusCode(OK)
+            .when().post(host("/acl"))
+        );
     // Try to publish one with the same name
-    given().formParam("name", aclName).formParam("acl", publicAclWrite).expect().statusCode(CONFLICT).when()
-        .post(host("/acl"));
+    given()
+        .formParam("name", aclName)
+        .formParam("acl", publicAclWrite)
+        .expect()
+        .statusCode(CONFLICT)
+        .when().post(host("/acl"));
     // Post one with a wrong acl
-    given().formParam("name", "Wrong").formParam("acl", "test").expect().statusCode(BAD_REQUEST).when()
-        .post(host("/acl"));
+    given()
+        .formParam("name", "Wrong")
+        .formParam("acl", "test")
+        .expect()
+        .statusCode(BAD_REQUEST)
+        .when().post(host("/acl"));
 
     // PUT
-    given().pathParam("aclId", publicAclWriteId).formParam("name", aclName).formParam("acl", publicAclWrite2).expect()
-        .body("name", equalTo(aclName)).body("acl.ace[0].action", equalTo("write"))
-        .body("acl.ace[0].allow", equalTo(false)).body("acl.ace[0].role", equalTo("SERIES_10_INSTRUCTOR"))
-        .statusCode(OK).when().put(host("/acl/{aclId}"));
-    given().pathParam("aclId", publicAclWriteId).formParam("name", aclName).formParam("acl", "test").expect()
-        .statusCode(BAD_REQUEST).when().put(host("/acl/{aclId}"));
-    given().pathParam("aclId", "wrong_id").formParam("name", aclName).formParam("acl", "test").expect()
-        .statusCode(NOT_FOUND).when().put(host("/acl/{aclId}"));
+    given()
+        .pathParam("aclId", publicAclWriteId).formParam("name", aclName)
+        .formParam("acl", publicAclWrite2)
+        .expect()
+        .body("name", equalTo(aclName))
+        .body("acl.ace[0].action", equalTo("write"))
+        .body("acl.ace[0].allow", equalTo(false))
+        .body("acl.ace[0].role", equalTo("SERIES_10_INSTRUCTOR"))
+        .statusCode(OK)
+        .when().put(host("/acl/{aclId}"));
+    given()
+        .pathParam("aclId", publicAclWriteId)
+        .formParam("name", aclName)
+        .formParam("acl", "test")
+        .expect()
+        .statusCode(BAD_REQUEST)
+        .when().put(host("/acl/{aclId}"));
+    given()
+        .pathParam("aclId", "wrong_id")
+        .formParam("name", aclName)
+        .formParam("acl", "test")
+        .expect()
+        .statusCode(NOT_FOUND)
+        .when().put(host("/acl/{aclId}"));
 
     // DELETE
-    given().pathParam("aclId", "wrong_id").expect().statusCode(NOT_FOUND).when().delete(host("/acl/{aclId}"));
-    given().pathParam("aclId", publicAclWriteId).expect().statusCode(NO_CONTENT).when().delete(host("/acl/{aclId}"));
-    given().pathParams("aclId", publicAclWriteId).expect().statusCode(NOT_FOUND).when().get(host("/acl/{aclId}"));
+    given()
+        .pathParam("aclId", "wrong_id")
+        .expect()
+        .statusCode(NOT_FOUND)
+        .when().delete(host("/acl/{aclId}"));
+    given()
+        .pathParam("aclId", publicAclWriteId)
+        .expect()
+        .statusCode(NO_CONTENT)
+        .when().delete(host("/acl/{aclId}"));
+    given()
+        .pathParams("aclId", publicAclWriteId)
+        .expect()
+        .statusCode(NOT_FOUND)
+        .when().get(host("/acl/{aclId}"));
   }
 
   // --

--- a/modules/authorization-manager/src/test/java/org/opencastproject/authorization/xacml/manager/endpoint/OsgiAclServiceRestEndpointTest.java
+++ b/modules/authorization-manager/src/test/java/org/opencastproject/authorization/xacml/manager/endpoint/OsgiAclServiceRestEndpointTest.java
@@ -38,6 +38,8 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.Collections;
+
 import javax.ws.rs.core.Response;
 
 public class OsgiAclServiceRestEndpointTest {
@@ -238,9 +240,7 @@ public class OsgiAclServiceRestEndpointTest {
         .body("[0].acl.ace[0].allow", equalTo(true))
         .body("[0].acl.ace[0].role", equalTo("SERIES_10_INSTRUCTOR"))
         .body("[1].name", equalTo("Private"))
-        .body("[1].acl.ace[0].action", equalTo("read"))
-        .body("[1].acl.ace[0].allow", equalTo(false))
-        .body("[1].acl.ace[0].role", equalTo("SERIES_10_INSTRUCTOR"))
+        .body("[1].ace", equalTo(null))
         .when().get(host("/acl/acls.json"));
 
     // POST
@@ -278,9 +278,7 @@ public class OsgiAclServiceRestEndpointTest {
         .formParam("acl", publicAclWrite2)
         .expect()
         .body("name", equalTo(aclName))
-        .body("acl.ace[0].action", equalTo("write"))
-        .body("acl.ace[0].allow", equalTo(false))
-        .body("acl.ace[0].role", equalTo("SERIES_10_INSTRUCTOR"))
+        .body("acl.ace", equalTo(Collections.emptyList()))
         .statusCode(OK)
         .when().put(host("/acl/{aclId}"));
     given()

--- a/modules/common/src/main/java/org/opencastproject/security/api/AccessControlParser.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/AccessControlParser.java
@@ -93,12 +93,16 @@ public final class AccessControlParser {
    *           if the format is invalid
    */
   public static AccessControlList parseAcl(String serializedForm) throws IOException, AccessControlParsingException {
+    AccessControlList parsed = null;
     // Determine whether to parse this as XML or JSON
     if (serializedForm.startsWith("{")) {
-      return parseJson(serializedForm);
+      parsed = parseJson(serializedForm);
     } else {
-      return parseXml(IOUtils.toInputStream(serializedForm, ENCODING));
+      parsed = parseXml(IOUtils.toInputStream(serializedForm, ENCODING));
     }
+    //Filter the parsed list of anything that's not an allow rule.  This matches the behaviour from the API endpoints.
+    parsed = new AccessControlList(parsed.getEntries().stream().filter(AccessControlEntry::isAllow).toList());
+    return parsed;
   }
 
   /** Same like {@link #parseAcl(String)} but throws runtime exceptions in case of an error. */

--- a/modules/common/src/test/java/org/opencastproject/security/api/AccessControlParserTest.java
+++ b/modules/common/src/test/java/org/opencastproject/security/api/AccessControlParserTest.java
@@ -85,4 +85,23 @@ public class AccessControlParserTest {
     }
   }
 
+  @Test
+  public void testDenyRuleParsing() throws Exception {
+    AccessControlEntry denyRule = new AccessControlEntry("ANY", "READ", false);
+    AccessControlList deny = new AccessControlList(denyRule);
+
+    acl.merge(deny);
+
+    //Ensure that after the merge the deny rule is still present
+    Assert.assertTrue(acl.getEntries().contains(denyRule));
+
+    String json = AccessControlParser.toJson(acl);
+    AccessControlList jsonAfter =  AccessControlParser.parseAcl(json);
+    Assert.assertFalse(jsonAfter.getEntries().stream().anyMatch(e -> e.getAction().equals("DENY")));
+
+    String xml = AccessControlParser.toXml(acl);
+    AccessControlList xmlAfter =  AccessControlParser.parseAcl(json);
+    Assert.assertFalse(xmlAfter.getEntries().stream().anyMatch(e -> e.getAction().equals("DENY")));
+  }
+
 }


### PR DESCRIPTION
This PR enforces a lack of ACL deny rules by filtering them out of the final ACL.  This matches the behaviour in the api endpoints.

Open question is whether this is the *correct* behaviour, because I would be somewhat annoyed if I were trying to use deny rules and they were silently dropped...

Targetting `r/19.x` because imo this is a bug, but happy to punt this into `r/20.x` if there's complaints.

Fixes: #7718

### How to test this patch

Try an ACL like `{"id": 557,"name": "test","organizationId": "mh_default_org","acl": {"ace":[{"role": "ROLE_USER","action": "read","allow": false}]}}` in POSTs `/acl-manager/acl` and `/admin-ng/acl/`.

### AI Usage

N/A

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] ~include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)~
