### PR TITLE
Allow configuring flavor type for configure-by-dcterm

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/configure-by-dcterm-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/configure-by-dcterm-woh.md
@@ -20,17 +20,23 @@ Parameter Table
 
 Tags and flavors can be used in combination.
 
-|configuration keys|example|description|default value|
-|------------------|-------|-----------|-------------|
-|dccatalog         |"episode" or "series"|the type of catalog in which to search for `dcterm`|EMPTY|
-|dcterm            |"creator"            |the name of the Dublin Core term which to check|EMPTY|
-|match-value       |"Joe Bloggs"         |the Dublin Core term value to check for|EMPTY|
-|default-value     |"Anon"               |the implied value if the dubincore term is not present in the catalog|EMPTY|
-|*configProperty*  |true / false         |a configuration property and the value it will be given if a match is found|EMPTY|
+| configuration keys | example               | description                                                                 | default value |
+|--------------------|-----------------------|-----------------------------------------------------------------------------|---------------|
+| dccatalog          | "episode" or "series" | the subtype of catalog in which to search for `dcterm`                      | EMPTY         |
+| dccatalog-type     | "dublincore"          | the type of catalog in which to search for `dcterm`                         | "dublincore"  |
+| dcterm             | "creator"             | the name of the Dublin Core term which to check                             | EMPTY         |
+| match-value        | "Joe Bloggs"          | the Dublin Core term value to check for                                     | EMPTY         |
+| default-value      | "Anon"                | the implied value if the dubincore term is not present in the catalog       | EMPTY         |
+| *configProperty*   | true / false          | a configuration property and the value it will be given if a match is found | EMPTY         |
 
 ### dccatalog
 
-The type of Dublin Core catalog in which to look for the `dcterm`. This will usually be `episode` or `series`.
+The flavor subtype of Dublin Core catalog in which to look for the `dcterm`. This will usually be `episode` or `series`.
+
+### dccatalog
+
+The flavor type of Dublin Core catalog in which to look for the `dcterm`. This will usually be `episode` or `series`.
+Will default to 'dublincore'.
 
 ### dcterm
 

--- a/docs/guides/admin/docs/workflowoperationhandlers/configure-by-dcterm-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/configure-by-dcterm-woh.md
@@ -33,9 +33,9 @@ Tags and flavors can be used in combination.
 
 The flavor subtype of Dublin Core catalog in which to look for the `dcterm`. This will usually be `episode` or `series`.
 
-### dccatalog
+### dccatalog-type
 
-The flavor type of Dublin Core catalog in which to look for the `dcterm`. This will usually be `episode` or `series`.
+The flavor type of Dublin Core catalog in which to look for the `dcterm`. This will usually be `dublincore`.
 Will default to 'dublincore'.
 
 ### dcterm

--- a/docs/guides/admin/docs/workflowoperationhandlers/configure-by-dcterm-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/configure-by-dcterm-woh.md
@@ -20,14 +20,14 @@ Parameter Table
 
 Tags and flavors can be used in combination.
 
-| configuration keys | example               | description                                                                 | default value |
-|--------------------|-----------------------|-----------------------------------------------------------------------------|---------------|
-| dccatalog          | "episode" or "series" | the subtype of catalog in which to search for `dcterm`                      | EMPTY         |
-| dccatalog-type     | "dublincore"          | the type of catalog in which to search for `dcterm`                         | "dublincore"  |
-| dcterm             | "creator"             | the name of the Dublin Core term which to check                             | EMPTY         |
-| match-value        | "Joe Bloggs"          | the Dublin Core term value to check for                                     | EMPTY         |
-| default-value      | "Anon"                | the implied value if the dubincore term is not present in the catalog       | EMPTY         |
-| *configProperty*   | true / false          | a configuration property and the value it will be given if a match is found | EMPTY         |
+| configuration keys | example                              | description                                                                                        | default value |
+|--------------------|--------------------------------------|----------------------------------------------------------------------------------------------------|---------------|
+| dccatalog          | "episode" or "series"                | the subtype of catalog in which to search for `dcterm`                                             | EMPTY         |
+| dccatalog-type     | "dublincore"                         | the type of catalog in which to search for `dcterm`                                                | "dublincore"  |
+| dcterm             | "{http://purl.org/dc/terms/}creator" | the XML Expanded Name, consists of a namespace and the name of the Dublin Core term which to check | EMPTY         |
+| match-value        | "Joe Bloggs"                         | the Dublin Core term value to check for                                                            | EMPTY         |
+| default-value      | "Anon"                               | the implied value if the dubincore term is not present in the catalog                              | EMPTY         |
+| *configProperty*   | true / false                         | a configuration property and the value it will be given if a match is found                        | EMPTY         |
 
 ### dccatalog
 
@@ -40,8 +40,10 @@ Will default to 'dublincore'.
 
 ### dcterm
 
-The name of the Dublin Core term to look for in the `dccatalog`. This could be one of the terms set by Opencast or an
-additional term adding to the catalog.
+The expanded name is a pair consisting of a namespace name and a local name.
+The local name is the name of the Dublin Core term to look for in the `dccatalog` and the namespace name is the name of 
+the namespace it belongs to.
+The Dublin Core term could be one of the terms set by Opencast or an additional term adding to the catalog.
 
 ### match-value
 
@@ -74,7 +76,7 @@ Operation Example
     description: Configure publication channel by dcterm
     configurations:
       - dccatalog: episode
-      - dcterm: audience
+      - dcterm: "{http://purl.org/dc/terms/}audience"
       - match-value: private
       - publishPrivate: true
 

--- a/docs/guides/admin/docs/workflowoperationhandlers/tag-by-dcterm-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/tag-by-dcterm-woh.md
@@ -40,9 +40,9 @@ Note: see [`tag` operation](tag-woh.md) for further explanation of the source/ta
 
 The flavor subtype of Dublin Core catalog in which to look for the `dcterm`. This will usually be `episode` or `series`.
 
-### dccatalog
+### dccatalog-type
 
-The flavor type of Dublin Core catalog in which to look for the `dcterm`. This will usually be `episode` or `series`.
+The flavor type of Dublin Core catalog in which to look for the `dcterm`. This will usually be `dublincore`.
 Will default to 'dublincore'.
 
 ### dcterm

--- a/docs/guides/admin/docs/workflowoperationhandlers/tag-by-dcterm-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/tag-by-dcterm-woh.md
@@ -27,7 +27,7 @@ Tags and flavors can be used in combination.
 |source-flavors    | "presentation/trimmed"                | Tag any media package elements with one of these (comma separated) flavors.                                                                                                                                                                                                                                      |EMPTY|
 |dccatalog         | "episode" or "series"                 | the subtype of catalog in which to search for dcterm                                                                                                                                                                                                                                                             |EMPTY|
 | dccatalog-type   | "dublincore"                          | the type of catalog in which to search for `dcterm`                                                                                                                                                                                                                                                              | "dublincore"  |
-|dcterm            | "creator"                             | the name of the Dublin Core term which to check                                                                                                                                                                                                                                                                  |EMPTY|
+|dcterm            | "{http://purl.org/dc/terms/}creator"  | the XML Expanded Name, consists of a namespace and the name of the Dublin Core term which to check                                                                                                                                                                                                                                                                  |EMPTY|
 |match-value       | "Joe Bloggs"                          | the Dublin Core term value to check for                                                                                                                                                                                                                                                                          |EMPTY|
 |default-value"    | "Anon"                                | the implied value if the dublincore term is not present in the catalog                                                                                                                                                                                                                                           |EMPTY|
 |target-tags       | "tagged,+engage" / "-engaged,+tagged" | Apply these (comma separated) tags to any media package elements. If a target-tag starts with a '-', it will be removed from preexisting tags, if a target-tag starts with a '+', it will be added to preexisting tags. If there is no prefix, all preexisting tags are removed and replaced by the target-tags. |EMPTY|
@@ -47,8 +47,10 @@ Will default to 'dublincore'.
 
 ### dcterm
 
-The name of the Dublin Core term to look for in the `dccatalog`. This could be one of the terms set by Opencast or an
-additional term adding to the catalog.
+The expanded name is a pair consisting of a namespace name and a local name.
+The local name is the name of the Dublin Core term to look for in the `dccatalog` and the namespace name is the name of
+the namespace it belongs to.
+The Dublin Core term could be one of the terms set by Opencast or an additional term adding to the catalog.
 
 ### match-value
 
@@ -71,7 +73,7 @@ Operation Example
     configurations:
       - source-flavors: dublincore/*,security/*
       - dccatalog: episode
-      - dcterm: audience
+      - dcterm: "{http://purl.org/dc/terms/}audience"
       - match-value: learning-difficulties
       - default-value: all-enrolled
       - target-tags: +publishBeforeEditing

--- a/docs/guides/admin/docs/workflowoperationhandlers/tag-by-dcterm-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/tag-by-dcterm-woh.md
@@ -21,23 +21,29 @@ Parameter Table
 
 Tags and flavors can be used in combination.
 
-|configuration keys|example|description|default value|
-|------------------|-------|-----------|-------------|
-|source-tags       |"engage,-publish"|Tag any media package elements with one of these (comma separated) tags. If a source-tag starts with a '-', media package elements with this tag will be excluded.|EMPTY|
-|source-flavors    |"presentation/trimmed"    |Tag any media package elements with one of these (comma separated) flavors.|EMPTY|
-|dccatalog         |"episode" or "series"     |the type of catalog in which to search for dcterm|EMPTY|
-|dcterm            |"creator"                 |the name of the Dublin Core term which to check|EMPTY|
-|match-value       |"Joe Bloggs"              |the Dublin Core term value to check for|EMPTY|
-|default-value"    |"Anon"                    |the implied value if the dublincore term is not present in the catalog|EMPTY|
-|target-tags       |"tagged,+engage" / "-engaged,+tagged"|Apply these (comma separated) tags to any media package elements. If a target-tag starts with a '-', it will be removed from preexisting tags, if a target-tag starts with a '+', it will be added to preexisting tags. If there is no prefix, all preexisting tags are removed and replaced by the target-tags.|EMPTY|
-|target-flavor     |"presentation/tagged"     |Apply these flavor to any media package elements|EMPTY|
-|copy              |"true" or "false"         |Indicates if matching elements will be cloned before tagging is applied or whether tagging is applied to the original element. Set to "true" to create a copy first, "false" otherwise.|FALSE|
+|configuration keys| example                               | description                                                                                                                                                                                                                                                                                                      |default value|
+|------------------|---------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+|source-tags       | "engage,-publish"                     | Tag any media package elements with one of these (comma separated) tags. If a source-tag starts with a '-', media package elements with this tag will be excluded.                                                                                                                                               |EMPTY|
+|source-flavors    | "presentation/trimmed"                | Tag any media package elements with one of these (comma separated) flavors.                                                                                                                                                                                                                                      |EMPTY|
+|dccatalog         | "episode" or "series"                 | the subtype of catalog in which to search for dcterm                                                                                                                                                                                                                                                             |EMPTY|
+| dccatalog-type   | "dublincore"                          | the type of catalog in which to search for `dcterm`                                                                                                                                                                                                                                                              | "dublincore"  |
+|dcterm            | "creator"                             | the name of the Dublin Core term which to check                                                                                                                                                                                                                                                                  |EMPTY|
+|match-value       | "Joe Bloggs"                          | the Dublin Core term value to check for                                                                                                                                                                                                                                                                          |EMPTY|
+|default-value"    | "Anon"                                | the implied value if the dublincore term is not present in the catalog                                                                                                                                                                                                                                           |EMPTY|
+|target-tags       | "tagged,+engage" / "-engaged,+tagged" | Apply these (comma separated) tags to any media package elements. If a target-tag starts with a '-', it will be removed from preexisting tags, if a target-tag starts with a '+', it will be added to preexisting tags. If there is no prefix, all preexisting tags are removed and replaced by the target-tags. |EMPTY|
+|target-flavor     | "presentation/tagged"                 | Apply these flavor to any media package elements                                                                                                                                                                                                                                                                 |EMPTY|
+|copy              | "true" or "false"                     | Indicates if matching elements will be cloned before tagging is applied or whether tagging is applied to the original element. Set to "true" to create a copy first, "false" otherwise.                                                                                                                          |FALSE|
 
 Note: see [`tag` operation](tag-woh.md) for further explanation of the source/target-flavor/tags
 
 ### dccatalog
 
-The type of Dublin Core catalog in which to look for the `dcterm`. This will usually be `episode` or `series`.
+The flavor subtype of Dublin Core catalog in which to look for the `dcterm`. This will usually be `episode` or `series`.
+
+### dccatalog
+
+The flavor type of Dublin Core catalog in which to look for the `dcterm`. This will usually be `episode` or `series`.
+Will default to 'dublincore'.
 
 ### dcterm
 

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ConfigureByDublinCoreTermWOH.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ConfigureByDublinCoreTermWOH.java
@@ -20,11 +20,8 @@
  */
 package org.opencastproject.workflow.handler.workflow;
 
-import static org.opencastproject.metadata.dublincore.DublinCore.TERMS_NS_URI;
-
 import org.opencastproject.job.api.JobContext;
 import org.opencastproject.mediapackage.Catalog;
-import org.opencastproject.mediapackage.EName;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
@@ -121,13 +118,15 @@ public class ConfigureByDublinCoreTermWOH extends ResumableWorkflowOperationHand
 
     if (catalogs != null && catalogs.length > 0) {
       Boolean foundValue = false;
-      EName dcterm = new EName(TERMS_NS_URI, configuredDCTerm);
 
       // Find DCTerm
       for (Catalog catalog : catalogs) {
         DublinCoreCatalog dc = DublinCoreUtil.loadDublinCore(workspace, catalog);
         // Match Value
-        List<DublinCoreValue> values = dc.get(dcterm);
+        List<DublinCoreValue> values = dc.getProperties().stream()
+            .filter(property -> property.getLocalName().equals(configuredDCTerm))
+            .flatMap(property -> dc.get(property).stream())
+            .toList();
         if (values.isEmpty()) {
           // Use default
           if (configuredDefaultValue != null) {

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ConfigureByDublinCoreTermWOH.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ConfigureByDublinCoreTermWOH.java
@@ -47,6 +47,7 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Take look in specified catalog for specified term, if the value matches the specified value add the target-tags
@@ -65,6 +66,9 @@ public class ConfigureByDublinCoreTermWOH extends ResumableWorkflowOperationHand
 
   /** Name of the configuration option that provides the catalog to examine */
   public static final String DCCATALOG_PROPERTY = "dccatalog";
+
+  /** Flavor type of the catalog in case it is not dublincore */
+  public static final String DCCATALOG_TYPE_PROPERTY = "dccatalog-type";
 
   /** Name of the configuration option that provides Dublin Core term/element */
   public static final String DCTERM_PROPERTY = "dcterm";
@@ -104,13 +108,16 @@ public class ConfigureByDublinCoreTermWOH extends ResumableWorkflowOperationHand
     WorkflowOperationInstance currentOperation = workflowInstance.getCurrentOperation();
 
     String configuredCatalog = StringUtils.trimToEmpty(currentOperation.getConfiguration(DCCATALOG_PROPERTY));
+    Optional<String> optConfiguredCatalogType = Optional.ofNullable(StringUtils.trimToNull(
+        currentOperation.getConfiguration(DCCATALOG_TYPE_PROPERTY)));
+    String catalogType = optConfiguredCatalogType.isPresent() ? optConfiguredCatalogType.get() : "dublincore";
     String configuredDCTerm = StringUtils.trimToEmpty(currentOperation.getConfiguration(DCTERM_PROPERTY));
     String configuredDefaultValue = StringUtils.trimToNull(currentOperation.getConfiguration(DEFAULT_VALUE_PROPERTY));
     String configuredMatchValue = StringUtils.trimToEmpty(currentOperation.getConfiguration(MATCH_VALUE_PROPERTY));
 
     // Find Catalog
     Catalog[] catalogs = mediaPackage
-            .getCatalogs(new MediaPackageElementFlavor("dublincore", StringUtils.lowerCase(configuredCatalog)));
+            .getCatalogs(new MediaPackageElementFlavor(catalogType, StringUtils.lowerCase(configuredCatalog)));
 
     if (catalogs != null && catalogs.length > 0) {
       Boolean foundValue = false;

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ConfigureByDublinCoreTermWOH.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ConfigureByDublinCoreTermWOH.java
@@ -20,8 +20,6 @@
  */
 package org.opencastproject.workflow.handler.workflow;
 
-import static org.opencastproject.metadata.dublincore.DublinCore.TERMS_NS_URI;
-
 import org.opencastproject.job.api.JobContext;
 import org.opencastproject.mediapackage.Catalog;
 import org.opencastproject.mediapackage.EName;
@@ -111,7 +109,7 @@ public class ConfigureByDublinCoreTermWOH extends ResumableWorkflowOperationHand
     Optional<String> optConfiguredCatalogType = Optional.ofNullable(StringUtils.trimToNull(
         currentOperation.getConfiguration(DCCATALOG_TYPE_PROPERTY)));
     String catalogType = optConfiguredCatalogType.isPresent() ? optConfiguredCatalogType.get() : "dublincore";
-    String configuredDCTerm = StringUtils.trimToEmpty(currentOperation.getConfiguration(DCTERM_PROPERTY));
+    EName configuredDCTerm = EName.fromString(currentOperation.getConfiguration(DCTERM_PROPERTY));
     String configuredDefaultValue = StringUtils.trimToNull(currentOperation.getConfiguration(DEFAULT_VALUE_PROPERTY));
     String configuredMatchValue = StringUtils.trimToEmpty(currentOperation.getConfiguration(MATCH_VALUE_PROPERTY));
 
@@ -121,13 +119,12 @@ public class ConfigureByDublinCoreTermWOH extends ResumableWorkflowOperationHand
 
     if (catalogs != null && catalogs.length > 0) {
       Boolean foundValue = false;
-      EName dcterm = new EName(TERMS_NS_URI, configuredDCTerm);
 
       // Find DCTerm
       for (Catalog catalog : catalogs) {
         DublinCoreCatalog dc = DublinCoreUtil.loadDublinCore(workspace, catalog);
         // Match Value
-        List<DublinCoreValue> values = dc.get(dcterm);
+        List<DublinCoreValue> values = dc.get(configuredDCTerm);
         if (values.isEmpty()) {
           // Use default
           if (configuredDefaultValue != null) {

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ConfigureByDublinCoreTermWOH.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ConfigureByDublinCoreTermWOH.java
@@ -20,8 +20,11 @@
  */
 package org.opencastproject.workflow.handler.workflow;
 
+import static org.opencastproject.metadata.dublincore.DublinCore.TERMS_NS_URI;
+
 import org.opencastproject.job.api.JobContext;
 import org.opencastproject.mediapackage.Catalog;
+import org.opencastproject.mediapackage.EName;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
@@ -118,15 +121,13 @@ public class ConfigureByDublinCoreTermWOH extends ResumableWorkflowOperationHand
 
     if (catalogs != null && catalogs.length > 0) {
       Boolean foundValue = false;
+      EName dcterm = new EName(TERMS_NS_URI, configuredDCTerm);
 
       // Find DCTerm
       for (Catalog catalog : catalogs) {
         DublinCoreCatalog dc = DublinCoreUtil.loadDublinCore(workspace, catalog);
         // Match Value
-        List<DublinCoreValue> values = dc.getProperties().stream()
-            .filter(property -> property.getLocalName().equals(configuredDCTerm))
-            .flatMap(property -> dc.get(property).stream())
-            .toList();
+        List<DublinCoreValue> values = dc.get(dcterm);
         if (values.isEmpty()) {
           // Use default
           if (configuredDefaultValue != null) {

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TagByDublinCoreTermWOH.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TagByDublinCoreTermWOH.java
@@ -20,11 +20,8 @@
  */
 package org.opencastproject.workflow.handler.workflow;
 
-import static org.opencastproject.metadata.dublincore.DublinCore.TERMS_NS_URI;
-
 import org.opencastproject.job.api.JobContext;
 import org.opencastproject.mediapackage.Catalog;
-import org.opencastproject.mediapackage.EName;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElement;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
@@ -149,13 +146,15 @@ public class TagByDublinCoreTermWOH extends ResumableWorkflowOperationHandlerBas
 
     if (catalogs != null && catalogs.length > 0) {
       Boolean foundValue = false;
-      EName dcterm = new EName(TERMS_NS_URI, configuredDCTerm);
 
       // Find DCTerm
       for (Catalog catalog : catalogs) {
         DublinCoreCatalog dc = DublinCoreUtil.loadDublinCore(workspace, catalog);
         // Match Value
-        List<DublinCoreValue> values = dc.get(dcterm);
+        List<DublinCoreValue> values = dc.getProperties().stream()
+            .filter(property -> property.getLocalName().equals(configuredDCTerm))
+            .flatMap(property -> dc.get(property).stream())
+            .toList();
         if (values.isEmpty()) {
           // Use default
           if (configuredDefaultValue != null) {

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TagByDublinCoreTermWOH.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TagByDublinCoreTermWOH.java
@@ -20,8 +20,11 @@
  */
 package org.opencastproject.workflow.handler.workflow;
 
+import static org.opencastproject.metadata.dublincore.DublinCore.TERMS_NS_URI;
+
 import org.opencastproject.job.api.JobContext;
 import org.opencastproject.mediapackage.Catalog;
+import org.opencastproject.mediapackage.EName;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElement;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
@@ -146,15 +149,13 @@ public class TagByDublinCoreTermWOH extends ResumableWorkflowOperationHandlerBas
 
     if (catalogs != null && catalogs.length > 0) {
       Boolean foundValue = false;
+      EName dcterm = new EName(TERMS_NS_URI, configuredDCTerm);
 
       // Find DCTerm
       for (Catalog catalog : catalogs) {
         DublinCoreCatalog dc = DublinCoreUtil.loadDublinCore(workspace, catalog);
         // Match Value
-        List<DublinCoreValue> values = dc.getProperties().stream()
-            .filter(property -> property.getLocalName().equals(configuredDCTerm))
-            .flatMap(property -> dc.get(property).stream())
-            .toList();
+        List<DublinCoreValue> values = dc.get(dcterm);
         if (values.isEmpty()) {
           // Use default
           if (configuredDefaultValue != null) {

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TagByDublinCoreTermWOH.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TagByDublinCoreTermWOH.java
@@ -20,8 +20,6 @@
  */
 package org.opencastproject.workflow.handler.workflow;
 
-import static org.opencastproject.metadata.dublincore.DublinCore.TERMS_NS_URI;
-
 import org.opencastproject.job.api.JobContext;
 import org.opencastproject.mediapackage.Catalog;
 import org.opencastproject.mediapackage.EName;
@@ -128,7 +126,7 @@ public class TagByDublinCoreTermWOH extends ResumableWorkflowOperationHandlerBas
     Optional<String> optConfiguredCatalogType = Optional.ofNullable(StringUtils.trimToNull(
         currentOperation.getConfiguration(DCCATALOG_TYPE_PROPERTY)));
     String catalogType = optConfiguredCatalogType.isPresent() ? optConfiguredCatalogType.get() : "dublincore";
-    String configuredDCTerm = StringUtils.trimToEmpty(currentOperation.getConfiguration(DCTERM_PROPERTY));
+    EName configuredDCTerm = EName.fromString(currentOperation.getConfiguration(DCTERM_PROPERTY));
     String configuredDefaultValue = StringUtils.trimToNull(currentOperation.getConfiguration(DEFAULT_VALUE_PROPERTY));
     String configuredMatchValue = StringUtils.trimToEmpty(currentOperation.getConfiguration(MATCH_VALUE_PROPERTY));
     List<MediaPackageElementFlavor> configuredTargetFlavor = tagsAndFlavors.getTargetFlavors();
@@ -149,13 +147,12 @@ public class TagByDublinCoreTermWOH extends ResumableWorkflowOperationHandlerBas
 
     if (catalogs != null && catalogs.length > 0) {
       Boolean foundValue = false;
-      EName dcterm = new EName(TERMS_NS_URI, configuredDCTerm);
 
       // Find DCTerm
       for (Catalog catalog : catalogs) {
         DublinCoreCatalog dc = DublinCoreUtil.loadDublinCore(workspace, catalog);
         // Match Value
-        List<DublinCoreValue> values = dc.get(dcterm);
+        List<DublinCoreValue> values = dc.get(configuredDCTerm);
         if (values.isEmpty()) {
           // Use default
           if (configuredDefaultValue != null) {

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TagByDublinCoreTermWOH.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TagByDublinCoreTermWOH.java
@@ -52,6 +52,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Take look in specified catalog for specified term, if the value matches the specified value add the target-tags
@@ -78,6 +79,9 @@ public class TagByDublinCoreTermWOH extends ResumableWorkflowOperationHandlerBas
 
   /** Name of the configuration option that provides the catalog to examine */
   public static final String DCCATALOG_PROPERTY = "dccatalog";
+
+  /** Flavor type of the catalog in case it is not dublincore */
+  public static final String DCCATALOG_TYPE_PROPERTY = "dccatalog-type";
 
   /** Name of the configuration option that provides Dublin Core term/element */
   public static final String DCTERM_PROPERTY = "dcterm";
@@ -121,6 +125,9 @@ public class TagByDublinCoreTermWOH extends ResumableWorkflowOperationHandlerBas
     List<MediaPackageElementFlavor> configuredSourceFlavors = tagsAndFlavors.getSrcFlavors();
     List<String> configuredSourceTags = tagsAndFlavors.getSrcTags();
     String configuredCatalog = StringUtils.trimToEmpty(currentOperation.getConfiguration(DCCATALOG_PROPERTY));
+    Optional<String> optConfiguredCatalogType = Optional.ofNullable(StringUtils.trimToNull(
+        currentOperation.getConfiguration(DCCATALOG_TYPE_PROPERTY)));
+    String catalogType = optConfiguredCatalogType.isPresent() ? optConfiguredCatalogType.get() : "dublincore";
     String configuredDCTerm = StringUtils.trimToEmpty(currentOperation.getConfiguration(DCTERM_PROPERTY));
     String configuredDefaultValue = StringUtils.trimToNull(currentOperation.getConfiguration(DEFAULT_VALUE_PROPERTY));
     String configuredMatchValue = StringUtils.trimToEmpty(currentOperation.getConfiguration(MATCH_VALUE_PROPERTY));
@@ -137,7 +144,7 @@ public class TagByDublinCoreTermWOH extends ResumableWorkflowOperationHandlerBas
     }
 
     // Find Catalog
-    Catalog[] catalogs = mediaPackage.getCatalogs(new MediaPackageElementFlavor("dublincore",
+    Catalog[] catalogs = mediaPackage.getCatalogs(new MediaPackageElementFlavor(catalogType,
         StringUtils.lowerCase(configuredCatalog)));
 
     if (catalogs != null && catalogs.length > 0) {

--- a/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/ConfigureByDublinCoreTermWOHTest.java
+++ b/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/ConfigureByDublinCoreTermWOHTest.java
@@ -77,7 +77,7 @@ public class ConfigureByDublinCoreTermWOHTest {
   @Test
   public void testMatchPresentDCTerm() throws Exception {
     operation.setConfiguration(ConfigureByDublinCoreTermWOH.DCCATALOG_PROPERTY, "episode");
-    operation.setConfiguration(ConfigureByDublinCoreTermWOH.DCTERM_PROPERTY, "publisher");
+    operation.setConfiguration(ConfigureByDublinCoreTermWOH.DCTERM_PROPERTY, "{http://purl.org/dc/terms/}publisher");
     operation.setConfiguration(ConfigureByDublinCoreTermWOH.MATCH_VALUE_PROPERTY, "University of Opencast");
     operation.setConfiguration(ConfigureByDublinCoreTermWOH.COPY_PROPERTY, "false");
     operation.setConfiguration("newConfigProperty", "true");
@@ -92,7 +92,7 @@ public class ConfigureByDublinCoreTermWOHTest {
   @Test
   public void testMatchPresentDCTermOverwriteProperty() throws Exception {
     operation.setConfiguration(ConfigureByDublinCoreTermWOH.DCCATALOG_PROPERTY, "episode");
-    operation.setConfiguration(ConfigureByDublinCoreTermWOH.DCTERM_PROPERTY, "publisher");
+    operation.setConfiguration(ConfigureByDublinCoreTermWOH.DCTERM_PROPERTY, "{http://purl.org/dc/terms/}publisher");
     operation.setConfiguration(ConfigureByDublinCoreTermWOH.MATCH_VALUE_PROPERTY, "University of Opencast");
     operation.setConfiguration(ConfigureByDublinCoreTermWOH.COPY_PROPERTY, "false");
     operation.setConfiguration("oldConfigProperty", "bar");
@@ -108,7 +108,7 @@ public class ConfigureByDublinCoreTermWOHTest {
   public void testMatchDefaultDCTerm() throws Exception {
     // Match == Default Value
     operation.setConfiguration(ConfigureByDublinCoreTermWOH.DCCATALOG_PROPERTY, "episode");
-    operation.setConfiguration(ConfigureByDublinCoreTermWOH.DCTERM_PROPERTY, "source");
+    operation.setConfiguration(ConfigureByDublinCoreTermWOH.DCTERM_PROPERTY, "{http://purl.org/dc/terms/}source");
     operation.setConfiguration(ConfigureByDublinCoreTermWOH.DEFAULT_VALUE_PROPERTY, "Timbuktu");
     operation.setConfiguration(ConfigureByDublinCoreTermWOH.MATCH_VALUE_PROPERTY, "Timbuktu");
     operation.setConfiguration(ConfigureByDublinCoreTermWOH.COPY_PROPERTY, "false");
@@ -125,7 +125,7 @@ public class ConfigureByDublinCoreTermWOHTest {
   public void testMisMatchDefaultDCTerm() throws Exception {
     // Match != Default Value
     operation.setConfiguration(ConfigureByDublinCoreTermWOH.DCCATALOG_PROPERTY, "episode");
-    operation.setConfiguration(ConfigureByDublinCoreTermWOH.DCTERM_PROPERTY, "source");
+    operation.setConfiguration(ConfigureByDublinCoreTermWOH.DCTERM_PROPERTY, "{http://purl.org/dc/terms/}source");
     operation.setConfiguration(ConfigureByDublinCoreTermWOH.DEFAULT_VALUE_PROPERTY, "Cairo");
     operation.setConfiguration(ConfigureByDublinCoreTermWOH.MATCH_VALUE_PROPERTY, "Timbuktu");
     operation.setConfiguration(ConfigureByDublinCoreTermWOH.COPY_PROPERTY, "false");
@@ -141,7 +141,7 @@ public class ConfigureByDublinCoreTermWOHTest {
   public void testMissingNoDefaultDCTerm() throws Exception {
     // No Default Value
     operation.setConfiguration(ConfigureByDublinCoreTermWOH.DCCATALOG_PROPERTY, "episode");
-    operation.setConfiguration(ConfigureByDublinCoreTermWOH.DCTERM_PROPERTY, "source");
+    operation.setConfiguration(ConfigureByDublinCoreTermWOH.DCTERM_PROPERTY, "{http://purl.org/dc/terms/}source");
     operation.setConfiguration(ConfigureByDublinCoreTermWOH.MATCH_VALUE_PROPERTY, "Timbuktu");
     operation.setConfiguration(ConfigureByDublinCoreTermWOH.COPY_PROPERTY, "false");
     operation.setConfiguration("newConfigProperty", "true");
@@ -157,7 +157,7 @@ public class ConfigureByDublinCoreTermWOHTest {
     // No Match or Default Value
     // without dcterm or default the match should always fail
     operation.setConfiguration(ConfigureByDublinCoreTermWOH.DCCATALOG_PROPERTY, "episode");
-    operation.setConfiguration(ConfigureByDublinCoreTermWOH.DCTERM_PROPERTY, "source");
+    operation.setConfiguration(ConfigureByDublinCoreTermWOH.DCTERM_PROPERTY, "{http://purl.org/dc/terms/}source");
     operation.setConfiguration(ConfigureByDublinCoreTermWOH.COPY_PROPERTY, "false");
 
     WorkflowOperationResult result = operationHandler.start(instance, null);

--- a/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/TagByDublinCoreTermWOHTest.java
+++ b/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/TagByDublinCoreTermWOHTest.java
@@ -77,7 +77,7 @@ public class TagByDublinCoreTermWOHTest {
   public void testMatchPresentDCTerm() throws Exception {
     operation.setConfiguration(TagByDublinCoreTermWOH.SOURCE_FLAVORS_PROPERTY, "dublincore/*");
     operation.setConfiguration(TagByDublinCoreTermWOH.DCCATALOG_PROPERTY, "episode");
-    operation.setConfiguration(TagByDublinCoreTermWOH.DCTERM_PROPERTY, "publisher");
+    operation.setConfiguration(TagByDublinCoreTermWOH.DCTERM_PROPERTY, "{http://purl.org/dc/terms/}publisher");
     operation.setConfiguration(TagByDublinCoreTermWOH.MATCH_VALUE_PROPERTY, "University of Opencast");
     operation.setConfiguration(TagByDublinCoreTermWOH.TARGET_TAGS_PROPERTY, "tag1,tag2");
     operation.setConfiguration(TagByDublinCoreTermWOH.COPY_PROPERTY, "false");
@@ -95,7 +95,7 @@ public class TagByDublinCoreTermWOHTest {
     // Match == Default Value
     operation.setConfiguration(TagByDublinCoreTermWOH.SOURCE_FLAVORS_PROPERTY, "dublincore/*");
     operation.setConfiguration(TagByDublinCoreTermWOH.DCCATALOG_PROPERTY, "episode");
-    operation.setConfiguration(TagByDublinCoreTermWOH.DCTERM_PROPERTY, "source");
+    operation.setConfiguration(TagByDublinCoreTermWOH.DCTERM_PROPERTY, "{http://purl.org/dc/terms/}source");
     operation.setConfiguration(TagByDublinCoreTermWOH.DEFAULT_VALUE_PROPERTY, "Timbuktu");
     operation.setConfiguration(TagByDublinCoreTermWOH.MATCH_VALUE_PROPERTY, "Timbuktu");
     operation.setConfiguration(TagByDublinCoreTermWOH.TARGET_TAGS_PROPERTY, "tag1,tag2");
@@ -115,7 +115,7 @@ public class TagByDublinCoreTermWOHTest {
     // Match != Default Value
     operation.setConfiguration(TagByDublinCoreTermWOH.SOURCE_FLAVORS_PROPERTY, "dublincore/*");
     operation.setConfiguration(TagByDublinCoreTermWOH.DCCATALOG_PROPERTY, "episode");
-    operation.setConfiguration(TagByDublinCoreTermWOH.DCTERM_PROPERTY, "source");
+    operation.setConfiguration(TagByDublinCoreTermWOH.DCTERM_PROPERTY, "{http://purl.org/dc/terms/}source");
     operation.setConfiguration(TagByDublinCoreTermWOH.DEFAULT_VALUE_PROPERTY, "Cairo");
     operation.setConfiguration(TagByDublinCoreTermWOH.MATCH_VALUE_PROPERTY, "Timbuktu");
     operation.setConfiguration(TagByDublinCoreTermWOH.TARGET_TAGS_PROPERTY, "tag1,tag2");
@@ -134,7 +134,7 @@ public class TagByDublinCoreTermWOHTest {
     // No Default Value
     operation.setConfiguration(TagByDublinCoreTermWOH.SOURCE_FLAVORS_PROPERTY, "dublincore/*");
     operation.setConfiguration(TagByDublinCoreTermWOH.DCCATALOG_PROPERTY, "episode");
-    operation.setConfiguration(TagByDublinCoreTermWOH.DCTERM_PROPERTY, "source");
+    operation.setConfiguration(TagByDublinCoreTermWOH.DCTERM_PROPERTY, "{http://purl.org/dc/terms/}source");
     operation.setConfiguration(TagByDublinCoreTermWOH.MATCH_VALUE_PROPERTY, "Timbuktu");
     operation.setConfiguration(TagByDublinCoreTermWOH.TARGET_TAGS_PROPERTY, "tag1,tag2");
     operation.setConfiguration(TagByDublinCoreTermWOH.COPY_PROPERTY, "false");
@@ -153,7 +153,7 @@ public class TagByDublinCoreTermWOHTest {
     // without dcterm or default the match should always fail
     operation.setConfiguration(TagByDublinCoreTermWOH.SOURCE_FLAVORS_PROPERTY, "dublincore/*");
     operation.setConfiguration(TagByDublinCoreTermWOH.DCCATALOG_PROPERTY, "episode");
-    operation.setConfiguration(TagByDublinCoreTermWOH.DCTERM_PROPERTY, "source");
+    operation.setConfiguration(TagByDublinCoreTermWOH.DCTERM_PROPERTY, "{http://purl.org/dc/terms/}source");
     operation.setConfiguration(TagByDublinCoreTermWOH.TARGET_TAGS_PROPERTY, "tag1,tag2");
     operation.setConfiguration(TagByDublinCoreTermWOH.COPY_PROPERTY, "false");
 


### PR DESCRIPTION
Adds a new, optional configuration key to the WOHs 'configure-by-dcterm' and 'tag-by-dcterm' called dccatalog-type.

These two WOHs are assuming that the flavor type of metadata catalogs is always 'dublincore'. With the new configuration key this assumption can now be overridden. This is useful if the metadata catalog you want to use has a different flavor type than 'dublincore' (as might be the case for extended metadata).

### How to test this patch

One way to test this is to create a new extended metadata catalog in your Opencast (see https://docs.opencast.org/develop/admin/#configuration/metadata/#extended-metadata for more information). Make sure you change the flavor to something other than 'dublincore'. Then modify or create a test workflow to use the respective WOHs.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
