### PR TITLE
Changing `output-background` color code in partial-theming-watermark WF to a string

### DIFF
--- a/etc/workflows/partial-theming-watermark.yaml
+++ b/etc/workflows/partial-theming-watermark.yaml
@@ -20,7 +20,7 @@ operations:
       - encoding-profile: composite.http
       - target-flavor: presenter/trimmed
       - output-resolution: lower
-      - output-background: 0x000000FF
+      - output-background: '0x000000FF'
       - layout-single: |-
           {"horizontalCoverage":1.0,"anchorOffset":{"referring":{"left":1.0,"top":0.0},"reference":{"left":1.0,"top":0.0},"offset":{"x":0,"y":0}}};
                     ${theme_watermark_layout_variable}
@@ -36,7 +36,7 @@ operations:
       - encoding-profile: composite.http
       - target-flavor: presentation/trimmed
       - output-resolution: lower
-      - output-background: 0x000000FF
+      - output-background: '0x000000FF'
       - layout-single: |-
           {"horizontalCoverage":1.0,"anchorOffset":{"referring":{"left":1.0,"top":0.0},"reference":{"left":1.0,"top":0.0},"offset":{"x":0,"y":0}}};
                     ${theme_watermark_layout_variable}


### PR DESCRIPTION
In the composite step of the partial-theming-watermark WF, the color code has to be defined as a string. Setting the value to a hex value like 0x000000FF leads to ffmpeg errors such as these:

```
...
INFO  | (EncoderEngine:495) - [Parsed_pad_1 @ 0x55744f9d0c80] Invalid 0xRRGGBB[AA] color string: '255'
INFO  | (EncoderEngine:495) - [Parsed_pad_1 @ 0x55744f9d0c80] Unable to parse option value "255" as color
INFO  | (EncoderEngine:495) - Error applying option 'color' to filter 'pad': Invalid argument
INFO  | (EncoderEngine:495) - Error opening output file /srv/opencast/workspace/mediapackage/909d5800-1d60-4de9-9efb-6e346e14f48a/1e6cac7f-7cbc-4445-9242-6d45abaa46d4/cc_ink_stamp_anim
ation__1080p__f7fc9977-21c3-4e02-a575-94b0433953cb-compound.mkv.
INFO  | (EncoderEngine:495) - Error opening output files: Invalid argument
WARN  | (EncoderEngine:245) - Error while encoding {video=/srv/opencast/workspace/mediapackage/909d5800-1d60-4de9-9efb-6e346e14f48a/1e6cac7f-7cbc-4445-9242-6d45abaa46d4/cc_ink_stamp_an
imation__1080p_.mp4}  using profile 'composite.http'
...
```

This pull request targets the legacy branch because watermark theming has probably not been working since the introduction of the YAML-WF.

### How to test this patch

- activate theming for Opencast
- create a branding with watermark
- create a series that uses the branding with the watermark
- upload a video to that series
- check that the video is published with the watermark


### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
