### PR TITLE
Fix some maven warnings

### DIFF
--- a/modules/security-jwt/pom.xml
+++ b/modules/security-jwt/pom.xml
@@ -43,10 +43,6 @@
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
-      <artifactId>spring-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
       <artifactId>spring-expression</artifactId>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -641,6 +641,11 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>3.1.4</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.5.3</version>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1159,7 +1159,7 @@
       <dependency>
         <groupId>xml-apis</groupId>
         <artifactId>xml-apis</artifactId>
-        <version>2.0.2</version>
+        <version>1.0.b2</version>
       </dependency>
       <!-- logging -->
       <dependency>


### PR DESCRIPTION
Fixes some warnings during the maven build. See individual commits for some more details.

This was created with the help of Opencode (the harness) using the Opencode (the service provider) Zen „Big Pickle“ model (which is a stealth model, though, so this is not really useful information).