### PR TITLE
Prevent scheduler from deleting events that have been processed

### DIFF
--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -872,6 +872,12 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
         notFoundInDatabase = true;
       }
 
+      // If the mediapackage has been processed, don't remove it elsewhere
+      Optional<Snapshot> latestSnapshot = assetManager.getLatestSnapshot(mediaPackageId);
+      if (latestSnapshot.get().getOwner() != SNAPSHOT_OWNER) {
+        return;
+      }
+
       // Delete scheduler snapshot
       long deletedSnapshots = assetManager.deleteSnapshots(mediaPackageId);
       notFoundInAssetManager = deletedSnapshots == 0;

--- a/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
+++ b/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
@@ -805,7 +805,7 @@ public class SchedulerServiceImplTest {
     assertTrue(schedSvc.getCaptureAgentConfiguration(randomMpId).size() >= caProperties.size());
   }
 
-  @Test(expected = SchedulerConflictException.class)
+  @Test(expected = SchedulerException.class)
   public void testAddMultipleEventsConflict() throws Exception {
     for (int i = 0; i < 2; i++) {
       final RRule rrule = new RRule("FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=7;BYMINUTE=30");


### PR DESCRIPTION
Fixes #6629

Removing a scheduled event completely requires deleting scheduling info from the database, as well as removing it from the asset manager and index. This is done by the `removeEvent` method in the SchedulerService.

However, when a scheduled event has been processed, this deletion process becomes half-hearted, as it does not fully delete the event anymore (e.g. the event remains in search). This patch proposes that for former scheduled events only the scheduling info is removed when calling `removeEvent` in the SchedulerService. This way the event remains intact, but scheduling info can still be removed.

### How to test this patch

See the linked issue for how one might test this patch.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
