### PR TITLE
Avoid failing ZipWOH at inopportune time

### DIFF
--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ZipWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ZipWorkflowOperationHandler.java
@@ -229,6 +229,13 @@ public class ZipWorkflowOperationHandler extends AbstractWorkflowOperationHandle
       throw new WorkflowOperationException("Unable to create a zip archive from mediapackage " + mediaPackage, e);
     }
 
+    Checksum checksum;
+    try {
+      checksum = Checksum.create(ChecksumType.DEFAULT_TYPE, zip);
+    } catch (IOException e) {
+      throw new WorkflowOperationException("Unable to calculate checksum for zip file " + zip, e);
+    }
+
     // Get the collection for storing the archived mediapackage
     String configuredCollectionId = currentOperation.getConfiguration(ZIP_COLLECTION_PROPERTY);
     String collectionId = configuredCollectionId == null ? DEFAULT_ZIP_COLLECTION : configuredCollectionId;
@@ -253,11 +260,7 @@ public class ZipWorkflowOperationHandler extends AbstractWorkflowOperationHandle
 
     Attachment attachment = (Attachment) MediaPackageElementBuilderFactory.newInstance().newElementBuilder()
             .elementFromURI(uri, Type.Attachment, targetFlavor);
-    try {
-      attachment.setChecksum(Checksum.create(ChecksumType.DEFAULT_TYPE, zip));
-    } catch (IOException e) {
-      throw new WorkflowOperationException(e);
-    }
+    attachment.setChecksum(checksum);
     attachment.setMimeType(MimeTypes.ZIP);
 
     // Apply the target tags


### PR DESCRIPTION
Fixes #1172.

Moves the checksum calculation before adding the zip to the collection. This prevents an issue where an
exception would leave a zip in the workspace.

### How to test this patch

You can use the [ZIP WOH](https://docs.opencast.org/r/20.x/admin/#workflowoperationhandlers/zip-woh/) to test this.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
