### PR TITLE
Fix outdated developer quick-start docs and surface Installation in nav

### DIFF
--- a/docs/guides/admin/mkdocs.yml
+++ b/docs/guides/admin/mkdocs.yml
@@ -37,6 +37,22 @@ extra:
 nav:
   - Home: "index.md"
   - Version Support: "version-support.md"
+  - Installation:
+      - Overview: "installation/index.md"
+      - Hardware Requirements: installation/server-requirements.md
+      - Java Versions: installation/java-version.md
+      - Installation from Package:
+          - Debian/Ubuntu: "installation/debs.md"
+          - RHEL/Rocky/CentOS: "installation/rpm-el.md"
+      - Installation with Docker:
+          - Testing Locally: "installation/docker-local.md"
+      - Installation from Source:
+          - Linux: "installation/source-linux.md"
+          - macOS: "installation/source-macosx.md"
+      - Installation via script:
+          - Ansible: "installation/ansible.md"
+      - Multiple Servers: "installation/multiple-servers.md"
+      - Prerelease Testing: "installation/prereleases.md"
   - Release Notes: "releasenotes.md"
   - Upgrade Guide: "upgrade.md"
   - Registration: "registration.md"
@@ -61,22 +77,6 @@ nav:
           - Opencast 4: "changelog/older-versions/opencast-4.md"
           - Opencast 3: "changelog/older-versions/opencast-3.md"
           - Opencast 2.x: "changelog/older-versions/opencast-2.x.md"
-  - Installation:
-      - Overview: "installation/index.md"
-      - Hardware Requirements: installation/server-requirements.md
-      - Java Versions: installation/java-version.md
-      - Installation from Package:
-          - Debian/Ubuntu: "installation/debs.md"
-          - RHEL/Rocky/CentOS: "installation/rpm-el.md"
-      - Installation with Docker:
-          - Testing Locally: "installation/docker-local.md"
-      - Installation from Source:
-          - Linux: "installation/source-linux.md"
-          - macOS: "installation/source-macosx.md"
-      - Installation via script:
-          - Ansible: "installation/ansible.md"
-      - Multiple Servers: "installation/multiple-servers.md"
-      - Prerelease Testing: "installation/prereleases.md"
   - Configuration:
       - Overview: "configuration/index.md"
       - Basic: "configuration/basic.md"

--- a/docs/guides/developer/docs/develop/development-tips.md
+++ b/docs/guides/developer/docs/develop/development-tips.md
@@ -13,7 +13,7 @@ Every development environment has its quirks, so here are a few which have been 
 * If your IDE stubbornly refuses to acknowledge that a class exists, even when you're sure it's there, try closing your
   IDE, then running `git clean -fdx`, then building.  This will ensure everything in your clone is up-to-date.  Also
   ensure you find your project workspace to make sure your IDE isn't keeping a cache of things.
-* Check if you have selected the correct java version in your IDE. Opencast requires Java 11 or 17, but your IDE might have
+* Check if you have selected the correct java version in your IDE. Opencast requires Java 21, but your IDE might have
   selected a different version.
 * Absolute worst case, remove your Maven cache (typically ~/.m2), and possibly your Node cache (typically ~/.npm) and
   repeat the above steps.  This is completely starting from scratch.
@@ -73,7 +73,7 @@ Specific development environments tips
 --------------------------------------
 
 
-### Ubuntu (Using JDK 11)
+### Ubuntu (Using JDK 21)
 
 #### Update System
 
@@ -85,7 +85,7 @@ $ apt upgrade -y
 #### Install Packages via APT
 
 ```sh
-$ apt install -y git openjdk-17-jdk maven gcc g++ build-essential cmake curl hunspell synfig ffmpeg
+$ apt install -y git openjdk-21-jdk maven gcc g++ build-essential cmake curl hunspell synfig ffmpeg
 ```
 
 #### Install NodeJS (optional)
@@ -127,9 +127,9 @@ $ update-alternatives --config java
 
 Try to install all updates via the App Store or system settings.
 
-#### Java JDK 11
+#### Java JDK 21
 
-Install the JDK 11
+Install the JDK 21
 It's recommended to use [SDKMAN](https://sdkman.io/) to install and manage Java versions.
 
 #### XCode

--- a/docs/guides/developer/docs/develop/setup-opencast-for-develop.md
+++ b/docs/guides/developer/docs/develop/setup-opencast-for-develop.md
@@ -16,6 +16,7 @@ Warning: This probably won´t work with Windows.
 ```sh
 $ git clone https://github.com/opencast/opencast.git
 $ cd opencast
+$ git submodule update --init --recursive
 $ ./mvnw clean install -Pdev
 $ cd build/opencast-dist-develop-*
 $ ./bin/start-opencast
@@ -41,6 +42,16 @@ Cloning the Git repository:
 $ git clone https://github.com/opencast/opencast.git
 ```
 
+Some frontend modules (`admin`, `editor` and `studio`) are included as Git submodules. They need to be initialized
+before building, otherwise the build fails with an error about missing child modules:
+
+```sh
+$ git submodule update --init --recursive
+```
+
+For more details on working with submodules, see the
+[development process documentation](../participate/development-process.md#git-submodules).
+
 
 ## Install Dependencies
 
@@ -49,7 +60,7 @@ Please make sure to install the following dependencies.
 
 Required:
 
-    java-17-openjdk-devel
+    java-21-openjdk-devel
     ffmpeg >= 3.2.4
     maven >= 3.6
     python
@@ -61,7 +72,7 @@ Required:
 
 Required as a service for running Opencast:
 
-    elasticsearch = 7.9.x and analysis-icu plugin
+    OpenSearch 1.x and analysis-icu plugin
 
 Required for some services. Some tests may be skipped and some features
 may not be usable if they are not installed. Hence, it's generally a good idea to
@@ -192,7 +203,7 @@ This is especially useful when building inside a container:
 
 ### JDK Version
 
-Some IDEs attempt to use the most recent version of the JDK. Make sure that your IDE uses JDK 11.
+Some IDEs attempt to use the most recent version of the JDK. Make sure that your IDE uses JDK 21.
 
 ## Recommended Development Tools
 
@@ -214,7 +225,7 @@ Follow the next steps, if you want to import opencast correctly
 - Search for projects recursively
 - Uncheck all listed profiles
 - Check all projects to import
-- Select JDK 17, it should be somewhere around `/usr/lib/jvm/java-17-openjdk` depending on your current system
+- Select JDK 21, it should be somewhere around `/usr/lib/jvm/java-21-openjdk` depending on your current system
 
 Now Idea should import the projects, it could take some time, you can make it faster by following [this](#slow-intellij-idea-fix).
 


### PR DESCRIPTION
This addresses part of #7457 by fixing the parts of the install documentation that are incorrect or hard to find. It
does **not** add the new adopter quick-start page also requested there, since that depends on the documentation
restructure in #7413 (still an open, conflicting draft).

Following the developer setup guide from scratch on a clean machine, each of these caused a first build/run to fail or
mislead:

- **Java version** — the docs listed Java 17 (and Java 11 in several places), but Opencast 17 and newer require Java 21
  per `installation/java-version.md`. Building on Java 17 fails with `release version 21 not supported`.
- **Missing submodule step** — the quick-start went straight from `git clone` to the Maven build, which aborts
  immediately because the `admin`, `editor` and `studio` submodules are not initialized. Added the required
  `git submodule update --init --recursive` step, with a pointer to the existing submodule documentation.
- **Search service** — the developer docs listed Elasticsearch 7.9.x; the admin installation docs require
  OpenSearch 1.x. Aligned the developer docs with that.
- **Findability** — the Installation section was listed below the release notes, upgrade guide, registration and the
  full changelog history. Moved it directly under Version Support.

The two concerns are kept in separate commits so the objective corrections and the navigation change can be reviewed
independently.

### How to test this patch

- `cd docs/guides && npm ci && npm test` — markdownlint passes.
- Build the admin documentation with mkdocs and confirm the navigation now shows **Installation** directly under
  **Version Support**.

The instructions themselves were verified end to end: fresh clone, `git submodule update --init --recursive`, install
Java 21 + ffmpeg + a search backend, `./mvnw clean install -Pdev`, and Opencast started successfully.

### AI Usage

This pull request was prepared with the assistance of an AI coding agent (Anthropic Claude, Opus 4.8) driven
interactively. The AI was used to work through the developer setup on a clean macOS machine and identify where the
existing instructions failed, to locate the authoritative version information in the repository
(`installation/java-version.md`, the admin installation guides, the root `pom.xml`), and to draft the documentation
edits and this description. All changes were reviewed by a human before submission. This is a documentation-only change;
no functional code was modified.

### Your pull request should…

* [x] have a concise title
* [x] be against the correct branch (`develop`)
* [x] include appropriate documentation
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] have proper commit messages (title and body) for all commits
* [ ] include a release note — not applicable; this is a documentation fix, not a feature
