### PR TITLE
#7805: Speechtotext workflow operation save JSON file

### DIFF
--- a/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/SpeechToTextServiceImpl.java
+++ b/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/SpeechToTextServiceImpl.java
@@ -145,6 +145,7 @@ public class SpeechToTextServiceImpl extends AbstractJobProducer implements Spee
       translate = false;
     }
     URI subtitleFilesURI;
+    URI jsonURI;
     var name = String.format("job-%d", job.getId());
     var jobDir  = Path.of(workspace.rootDirectory(), "collection", COLLECTION, name).toFile();
 
@@ -161,12 +162,23 @@ public class SpeechToTextServiceImpl extends AbstractJobProducer implements Spee
       try (FileInputStream in = new FileInputStream(result.getSubtitleFile())) {
         subtitleFilesURI = workspace.putInCollection(COLLECTION, outputName, in);
       }
+
+      // also put json in collection
+      final var jsonOutputName = String.format("%d-%s.json", job.getId(),
+                                  FilenameUtils.getBaseName(mediaFile.getPath()));
+      final var jsonFile = FilenameUtils.removeExtension(result.getSubtitleFile().getAbsolutePath()) + ".json";
+
+      try (FileInputStream in = new FileInputStream(jsonFile)) {
+        jsonURI = workspace.putInCollection(COLLECTION, jsonOutputName, in);
+      }
     } catch (Exception e) {
       throw new SpeechToTextServiceException("Error while generating subtitle from " + mediaFile, e);
     } finally {
       FileUtils.deleteQuietly(jobDir);
     }
-    return subtitleFilesURI.toString() + "," + language + "," + speechToTextEngine.getEngineName();
+
+    return subtitleFilesURI.toString() + "," + language + "," + speechToTextEngine.getEngineName()
+                            + "," + jsonURI.toString();
   }
 
 

--- a/modules/speech-to-text-workflowoperation/src/main/java/org/opencastproject/workflow/handler/speechtotext/SpeechToTextWorkflowOperationHandler.java
+++ b/modules/speech-to-text-workflowoperation/src/main/java/org/opencastproject/workflow/handler/speechtotext/SpeechToTextWorkflowOperationHandler.java
@@ -319,6 +319,7 @@ public class
       URI output = new URI(jobOutput[0]);
       String outputLanguage = jobOutput[1];
       String engineType = jobOutput[2];
+      URI jsonOutput = new URI(jobOutput[3]);
 
       MediaPackageElement subtitleMediaPackageElement;
       switch (appendSubtitleAs) {
@@ -357,6 +358,30 @@ public class
       applyTargetTagsToElement(targetTags, subtitleMediaPackageElement);
 
       parentMediaPackage.add(subtitleMediaPackageElement);
+
+      // attach json
+      try {
+        AttachmentImpl jsonAttachment = new AttachmentImpl();
+        jsonAttachment.generateIdentifier();
+
+        try (InputStream jsonIn = workspace.read(jsonOutput)) {
+          URI jsonUri = workspace.put(
+              parentMediaPackage.getIdentifier().toString(),
+              jsonAttachment.getIdentifier(),
+              FilenameUtils.getName(jsonOutput.getPath()),
+              jsonIn
+          );
+          jsonAttachment.setURI(jsonUri);
+        }
+
+        jsonAttachment.setFlavor(MediaPackageElementFlavor.parseFlavor("captions/json"));
+        jsonAttachment.addTag("archive");
+        parentMediaPackage.add(jsonAttachment);
+
+        workspace.delete(jsonOutput);
+      } catch (Exception e) {
+        throw new WorkflowOperationException("No JSON URI in speech-to-text payload {}", e);
+      }
 
       workspace.delete(output);
     } catch (Exception e) {


### PR DESCRIPTION
Modifies SpeechToTextServiceImpl.java to add the JSON generated by Whisper into the collection and return its URI, and SpeechToTextWorkflowOperationHandler.java to attach the JSON to the mediapackage as an attachment with flavor captions/json

### How to test this patch
Run the speechtotext workflow operation and afterward the JSON file will be attached to the event as an Attachment.

Currently being used in University of Cape Town's OpenCast system: https://github.com/cilt-uct/opencast/pull/433 OPENCAST-3440: Modify speech-to-text workflow operation to attach JSON file produced by Whisper- #433

### AI Usage
Minimal, code is based on vtt attachment code

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [-] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [-] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
