### PR TITLE
Fix LTI upload tool error when no series is specified

### DIFF
--- a/modules/lti/src/components/Upload.tsx
+++ b/modules/lti/src/components/Upload.tsx
@@ -88,22 +88,15 @@ class TranslatedUpload extends React.Component<UploadProps, UploadState> {
             if (metadataCollection.length > 0) {
                 const metadata = metadataCollection.find(col => col.flavor === "dublincore/episode");
                 if (metadata === undefined) { throw Error("Could not find episode metadata catalog")}
-                const seriesId = this.resolveSeries(metadata)
-                if (seriesId === undefined) {
-                    this.setState({
-                        ...this.state,
-                        metadata: "error"
-                    });
-                } else {
-                    this.setState({
-                        ...this.state,
-                        metadata: {
-                            initial: metadata,
-                            edited: metadata,
-                            seriesId: seriesId
-                        },
-                    });
-                }
+                const seriesId = this.resolveSeries(metadata) ?? "";
+                this.setState({
+                    ...this.state,
+                    metadata: {
+                        initial: metadata,
+                        edited: metadata,
+                        seriesId: seriesId
+                    },
+                });
             }
         }).catch((_) => this.setState({
             ...this.state,


### PR DESCRIPTION
If no series could be resolved from the URL or event metadata, the upload tool showed a permanent "Error loading event metadata" message instead of letting the upload proceed. Series is optional throughout Opencast, so default to an empty series id instead of failing.

This fixes #2183

### How to test this patch

Go to `/ltitools` and try using the upload tool without specifying a series.

### AI Usage
Worked with Clause Sonnet on this.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
