### PR TITLE
Replace FontAwesome with Lucide in LTI tools

### DIFF
--- a/modules/lti/package-lock.json
+++ b/modules/lti/package-lock.json
@@ -8,9 +8,6 @@
       "name": "opencast-lti",
       "version": "0.1.0",
       "dependencies": {
-        "@fortawesome/fontawesome-svg-core": "^7.2.0",
-        "@fortawesome/free-solid-svg-icons": "^7.2.0",
-        "@fortawesome/react-fontawesome": "^3.2.0",
         "@vitejs/plugin-react": "^6.0.0",
         "axios": "^1.13.6",
         "bootstrap": "^5.3.8",
@@ -21,6 +18,7 @@
         "react-bootstrap": "^2.10.10",
         "react-dom": "^19.2.6",
         "react-i18next": "^17.0.9",
+        "react-icons": "^5.7.0",
         "react-select": "^5.10.2",
         "typescript": "6.0.3"
       },
@@ -339,52 +337,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
-    },
-    "node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.3.0.tgz",
-      "integrity": "sha512-X/vND0Y1l9fVJ9O79UgtZnXSpz4aNF3bXlDxiJAEAm6kgeSftp9wjjBPgqzazJV8YlmxfRoeXNfSCJ48sf/Hhw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/fontawesome-svg-core": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.3.0.tgz",
-      "integrity": "sha512-MFbTNLDWkLJwbozDvHOZ7hwyDjQcBMBattlcOQ6ZmV5YD9bBrqdl1rNtmVjQ/lzqveXXX3sMz2Ew6fAgXoxmkw==",
-      "license": "MIT",
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "7.3.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/free-solid-svg-icons": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.3.0.tgz",
-      "integrity": "sha512-YxI/CuwWeI3nPIoYU//vkDS+3ige/67DPZ6XwMATpYEFESzO9L8zfJOKllGRgIlpT/uebrZCcvAzp3peD7GmTw==",
-      "license": "(CC-BY-4.0 AND MIT)",
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "7.3.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/react-fontawesome": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.4.0.tgz",
-      "integrity": "sha512-EgY5CXzzm6WGnUB40j9qNajYmoJHC8TUV/rvpcmHUoPZmQyRlh8WuRaxaerjMq61NZAz0vS+MOoJaPbZWRDibw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": "~6 || ~7",
-        "react": "^18.0.0 || ^19.0.0"
-      }
     },
     "node_modules/@internationalized/date": {
       "version": "3.12.2",
@@ -2143,6 +2095,15 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.7.0.tgz",
+      "integrity": "sha512-LBLy340Rzqy6+/yVhZKT3B/QpP1BZaesGqasf09HPOBzRarcDIFH0WwXlXQfE7q7ipxK4MSiC5DIBWURCny6fw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/modules/lti/package.json
+++ b/modules/lti/package.json
@@ -4,9 +4,6 @@
   "private": true,
   "homepage": "/ltitools",
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^7.2.0",
-    "@fortawesome/free-solid-svg-icons": "^7.2.0",
-    "@fortawesome/react-fontawesome": "^3.2.0",
     "@vitejs/plugin-react": "^6.0.0",
     "axios": "^1.13.6",
     "bootstrap": "^5.3.8",
@@ -17,6 +14,7 @@
     "react-bootstrap": "^2.10.10",
     "react-dom": "^19.2.6",
     "react-i18next": "^17.0.9",
+    "react-icons": "^5.7.0",
     "react-select": "^5.10.2",
     "typescript": "6.0.3"
   },

--- a/modules/lti/src/App.css
+++ b/modules/lti/src/App.css
@@ -19,3 +19,16 @@ header {
   max-width: 100%;
   max-height: 100%;
 }
+
+.spin {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/modules/lti/src/App.css
+++ b/modules/lti/src/App.css
@@ -25,10 +25,7 @@ header {
 }
 
 @keyframes spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
+  100% {
     transform: rotate(360deg);
   }
 }

--- a/modules/lti/src/components/Loading.tsx
+++ b/modules/lti/src/components/Loading.tsx
@@ -1,9 +1,8 @@
 import React from "react";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faSpinner } from "@fortawesome/free-solid-svg-icons";
+import { LuLoaderCircle } from "react-icons/lu";
 import * as i18next from "i18next";
 
 export const Loading: React.FC<{ t: i18next.TFunction }> = ({ t }) => <div>
-    <FontAwesomeIcon icon={faSpinner} spin />
+    <LuLoaderCircle className="spin" />
     <span>{t("LTI.LOADING")}</span>
 </div>;

--- a/modules/lti/src/components/Series.tsx
+++ b/modules/lti/src/components/Series.tsx
@@ -11,8 +11,7 @@ import { Loading } from "./Loading";
 import { withTranslation, WithTranslation } from "react-i18next";
 import "../App.css";
 import 'bootstrap/dist/css/bootstrap.css';
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faTrash, faEdit, faComments, faDownload, faChevronLeft, faChevronRight, faAnglesLeft, faAnglesRight } from "@fortawesome/free-solid-svg-icons";
+import { LuTrash2, LuPencil, LuMessageSquare, LuDownload, LuChevronLeft, LuChevronRight, LuChevronsLeft, LuChevronsRight } from "react-icons/lu";
 import * as i18next from "i18next";
 import { parsedQueryString, capitalize } from "../utils";
 import { sortByType } from "../trackUtils";
@@ -80,20 +79,20 @@ const SeriesEpisode: React.FC<EpisodeProps> = ({episode, deleteCallback, editCal
             <div className="ms-auto">
                 {deleteCallback !== undefined &&
                     <button onClick={(e) => { deleteCallback(episode.id); e.stopPropagation(); }}>
-                        <FontAwesomeIcon icon={faTrash} />
+                        <LuTrash2 />
                     </button>}
                 {editCallback !== undefined &&
                     <button onClick={(e) => { editCallback(episode.id); e.stopPropagation(); }}>
-                        <FontAwesomeIcon icon={faEdit} />
+                        <LuPencil />
                     </button>}
                 {annotateCallback !== undefined &&
                                     <button onClick={(e) => { annotateCallback(episode.id); e.stopPropagation(); }}>
-                                        <FontAwesomeIcon icon={faComments} />
+                                        <LuMessageSquare />
                                     </button>}
                 {downloadCallback !== undefined && Array.isArray(episode.mediapackage.tracks) && episode.mediapackage.tracks.length > 0 &&
                   <Dropdown style={{display: 'inline-block'}}>
                     <Dropdown.Toggle as={dropdownCustomToggle} >
-                      <FontAwesomeIcon icon={faDownload}/>
+                      <LuDownload/>
                     </Dropdown.Toggle>
                     <DropdownMenu>
                       {sortByType(episode.mediapackage.tracks).map((track) => {
@@ -337,7 +336,7 @@ const Pagination = ({
                 }}
                 aria-label="Go to first page"
             >
-                <FontAwesomeIcon icon={faAnglesLeft} />
+                <LuChevronsLeft />
             </button>
             <button
                 className={isNavigatePrevious() ? "page-link" : "page-link disabled"}
@@ -347,7 +346,7 @@ const Pagination = ({
                 }}
                 aria-label="Go to Previous page"
             >
-                <FontAwesomeIcon icon={faChevronLeft} />
+                <LuChevronLeft />
             </button>
             {accessiblePages.map((page, key) =>
                 page === activePage ? (
@@ -376,7 +375,7 @@ const Pagination = ({
                 }}
                 aria-label="Go to next page"
             >
-                <FontAwesomeIcon icon={faChevronRight} />
+                <LuChevronRight />
             </button>
             <button
                 className={isNavigateNext() ? "page-link" : "page-link disabled"}
@@ -386,7 +385,7 @@ const Pagination = ({
                 }}
                 aria-label="Go to last page"
             >
-                <FontAwesomeIcon icon={faAnglesRight} />
+                <LuChevronsRight />
             </button>
         </div>
     );

--- a/modules/lti/src/components/Series.tsx
+++ b/modules/lti/src/components/Series.tsx
@@ -11,7 +11,7 @@ import { Loading } from "./Loading";
 import { withTranslation, WithTranslation } from "react-i18next";
 import "../App.css";
 import 'bootstrap/dist/css/bootstrap.css';
-import { LuTrash2, LuPencil, LuMessageSquare, LuDownload, LuChevronLeft, LuChevronRight, LuChevronsLeft, LuChevronsRight } from "react-icons/lu";
+import { LuTrash, LuPencil, LuMessageCircle, LuDownload, LuChevronLeft, LuChevronRight, LuChevronsLeft, LuChevronsRight } from "react-icons/lu";
 import * as i18next from "i18next";
 import { parsedQueryString, capitalize } from "../utils";
 import { sortByType } from "../trackUtils";
@@ -79,7 +79,7 @@ const SeriesEpisode: React.FC<EpisodeProps> = ({episode, deleteCallback, editCal
             <div className="ms-auto">
                 {deleteCallback !== undefined &&
                     <button onClick={(e) => { deleteCallback(episode.id); e.stopPropagation(); }}>
-                        <LuTrash2 />
+                        <LuTrash />
                     </button>}
                 {editCallback !== undefined &&
                     <button onClick={(e) => { editCallback(episode.id); e.stopPropagation(); }}>
@@ -87,7 +87,7 @@ const SeriesEpisode: React.FC<EpisodeProps> = ({episode, deleteCallback, editCal
                     </button>}
                 {annotateCallback !== undefined &&
                                     <button onClick={(e) => { annotateCallback(episode.id); e.stopPropagation(); }}>
-                                        <LuMessageSquare />
+                                        <LuMessageCircle />
                                     </button>}
                 {downloadCallback !== undefined && Array.isArray(episode.mediapackage.tracks) && episode.mediapackage.tracks.length > 0 &&
                   <Dropdown style={{display: 'inline-block'}}>


### PR DESCRIPTION
The rest of the Opencast frontend (admin, studio) has moved to Lucide icons via react-icons' `lu` subset, leaving the LTI tools frontend as the only place still depending on `@fortawesome/*`.

This swaps the FontAwesomeIcon usages in Series.tsx and Loading.tsx for their react-icons/lu equivalents, dropping the three @fortawesome packages.


### How to test this patch

To test this, head to `/ltitools`. For example, to `/ltitools/index.html?subtool=series&edit=true&deletion=true`.

### AI Usage
Used Claude Sonnet for the icon migration.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
