### PR TITLE
Fix some metrics in MetricsExporter not going back to 0

### DIFF
--- a/modules/metrics-exporter/src/main/java/org/opencastproject/metrics/impl/MetricsExporter.java
+++ b/modules/metrics-exporter/src/main/java/org/opencastproject/metrics/impl/MetricsExporter.java
@@ -44,8 +44,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.StringWriter;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletResponse;
@@ -132,6 +133,10 @@ public class MetricsExporter {
   private OrganizationDirectoryService organizationDirectoryService;
   private AssetManager assetManager;
 
+  private final Set<String> previousWorkflowOrganizations = new HashSet<>();
+  private final Set<JobLabel> previousJobLabels = new HashSet<>();
+  private record JobLabel(String host, String organization) { }
+
   @Activate
   public void activate(BundleContext bundleContext) {
     final Version version = bundleContext.getBundle().getVersion();
@@ -168,19 +173,44 @@ public class MetricsExporter {
     }
 
     // set workflows by organization
-    for (var entry: serviceRegistry.countActiveTypeByOrganization("START_WORKFLOW").entrySet()) {
+    final var workflows = serviceRegistry.countActiveTypeByOrganization("START_WORKFLOW");
+    for (var entry : workflows.entrySet()) {
       workflowsActive.labels(entry.getKey()).set(entry.getValue());
     }
 
-    // set jobs by organization and host
-    for (var entry: serviceRegistry.countActiveByOrganizationAndHost().entrySet()) {
-      final var org = entry.getKey();
-      for (Map.Entry<String, Long> orgEntry: entry.getValue().entrySet()) {
-        final var host = orgEntry.getKey();
-        final var count = orgEntry.getValue();
-        jobsActive.labels(host, org).set(count);
+    for (var organization : previousWorkflowOrganizations) {
+      if (!workflows.containsKey(organization)) {
+        workflowsActive.labels(organization).set(0);
       }
     }
+
+    previousWorkflowOrganizations.clear();
+    previousWorkflowOrganizations.addAll(workflows.keySet());
+
+    // set jobs by organization and host
+    final var jobs = serviceRegistry.countActiveByOrganizationAndHost();
+    final var currentJobLabels = new HashSet<JobLabel>();
+
+    for (var entry : jobs.entrySet()) {
+      final var organization = entry.getKey();
+
+      for (var orgEntry : entry.getValue().entrySet()) {
+        final var host = orgEntry.getKey();
+        final var count = orgEntry.getValue();
+
+        jobsActive.labels(host, organization).set(count);
+        currentJobLabels.add(new JobLabel(host, organization));
+      }
+    }
+
+    for (var label : previousJobLabels) {
+      if (!currentJobLabels.contains(label)) {
+        jobsActive.labels(label.host(), label.organization()).set(0);
+      }
+    }
+
+    previousJobLabels.clear();
+    previousJobLabels.addAll(currentJobLabels);
 
     // Get numbers from asset manager
     if (assetManager != null && organizationDirectoryService.getOrganizations().size() == 1) {


### PR DESCRIPTION
Fixes #7244.

The metrics `opencast_workflow_active`, `opencast_job_active` would not drop back down to 0, even if there were no more workflows or jobs running. This intends to fix that.

This is a rather wordy fix, but I could not come up with a more concise solution. In particular, I did not want to modify the SQL queries too much to not risk impacting performance.

I'm not sure if setting `opencast_workflow_active` and `opencast_job_active` to 0 is the right thing to do here, or if it would be better to remove them. Because initially, before any workflow or job has run, those fields do not exist in the response, so maybe that is what is expected?

### How to test this patch

Can be tested as is. See the linked issue for reproduction steps.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
