### PR TITLE
Elect the job dispatcher automatically via a database lease

### DIFF
--- a/assemblies/dist-admin/pom.xml
+++ b/assemblies/dist-admin/pom.xml
@@ -9,7 +9,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <enableJobDispatching>true</enableJobDispatching>
   </properties>
   <artifactId>opencast-dist-admin</artifactId>
   <packaging>karaf-assembly</packaging>

--- a/assemblies/dist-adminpresentation/pom.xml
+++ b/assemblies/dist-adminpresentation/pom.xml
@@ -9,7 +9,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <enableJobDispatching>true</enableJobDispatching>
   </properties>
   <artifactId>opencast-dist-adminpresentation</artifactId>
   <packaging>karaf-assembly</packaging>

--- a/assemblies/dist-allinone/pom.xml
+++ b/assemblies/dist-allinone/pom.xml
@@ -9,7 +9,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <enableJobDispatching>true</enableJobDispatching>
   </properties>
   <artifactId>opencast-dist-allinone</artifactId>
   <packaging>karaf-assembly</packaging>

--- a/assemblies/dist-develop/pom.xml
+++ b/assemblies/dist-develop/pom.xml
@@ -10,7 +10,6 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <packaging.definition>${project.basedir}/target/classes/package.xml</packaging.definition>
-    <enableJobDispatching>true</enableJobDispatching>
     <enableDeveloperMode>true</enableDeveloperMode>
   </properties>
   <artifactId>opencast-dist-develop</artifactId>

--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -145,7 +145,6 @@
                 <target>
                   <ant antfile="../resources/build.xml">
                     <target name="basic configuration"/>
-                    <target name="job dispatching"/>
                     <target name="developer mode"/>
                   </ant>
                 </target>

--- a/assemblies/resources/build.xml
+++ b/assemblies/resources/build.xml
@@ -20,15 +20,6 @@
     <replaceregexp file="target/assembly/etc/config.properties" match="^felix.fileinstall.enableConfigSave .*=.*$" replace="felix.fileinstall.enableConfigSave = false" byline="true"/>
   </target>
 
-  <target if="enableJobDispatching" name="job dispatching">
-    <echo>Enabling job dispatching</echo>
-    <replaceregexp
-      file="target/classes/etc/org.opencastproject.serviceregistry.impl.JobDispatcher.cfg"
-      match="^#dispatch.interval=0$"
-      replace="dispatch.interval=2"
-      byline="true" />
-  </target>
-
   <target if="enableDeveloperMode" name="developer mode">
     <echo>Enabling developer mode</echo>
     <concat destfile="target/assembly/etc/shell.init.script" append="true">

--- a/docs/guides/admin/docs/installation/multiple-servers.md
+++ b/docs/guides/admin/docs/installation/multiple-servers.md
@@ -161,4 +161,3 @@ Set the base URL of the file server. When using a shared filesystem between serv
 set all servers to use the same URL (e.g. URL of the admin node).
 
     prop.org.opencastproject.file.repo.url=http://<ADMIN-URL>:8080
-

--- a/docs/guides/developer/docs/architecture/job-dispatch.md
+++ b/docs/guides/developer/docs/architecture/job-dispatch.md
@@ -1,3 +1,45 @@
-# Under construction
+# Job Dispatch
 
-While this page is being constructed, consider checking out [this webinar on Job Dispatching and Job Loads](https://explore.opencast.org/webinars/v/PGom1gu6yO4).
+For a general introduction, consider checking out [this webinar on Job Dispatching and Job Loads](https://explore.opencast.org/webinars/v/PGom1gu6yO4).
+
+## Overview
+
+The job dispatcher (`JobDispatcher`, in the `serviceregistry` module) periodically looks for queued jobs and
+assigns each one to the least loaded service capable of handling it. It is a scheduled polling loop that
+queries the database.
+
+## Automatic dispatcher election
+
+Job dispatching is enabled by default on every node that runs this component. The cluster automatically elects a single
+active dispatcher among all candidate nodes at runtime, and fails over to another candidate automatically if the current
+one goes down.
+
+Leader election is implemented as a lease stored in a single database row (`oc_dispatch_lock`). Every candidate node's
+dispatch tick first tries to acquire or renew this lease (`DispatchLeaseManager.tryAcquireOrRenew()`) before doing
+anything else; only the node holding a valid lease actually dispatches jobs that round. Acquisition is a single,
+portable JPQL bulk update:
+
+```sql
+UPDATE DispatchLock d
+   SET d.owner = :me, d.leaseExpires = :newExpiry
+ WHERE d.owner = :me OR d.leaseExpires < CURRENT_TIMESTAMP
+```
+
+The comparison uses the database's own `CURRENT_TIMESTAMP` rather than any node's local clock, so every competing
+node judges lease freshness against one shared clock instead of against each other. Race safety comes entirely from
+the database engine's row-level locking during the update itself - no advisory locks, no pessimistic entity
+locking, and no vendor-specific SQL, so this works identically on both supported databases (MariaDB and PostgreSQL)
+as well as the H2 database used for testing.
+
+The lease timeout (`dispatch.lock.timeout`, default `3 * dispatch.interval`) should be a small multiple of the
+dispatch interval, so that one missed tick doesn't cause an unnecessary failover, while a genuinely dead node is
+still detected and replaced quickly. On clean shutdown, a node proactively releases its lease
+(`DispatchLeaseManager.release()`) so a standby node can take over immediately rather than waiting out the full
+timeout.
+
+As a second line of defense, JPA optimistic locking (the `@Version` column on `JpaJob`) still guards against
+double-dispatch of the same job even in the unlikely event that two nodes both believe they hold the lease during
+a narrow race window.
+
+To exclude a specific node from ever becoming the dispatcher, set `dispatch.interval=0` on that node in
+`org.opencastproject.serviceregistry.impl.JobDispatcher.cfg`.

--- a/etc/org.opencastproject.serviceregistry.impl.JobDispatcher.cfg
+++ b/etc/org.opencastproject.serviceregistry.impl.JobDispatcher.cfg
@@ -1,8 +1,19 @@
 # Configuration for the job dispatcher
 
 # The interval in seconds between two rounds of dispatching in the service registry. A minimum value of 1s is enforced
-# due to performance reasons. Set to 0 to disable dispatching from this service registry.  Default for the job dispatch
-# node is 2. Service registry dispatching is automatically set to 0 on everything but admin or allinone nodes and should
-# usually not be activated on these nodes to avoid concurrency problems.
-# Default: 0
-#dispatch.interval=0
+# due to performance reasons.
+#
+# Job dispatching is enabled by default on every node that runs this service. Exactly one candidate node is elected
+# as the active dispatcher automatically at runtime; the others sit idle until they take over, e.g. because the
+# active dispatcher went down. This makes it safe to enable dispatching on multiple nodes for high availability -
+# there is no need to manually pick a single dispatch node.
+#
+# Set to 0 to explicitly exclude this node from ever becoming the dispatcher.
+# Default: 2
+#dispatch.interval=2
+
+# How long, in seconds, a dispatch lease stays valid before another candidate node is allowed to take over, if the
+# current dispatcher stops renewing it (e.g. it crashed or lost connectivity). Should be a small multiple of
+# dispatch.interval so that a single missed tick doesn't cause an unnecessary failover.
+# Default: 3 * dispatch.interval
+#dispatch.lock.timeout=6

--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/serviceregistry/impl/jpa/DispatchLockJpaImpl.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/serviceregistry/impl/jpa/DispatchLockJpaImpl.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.serviceregistry.impl.jpa;
+
+import java.util.Date;
+
+import javax.persistence.Access;
+import javax.persistence.AccessType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+/**
+ * A single-row lease used to elect exactly one active job dispatcher across a cluster of candidate nodes. There is
+ * always exactly one row, with a fixed id, representing the current lease holder and when that lease expires.
+ */
+@Entity(name = "DispatchLock")
+@Access(AccessType.FIELD)
+@Table(name = "oc_dispatch_lock")
+@NamedQueries({
+    @NamedQuery(
+        name = "DispatchLock.acquire",
+        query = "UPDATE DispatchLock d SET d.owner = :owner, d.leaseExpires = :leaseExpires "
+            + "WHERE d.id = :id AND (d.owner = :owner OR d.leaseExpires < CURRENT_TIMESTAMP)"
+    ),
+    @NamedQuery(
+        name = "DispatchLock.release",
+        query = "UPDATE DispatchLock d SET d.owner = null, d.leaseExpires = CURRENT_TIMESTAMP "
+            + "WHERE d.id = :id AND d.owner = :owner"
+    ),
+})
+public class DispatchLockJpaImpl {
+
+  /** The fixed id of the single lock row used cluster-wide. */
+  public static final long SINGLETON_ID = 1L;
+
+  @Id
+  @Column(name = "id")
+  private Long id;
+
+  @Column(name = "owner")
+  private String owner;
+
+  /**
+   * Defaults to the epoch (i.e. already expired) rather than null: a SQL comparison against a null timestamp never
+   * evaluates to true, which would otherwise make a freshly seeded row impossible for anyone to ever acquire.
+   */
+  @Temporal(TemporalType.TIMESTAMP)
+  @Column(name = "lease_expires", nullable = false)
+  private Date leaseExpires = new Date(0);
+
+  public DispatchLockJpaImpl() {
+  }
+
+  public DispatchLockJpaImpl(long id) {
+    this.id = id;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getOwner() {
+    return owner;
+  }
+
+  public void setOwner(String owner) {
+    this.owner = owner;
+  }
+
+  public Date getLeaseExpires() {
+    return leaseExpires;
+  }
+
+  public void setLeaseExpires(Date leaseExpires) {
+    this.leaseExpires = leaseExpires;
+  }
+}

--- a/modules/common-jpa-impl/src/main/resources/META-INF/persistence.xml
+++ b/modules/common-jpa-impl/src/main/resources/META-INF/persistence.xml
@@ -17,6 +17,7 @@
     <class>org.opencastproject.security.impl.jpa.JpaUserReference</class>
     <class>org.opencastproject.serviceregistry.impl.jpa.HostRegistrationJpaImpl</class>
     <class>org.opencastproject.serviceregistry.impl.jpa.ServiceRegistrationJpaImpl</class>
+    <class>org.opencastproject.serviceregistry.impl.jpa.DispatchLockJpaImpl</class>
     <shared-cache-mode>NONE</shared-cache-mode>
     <properties>
       <property name="eclipselink.ddl-generation" value="create-tables"/>

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/DispatchLeaseManager.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/DispatchLeaseManager.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.serviceregistry.impl;
+
+import static org.opencastproject.db.Queries.namedQuery;
+
+import org.opencastproject.db.DBSession;
+import org.opencastproject.serviceregistry.impl.jpa.DispatchLockJpaImpl;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Date;
+
+/**
+ * Elects exactly one job dispatcher across a cluster of candidate nodes by acquiring and renewing a lease stored in
+ * a single, shared database row. Only the node currently holding the lease should perform job dispatching; all
+ * other candidate nodes must sit idle until they acquire it, e.g. after the current holder stops renewing it.
+ *
+ * <p>Acquisition and renewal are both done with a single, portable JPQL bulk update whose {@code WHERE} clause
+ * compares the stored expiry against the database's own {@code CURRENT_TIMESTAMP}, not the calling node's local
+ * clock. This makes the race between competing nodes safe by relying purely on the database engine's row-level
+ * locking during the update, without needing vendor-specific advisory locks, and makes every competing node judge
+ * lease freshness against one shared clock rather than against each other's local clocks.
+ */
+public class DispatchLeaseManager {
+
+  private static final Logger logger = LoggerFactory.getLogger(DispatchLeaseManager.class);
+
+  private final DBSession db;
+  private final String owner;
+  private final long leaseTimeoutSeconds;
+
+  public DispatchLeaseManager(DBSession db, String owner, long leaseTimeoutSeconds) {
+    this.db = db;
+    this.owner = owner;
+    this.leaseTimeoutSeconds = leaseTimeoutSeconds;
+  }
+
+  /**
+   * Attempt to acquire the dispatch lease, or renew it if this node already holds it.
+   *
+   * @return true if this node is (now, or still) the elected dispatcher, false otherwise
+   */
+  public boolean tryAcquireOrRenew() {
+    ensureSeeded();
+
+    Date newExpiry = new Date(System.currentTimeMillis() + leaseTimeoutSeconds * 1000);
+    int updated = db.execTx(namedQuery.update(
+        "DispatchLock.acquire",
+        Pair.of("id", DispatchLockJpaImpl.SINGLETON_ID),
+        Pair.of("owner", owner),
+        Pair.of("leaseExpires", newExpiry)
+    ));
+
+    boolean isLeader = updated == 1;
+    logger.trace("Dispatch lease acquire/renew attempt by '{}': {}", owner, isLeader ? "leader" : "not leader");
+    return isLeader;
+  }
+
+  /**
+   * Release the lease if this node currently holds it, allowing another candidate node to take over immediately
+   * instead of waiting for the lease to expire. Safe to call even if this node isn't the current leader.
+   */
+  public void release() {
+    int updated = db.execTx(namedQuery.update(
+        "DispatchLock.release",
+        Pair.of("id", DispatchLockJpaImpl.SINGLETON_ID),
+        Pair.of("owner", owner)
+    ));
+    if (updated == 1) {
+      logger.debug("Released dispatch lease held by '{}'", owner);
+    }
+  }
+
+  /**
+   * Make sure the singleton lock row exists. Safe to call from multiple nodes concurrently; only one insert wins,
+   * the rest are simply ignored.
+   */
+  private void ensureSeeded() {
+    boolean exists = db.exec(namedQuery.findByIdOpt(DispatchLockJpaImpl.class, DispatchLockJpaImpl.SINGLETON_ID))
+        .isPresent();
+    if (exists) {
+      return;
+    }
+    try {
+      db.execTx(namedQuery.persist(new DispatchLockJpaImpl(DispatchLockJpaImpl.SINGLETON_ID)));
+      logger.debug("Seeded dispatch lease row");
+    } catch (Exception e) {
+      // Another node already seeded the row concurrently. That's fine, we can proceed.
+      logger.trace("Dispatch lease row already seeded by another node", e);
+    }
+  }
+}

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/JobDispatcher.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/JobDispatcher.java
@@ -102,17 +102,28 @@ public class JobDispatcher {
   /** Configuration key for the dispatch interval, in seconds */
   protected static final String OPT_DISPATCHINTERVAL = "dispatch.interval";
 
+  /** Configuration key for the dispatch lease timeout, in seconds */
+  protected static final String OPT_DISPATCH_LOCK_TIMEOUT = "dispatch.lock.timeout";
+
   /** Minimum delay between job dispatching attempts, in seconds */
   static final float MIN_DISPATCH_INTERVAL = 1.0F;
 
-  /** Default delay between job dispatching attempts, in seconds */
-  static final float DEFAULT_DISPATCH_INTERVAL = 0.0F;
+  /**
+   * Default delay between job dispatching attempts, in seconds. Dispatching is on by default: every node running
+   * this component is a candidate dispatcher, and the elected leader is decided automatically at runtime via
+   * {@link DispatchLeaseManager}. Set {@link #OPT_DISPATCHINTERVAL} to 0 on a node to explicitly exclude it from
+   * candidacy.
+   */
+  static final float DEFAULT_DISPATCH_INTERVAL = 2.0F;
 
   /** Multiplicative factor to transform dispatch interval captured in seconds to milliseconds */
   static final long DISPATCH_INTERVAL_MS_FACTOR = 1000;
 
   /** Default delay between checking if hosts are still alive in seconds * */
   static final long DEFAULT_HEART_BEAT = 60;
+
+  /** Default multiple of the dispatch interval used as the dispatch lease timeout, if not explicitly configured */
+  static final int DEFAULT_DISPATCH_LOCK_TIMEOUT_FACTOR = 3;
 
   private static final Logger logger = LoggerFactory.getLogger(JobDispatcher.class);
 
@@ -134,6 +145,9 @@ public class JobDispatcher {
   protected DBSession db;
 
   private ScheduledFuture jdfuture = null;
+
+  /** Elects a single active dispatcher across candidate nodes; null while dispatching is disabled on this node. */
+  private volatile DispatchLeaseManager leaseManager = null;
 
   /**
    * A list with job types that cannot be dispatched in each interation
@@ -229,9 +243,27 @@ public class JobDispatcher {
       }
     }
 
+    long dispatchLockTimeout = Math.round(dispatchInterval * DEFAULT_DISPATCH_LOCK_TIMEOUT_FACTOR);
+    String dispatchLockTimeoutString = StringUtils.trimToNull((String) properties.get(OPT_DISPATCH_LOCK_TIMEOUT));
+    if (StringUtils.isNotBlank(dispatchLockTimeoutString)) {
+      try {
+        dispatchLockTimeout = Long.parseLong(dispatchLockTimeoutString);
+      } catch (Exception e) {
+        logger.warn("Dispatch lock timeout '{}' is malformed, using default of {}s", dispatchLockTimeoutString,
+            dispatchLockTimeout);
+      }
+    }
+
     // Stop the current dispatch thread so we can configure a new one
     if (jdfuture != null) {
       jdfuture.cancel(true);
+    }
+
+    // Release any lease this node might still hold so another candidate can take over immediately, then discard the
+    // lease manager. A new one is created below if dispatching is (still) enabled.
+    if (leaseManager != null) {
+      leaseManager.release();
+      leaseManager = null;
     }
 
     // Schedule the job dispatching.
@@ -239,6 +271,7 @@ public class JobDispatcher {
       long dispatchIntervalMs = Math.round(dispatchInterval * DISPATCH_INTERVAL_MS_FACTOR);
       logger.info("Job dispatching is enabled");
       logger.debug("Starting job dispatching at a custom interval of {}s", dispatchInterval);
+      leaseManager = new DispatchLeaseManager(db, serviceRegistry.getRegistryHostname(), dispatchLockTimeout);
       jdfuture = scheduledExecutor.scheduleWithFixedDelay(getJobDispatcherRunnable(), dispatchIntervalMs,
           dispatchIntervalMs, TimeUnit.MILLISECONDS);
       // Schedule heartbeat for dispatching nodes
@@ -264,6 +297,12 @@ public class JobDispatcher {
         logger.error("Error shutting down the Job Dispatcher", e);
       }
     }
+
+    // Hand off leadership immediately rather than making other candidate nodes wait out the full lease timeout
+    if (leaseManager != null) {
+      leaseManager.release();
+      leaseManager = null;
+    }
   }
 
   Runnable getJobDispatcherRunnable() {
@@ -279,6 +318,12 @@ public class JobDispatcher {
      */
     @Override
     public void run() {
+      DispatchLeaseManager currentLeaseManager = leaseManager;
+      if (currentLeaseManager == null || !currentLeaseManager.tryAcquireOrRenew()) {
+        logger.debug("Not the elected dispatcher, skipping this round of job dispatch");
+        return;
+      }
+
       logger.debug("Starting job dispatch");
 
       undispatchableJobTypes = new ArrayList<>();

--- a/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/DispatchLeaseManagerTest.java
+++ b/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/DispatchLeaseManagerTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.serviceregistry.impl;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.opencastproject.db.DBTestEnv.newDBSession;
+
+import org.opencastproject.db.DBSession;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DispatchLeaseManagerTest {
+
+  private DBSession db;
+
+  @Before
+  public void setUp() {
+    db = newDBSession("org.opencastproject.common");
+  }
+
+  @After
+  public void tearDown() {
+    db.close();
+  }
+
+  @Test
+  public void onlyOneOfMultipleCandidatesAcquiresTheLease() {
+    DispatchLeaseManager nodeA = new DispatchLeaseManager(db, "nodeA", 60);
+    DispatchLeaseManager nodeB = new DispatchLeaseManager(db, "nodeB", 60);
+    DispatchLeaseManager nodeC = new DispatchLeaseManager(db, "nodeC", 60);
+
+    assertTrue(nodeA.tryAcquireOrRenew());
+    assertFalse(nodeB.tryAcquireOrRenew());
+    assertFalse(nodeC.tryAcquireOrRenew());
+  }
+
+  @Test
+  public void leaderCanRenewItsOwnLeaseRepeatedly() {
+    DispatchLeaseManager leader = new DispatchLeaseManager(db, "leader", 60);
+    DispatchLeaseManager other = new DispatchLeaseManager(db, "other", 60);
+
+    assertTrue(leader.tryAcquireOrRenew());
+    assertTrue(leader.tryAcquireOrRenew());
+    assertTrue(leader.tryAcquireOrRenew());
+    assertFalse(other.tryAcquireOrRenew());
+  }
+
+  @Test
+  public void anotherNodeCanAcquireAfterLeaseExpires() throws InterruptedException {
+    DispatchLeaseManager leader = new DispatchLeaseManager(db, "leader", 1);
+    DispatchLeaseManager successor = new DispatchLeaseManager(db, "successor", 60);
+
+    assertTrue(leader.tryAcquireOrRenew());
+    assertFalse(successor.tryAcquireOrRenew());
+
+    Thread.sleep(1500);
+
+    assertTrue(successor.tryAcquireOrRenew());
+    assertFalse(leader.tryAcquireOrRenew());
+  }
+
+  @Test
+  public void releaseAllowsImmediateTakeoverWithoutWaitingForTtl() {
+    DispatchLeaseManager leader = new DispatchLeaseManager(db, "leader", 60);
+    DispatchLeaseManager successor = new DispatchLeaseManager(db, "successor", 60);
+
+    assertTrue(leader.tryAcquireOrRenew());
+    assertFalse(successor.tryAcquireOrRenew());
+
+    leader.release();
+
+    assertTrue(successor.tryAcquireOrRenew());
+  }
+
+  @Test
+  public void releaseIsANoOpWhenNotHoldingTheLease() {
+    DispatchLeaseManager leader = new DispatchLeaseManager(db, "leader", 60);
+    DispatchLeaseManager other = new DispatchLeaseManager(db, "other", 60);
+
+    assertTrue(leader.tryAcquireOrRenew());
+
+    other.release();
+
+    assertFalse(other.tryAcquireOrRenew());
+  }
+}

--- a/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
+++ b/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
@@ -238,7 +238,10 @@ public class ServiceRegistryJpaImplTest {
     // Setup the job dispatcher
     ComponentContext cc = EasyMock.createNiceMock(ComponentContext.class);
     Dictionary<String, Object> jdProps = new Hashtable<>();
-    jdProps.put(JobDispatcher.OPT_DISPATCHINTERVAL, "0");
+    // Use a large interval so the periodic auto-dispatch never actually fires during the test (that would race with
+    // the manually-triggered runnable below) while still being > 0 so the dispatch lease manager gets created and
+    // manually-triggered dispatch runs can win the (uncontested) lease.
+    jdProps.put(JobDispatcher.OPT_DISPATCHINTERVAL, "600");
     EasyMock.expect(cc.getProperties()).andReturn(jdProps).anyTimes();
     EasyMock.replay(cc);
     jobDispatcher = new JobDispatcher();


### PR DESCRIPTION
Job dispatching (deciding which node picks up and runs a queued job) previously required manually enabling `dispatch.interval` on exactly one cluster node and disabling it everywhere else. Getting this wrong either stopped dispatching cluster-wide (if the sole enabled node went down) or caused two nodes to dispatch independently against the same database (if accidentally enabled on more than one), with only JPA optimistic locking on JpaJob as a soft, after-the-fact safeguard against the resulting races, which, in practice, caused issues for the entire cluster under load.

This introduces automatic leader election so admins no longer have to hand-pick a dispatch node:

- New `oc_dispatch_lock` table/entity (DispatchLockJpaImpl) holds a single-row lease: an owner and an expiry timestamp, seeded already expired (epoch) so the first node to look for it can always claim it. The table is created automatically by EclipseLink on next boot, same as every other entity in this persistence unit; no hand-written DB migration is needed.
- New DispatchLeaseManager acquires/renews the lease with a single, portable JPQL bulk UPDATE, comparing the stored expiry against the database's own CURRENT_TIMESTAMP rather than any node's local clock. Race safety comes entirely from the database engine's row-level locking during the update itself, so this works identically on MariaDB, PostgreSQL, and the H2 database used in tests, with no advisory locks and no vendor-specific SQL.
- JobDispatcher now tries to acquire or renew the lease at the start of every dispatch tick and only proceeds if it currently holds it. The lease is released proactively on clean shutdown and on reconfiguration, so a standby node can take over immediately instead of waiting out the full lease timeout. A new `dispatch.lock.timeout` property controls that timeout (default: 3x the dispatch interval).
- Dispatching is now enabled by default (`dispatch.interval=2`) on every node that runs this component, flipping the model from opt-in-one-node to opt-out-per-node: admins only need to touch config to explicitly exclude a node from ever becoming the dispatcher (`dispatch.interval=0`). Running dispatching on multiple admin/all-in-one nodes for HA is now the supported configuration rather than a misconfiguration to avoid.
- Removed the build-time `enableJobDispatching` mechanism (assemblies/*/pom.xml properties, the "job dispatching" Ant target in assemblies/resources/build.xml, and its invocation in assemblies/pom.xml) that used to patch the packaged config file per assembly, since the shipped default now covers it directly.
- Documented the mechanism in the developer architecture guide (job-dispatch.md, previously just a stub) and added an HA section to the multi-server admin installation guide.

Existing installs that already set `dispatch.interval` explicitly (whether 0 or a positive value) keep that behavior unchanged after upgrade; only nodes where the property was never set pick up the new default.

Adds DispatchLeaseManagerTest, covering contested acquisition between multiple candidates, self-renewal, TTL-based failover, explicit release, and releasing when not the current holder. Also adjusts the ComponentContext fixture in ServiceRegistryJpaImplTest, which previously disabled dispatching via `dispatch.interval=0` while manually driving the dispatch runnable directly for deterministic tests - it now uses a large interval so the periodic schedule never fires during the test while still letting the lease manager be created and the lease be won.

This fixes #7367

### How to test this patch

First, test with an all-in-one as usual. Nothing should change there. Then, build a small cluster. Here things get interesting:

First make sure you have a cluster-wide database (I use PostgreSQL for the following examples). Maybe use the dev containers for that:
```
podman-compose -f docker-compose-postgresql.yml up -d
```

Next, build the `allinone` distribution. I used two `allinone` nodes as the cluster:
```
mvnw clean install -Pallinone -DskipTests -Dcheckstyle.skip=true
```

Next, configure the cluster. To make things easy, put the following in `build/prep.sh` and then run the script to configure both nodes with `cd build; sh prep.sh`:

```sh
#!/bin/sh

set -eux

tar xf opencast-dist-*.tar.gz
mv opencast-dist-allinone opencast-dist-allinone-primary
tar xf opencast-dist-*.tar.gz
mv opencast-dist-allinone opencast-dist-allinone-secondary

mkdir -p shared-storage
ln -s ../../shared-storage opencast-dist-allinone-primary/data/opencast
ln -s ../../shared-storage opencast-dist-allinone-secondary/data/opencast

sed -i 's_localhost:8080_localhost:8081_' opencast-dist-allinone-secondary/etc/custom.properties
sed -i 's_port=8080_port=8081_' opencast-dist-allinone-secondary/etc/org.ops4j.pax.web.cfg

for node in allinone-primary allinone-secondary; do
  # configure database
  sed -i 's_^.*db.jdbc.driver=.*$_org.opencastproject.db.jdbc.driver=org.postgresql.Driver_' \
    "opencast-dist-${node}/etc/custom.properties"
  sed -i 's_^.*db.jdbc.url=.*$_org.opencastproject.db.jdbc.url=jdbc:postgresql://127.0.0.1/opencast_' \
    "opencast-dist-${node}/etc/custom.properties"
  sed -i 's_^.*db.jdbc.user=.*$_org.opencastproject.db.jdbc.user=opencast_' \
    "opencast-dist-${node}/etc/custom.properties"
  sed -i 's_^.*db.jdbc.pass=.*$_org.opencastproject.db.jdbc.pass=dbpassword_' \
    "opencast-dist-${node}/etc/custom.properties"

  # configure organization
  sed -i 's_^.*admin.ui.url=.*$_prop.org.opencastproject.admin.ui.url=http://localhost:8080_' \
    "opencast-dist-${node}/etc/org.opencastproject.organization-mh_default_org.cfg"
  sed -i 's_^.*engage.ui.url=.*$_prop.org.opencastproject.engage.ui.url=http://localhost:8081_' \
    "opencast-dist-${node}/etc/org.opencastproject.organization-mh_default_org.cfg"
  sed -i 's_^.*file.repo.url=.*$_prop.org.opencastproject.file.repo.url=${prop.org.opencastproject.admin.ui.url}_' \
    "opencast-dist-${node}/etc/org.opencastproject.organization-mh_default_org.cfg"

  # Enable debug logs for service registry
  sed -i 's/#log4j2.logger.ingest.level = DEBUG/log4j2.logger.ingest.level = DEBUG/' \
    "opencast-dist-${node}/etc/org.ops4j.pax.logging.cfg"
  sed -i 's/#log4j2.logger.ingest.name = org.opencastproject.ingest/log4j2.logger.ingest.name = org.opencastproject.serviceregistry.impl/' \
    "opencast-dist-${node}/etc/org.ops4j.pax.logging.cfg"
done
```

Then in two terminal windows run `./bin/start-opencast` in the primary and secondary folders. You should see the one you start first dispatching jobs in the debug logs if you run `log:tail` in the Karaf consoles. The second one should skip dispatching.

If you turn off the one you start first, the secondary should take over.

### How this looks in action

<img width="2537" height="1343" alt="Screenshot from 2026-07-19 13-10-16" src="https://github.com/user-attachments/assets/b9a708a2-4e31-4314-b7be-31d51d27f7ac" />

*Secondary is dispatching jobs. Primary is skipping job dispatching.*

—

<img width="2348" height="1392" alt="Screenshot from 2026-07-19 13-10-32" src="https://github.com/user-attachments/assets/ca59feb9-e431-40cf-ae5e-c18d6a5c5a2e" />

*Primary took over job dispatching after secondary was shut down.*

### AI Usage

Code and docs mostly generated with Claude Sonnet.


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
