### PR TITLE
Fix POST /api/playlists returning 405 without a trailing path segment

### DIFF
--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -271,6 +271,7 @@
     <sec:intercept-url pattern="/api/clearIndex" method="POST" access="hasRole('ROLE_ADMIN')"/>
     <sec:intercept-url pattern="/api/recreateIndex" method="POST" access="hasRole('ROLE_ADMIN')"/>
     <sec:intercept-url pattern="/api/recreateIndex/*" method="POST" access="hasRole('ROLE_ADMIN')"/>
+    <sec:intercept-url pattern="/api/playlists" method="POST" access="hasAnyRole('ROLE_ADMIN', 'ROLE_API_PLAYLISTS_CREATE', 'ROLE_API_PLAYLISTS_EDIT')" />
     <sec:intercept-url pattern="/api/playlists/*" method="POST" access="hasAnyRole('ROLE_ADMIN', 'ROLE_API_PLAYLISTS_CREATE', 'ROLE_API_PLAYLISTS_EDIT')" />
     <sec:intercept-url pattern="/api/playlists/*/entries" method="POST" access="hasAnyRole('ROLE_ADMIN', 'ROLE_API_PLAYLISTS_CREATE', 'ROLE_API_PLAYLISTS_EDIT')" />
     <sec:intercept-url pattern="/api/series" method="POST" access="hasAnyRole('ROLE_ADMIN', 'ROLE_API_SERIES_CREATE')" />


### PR DESCRIPTION
This PR was written primarily by Claude Code; I reviewed the change before submitting.

## Problem

`POST /api/playlists` (no trailing path segment) returns `405 Method Not Allowed`, even with valid credentials. As diagnosed in the issue, `PlaylistsEndpoint#createAsJson` is mapped to the bare path (`@Path("/api/playlists")` on the class, `@POST @Path("")` on the method), but the Spring Security configuration in `etc/security/mh_default_org.xml` only had a rule for `/api/playlists/*` (one or more path segments), not the exact `/api/playlists` path. The request is rejected by Spring Security before it ever reaches the servlet.

## Fix

Add the missing `/api/playlists` POST rule, using the same role set as the existing `/api/playlists/*` POST rule (both ultimately guard the same `createAsJson` method). This mirrors the existing precedent for `GET /api/playlists`, which already has both the exact-path and wildcard variants defined side by side (lines 234-235).

## Testing

This is a declarative Spring Security URL-pattern fix, not a Java code change, so it isn't amenable to the existing JUnit tests (which exercise `PlaylistsEndpoint`'s methods directly, not the security interceptor chain). I verified the fix is consistent with Spring's Ant-style path matching semantics (`/api/playlists/*` requires at least one additional path segment and does not match the bare path) and with the established dual-rule pattern already used for the GET endpoint in this same file.

Fixes #6828