### PR TITLE
Fix captions not being published

### DIFF
--- a/etc/workflows/partial-theming.yaml
+++ b/etc/workflows/partial-theming.yaml
@@ -32,7 +32,7 @@ operations:
       - source-flavors: captions/trimmed
       - target-flavor: captions/shifted
       - copy: false
-  
+
   - id: tag
     if: NOT ${theme_active}
     description: If no shifting was necessary, mark the trimmed chapters as shifted

--- a/etc/workflows/partial-theming.yaml
+++ b/etc/workflows/partial-theming.yaml
@@ -27,6 +27,14 @@ operations:
 
   - id: tag
     if: NOT ${theme_active}
+    description: If no shifting was necessary, mark the trimmed captions as shifted
+    configurations:
+      - source-flavors: captions/trimmed
+      - target-flavor: captions/shifted
+      - copy: false
+  
+  - id: tag
+    if: NOT ${theme_active}
     description: If no shifting was necessary, mark the trimmed chapters as shifted
     configurations:
       - source-flavors: chapters/trimmed


### PR DESCRIPTION
Fixes #7789

Removes captions from beeing marked as "themed". Captions with flavor `captions/themed` are not processed in the partial-theming WF, not marked as "shifted" and therefore not tagged for publication either.

### How to test this patch

1. Go to Opencast, create an event and upload a video and a subtitle file
2. Publish the event using the schedule-and-upload WF
3. Open the Paella Player to check that the subtitles are not available

This problem is already present in Opencast 19, therefore the PR targets the legacy branch.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
