### PR TITLE
Fix tag operation by adding missing callback

### DIFF
--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TagWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TagWorkflowOperationHandler.java
@@ -36,6 +36,7 @@ import org.opencastproject.workflow.api.WorkflowOperationHandler;
 import org.opencastproject.workflow.api.WorkflowOperationInstance;
 import org.opencastproject.workflow.api.WorkflowOperationResult;
 import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
+import org.opencastproject.workspace.api.Workspace;
 
 import org.apache.commons.lang3.BooleanUtils;
 import org.osgi.service.component.annotations.Component;
@@ -78,6 +79,17 @@ public class TagWorkflowOperationHandler extends AbstractWorkflowOperationHandle
 
   /** Name of the configuration option that provides the copy boolean we are looking for */
   public static final String COPY_PROPERTY = "copy";
+
+  /**
+   * Callback for the OSGi environment to set the workspace reference.
+   *
+   * @param workspace
+   *          the workspace
+   */
+  @Reference
+  protected void setWorkspace(Workspace workspace) {
+    this.workspace = workspace;
+  }
 
   /**
    * {@inheritDoc}


### PR DESCRIPTION
This PR fixes https://github.com/opencast/opencast/issues/7702 by adding a missing OSGi callback method. 

### How to test this patch

Use OC version 19.5 or higher and try to run a workflow which uses a tag operation with the configuration option `copy: true` . If the operation works without issues and creates the copy, this patch works as intended. 

### AI Usage
N/A

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
