### PR TITLE
Wire in existing en-GB and zh-TW locale files

### DIFF
--- a/modules/lti/src/i18n.ts
+++ b/modules/lti/src/i18n.ts
@@ -5,6 +5,7 @@ import daJson from "./i18n/lang-da_DK.json";
 import deJson from "./i18n/lang-de_DE.json";
 import elJson from "./i18n/lang-el_GR.json";
 import enJson from "./i18n/lang-en_US.json";
+import enGbJson from "./i18n/lang-en_GB.json";
 import esJson from "./i18n/lang-es_ES.json";
 import frJson from "./i18n/lang-fr_FR.json";
 import glJson from "./i18n/lang-gl_ES.json";
@@ -16,6 +17,7 @@ import slJson from "./i18n/lang-sl_SI.json";
 import svJson from "./i18n/lang-sv_SE.json";
 import trJson from "./i18n/lang-tr_TR.json";
 import zhJson from "./i18n/lang-zh_CN.json";
+import zhTwJson from "./i18n/lang-zh_TW.json";
 
 i18n
     .use(LanguageDetector)
@@ -25,6 +27,9 @@ i18n
         resources: {
             en: {
                 translations: enJson
+            },
+            "en-GB": {
+                translations: enGbJson
             },
             da: {
                 translations: daJson
@@ -67,6 +72,9 @@ i18n
             },
             zh: {
                 translations: zhJson
+            },
+            "zh-TW": {
+                translations: zhTwJson
             }
         },
         fallbackLng: "en",


### PR DESCRIPTION
lang-en_GB.json and lang-zh_TW.json existed under src/i18n/ but were never imported or registered with i18next, so those locales were unreachable and always fell back to en/zh. Register them as en-GB and zh-TW resources, matching the BCP-47 tags reported by i18next-browser-languagedetector.

### AI Usage

Noticed in an AI review.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
