### PR TITLE
Fix fragile debug-flag detection in OpencastRest

### DIFF
--- a/modules/lti/src/OpencastRest.ts
+++ b/modules/lti/src/OpencastRest.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { parsedQueryString } from "./utils";
 
 export interface Attachment {
     readonly type: string;
@@ -124,7 +125,7 @@ export function collectionToPairs(c: EventMetadataCollection): [string, string][
     return Object.keys(c).map((k) => [k, c[k]]);
 }
 
-const debug = window.location.search.includes("&debug=true");
+const debug = parsedQueryString().debug === "true";
 
 function hostAndPort() {
     return debug ? "http://localhost:7878" : "";


### PR DESCRIPTION
window.location.search.includes("&debug=true") missed the flag whenever debug was the first query parameter (e.g. "?debug=true&foo=bar" has no literal "&debug=true" substring).

Use the existing parsedQueryString() helper instead, matching how every other query parameter in this module is read.

### AI Usage
Worked with Claude Sonnet to do the review.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
