### PR TITLE
Fix bundle_name column too short for long install paths

### DIFF
--- a/docs/upgrade/20_to_21/mariadb.sql
+++ b/docs/upgrade/20_to_21/mariadb.sql
@@ -1,0 +1,3 @@
+-- Bundle name column was too short for some bundle symbolic names (e.g. wrap: protocol
+-- bundles installed from a long file path). Drop table so it gets recreated with the fix.
+drop table oc_bundleinfo;

--- a/docs/upgrade/20_to_21/postgresql.sql
+++ b/docs/upgrade/20_to_21/postgresql.sql
@@ -1,0 +1,3 @@
+-- Bundle name column was too short for some bundle symbolic names (e.g. wrap: protocol
+-- bundles installed from a long file path). Drop table so it gets recreated with the fix.
+drop table oc_bundleinfo;

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/bundleinfo/BundleInfoJpa.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/bundleinfo/BundleInfoJpa.java
@@ -68,7 +68,7 @@ public class BundleInfoJpa {
   @Column(name = "host", length = 128, nullable = false)
   protected String host;
 
-  @Column(name = "bundle_name", length = 128, nullable = false)
+  @Column(name = "bundle_name", length = 255, nullable = false)
   protected String bundleSymbolicName;
 
   @Column(name = "bundle_id", length = 128, nullable = false)


### PR DESCRIPTION
Staring up Opencast, there are stack traces in the logs. The main error was that the opencast-kernel bundle's BundleInfoLogger component fails to activate because inserting a row into the oc_bundleinfo table fails with an H2 database error:

    Value too long for column "BUNDLE_NAME CHARACTER VARYING(128)":
    "'wrap_file__home_lars_dev_opencast_opencast_build_opencast-dist-develop-21-SNAPS... (147)"

BundleInfoLoggera failed to activate on startup because bundle.getSymbolicName() can exceed the 128-char bundle_name column for wrap:-protocol bundles, whose auto-generated symbolic name embeds the full install path. Widen the column to 255 chars and add a migration to drop the auto-recreated oc_bundleinfo table for existing installs.

### AI Usage
Analyzed logs via Claude Sonnet.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
