### PR TITLE
Group dependabot PRs for minor/patch updates in lti module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,9 +26,10 @@ updates:
   schedule:
     interval: monthly
   groups:
-    fontawesome:
-      patterns:
-        - "@fortawesome*"
+    minor-and-patch:
+      update-types:
+        - minor
+        - patch
   open-pull-requests-limit: 10
 - package-ecosystem: npm
   directory: "/modules/runtime-info-ui"


### PR DESCRIPTION
Instead of having a PR for every dependency that changed, this patch makes dependabot bundle them up into a single PR, as long as it is a minor or patch version change. This is something we are doing in the admin ui and editor repos already.

The goal is to make upgrading dependencies easier and faster for committers. It also reduces clutter on the pull request web page.

Maybe we could do this for other modules as well? Have not checked if it would be reasonable.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
