### PR TITLE
Fix timelinepreview error for events with captions track

### DIFF
--- a/etc/workflows/partial-publish.yaml
+++ b/etc/workflows/partial-publish.yaml
@@ -113,7 +113,7 @@ operations:
     exception-handler-workflow: partial-error
     description: Creating timeline preview images
     configurations:
-      - source-flavor: '*/trimmed'
+      - source-flavors: presenter/trimmed,presentation/trimmed
       - target-flavor: '*/timeline+preview'
       - target-tags: engage-download
       - image-count: 100


### PR DESCRIPTION
For events with a captions track, the `timelinepreview` step in the partial-publish workflow always fails. This is because, when using `*/trimmed` as source-flavor, `timelinepreview` tries to create a preview for the captions track, which is not possible.
This PR uses `presenter/trimmed,presentation/trimmed` as source-flavors instead.

### How to test this patch

1. Go to Opencast, create an event and upload a video and a subtitle file
2. Publish the event
3. Check if `timelinepreview` is failing

This problem is already present in Opencast 19, therefore the PR targets the legacy branch.

### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
