### PR TITLE
Add player thumbnails to internal publication in community workflows

### DIFF
--- a/etc/workflows/fast.yaml
+++ b/etc/workflows/fast.yaml
@@ -99,7 +99,7 @@ operations:
     exception-handler-workflow: partial-error
     description: Publish to preview publication channel
     configurations:
-      - download-source-flavors: '*/preview'
+      - download-source-flavors: '*/preview,*/player+preview'
       - channel-id: internal
       - url-pattern: ${org_org_opencastproject_admin_ui_url!'http://localhost:8080'}/editor-ui/index.html?id=${event_id}
       - check-availability: false

--- a/etc/workflows/partial-publish.yaml
+++ b/etc/workflows/partial-publish.yaml
@@ -213,6 +213,18 @@ operations:
   # Send the encoded material along with the metadata to the
   # publication channels.
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  # Publish to internal
+  - id: publish-configure
+    exception-handler-workflow: partial-error
+    description: Publish to preview publication channel
+    configurations:
+      - download-source-tags: preview,editor
+      - download-source-flavors: '*/player+preview'
+      - channel-id: internal
+      - url-pattern: ${org_org_opencastproject_admin_ui_url!'http://localhost:8080'}/editor-ui/index.html?id=${event_id}
+      - check-availability: false
+
   # Publish to engage player
   - id: publish-engage
     max-attempts: 2


### PR DESCRIPTION
Adds the automatically generated player thumbnails to the interal publication, so that the editor can pick up on them and display them in the frontend.

### How to test this patch
Enable the thumbnail view in the editor in `etc/ui-config/mh_default_org/editor/editor-settings.toml`.
Upload an event with the fast and schedule-and-upload workflows. Check that the thumbnails show up in the thumbnail view in the editor.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
