### PR TITLE
Report ACLs with deny rules once per index rebuild

### DIFF
--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/event/EventIndexUtils.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/event/EventIndexUtils.java
@@ -31,6 +31,7 @@ import org.opencastproject.elasticsearch.index.ElasticsearchIndex;
 import org.opencastproject.elasticsearch.index.objects.series.Series;
 import org.opencastproject.elasticsearch.index.objects.series.SeriesIndexSchema;
 import org.opencastproject.elasticsearch.index.objects.series.SeriesSearchQuery;
+import org.opencastproject.elasticsearch.index.rebuild.DenyAclCollector;
 import org.opencastproject.list.api.DefaultResourceListQuery;
 import org.opencastproject.list.api.ResourceListQuery;
 import org.opencastproject.mediapackage.Attachment;
@@ -407,7 +408,10 @@ public final class EventIndexUtils {
     // Convert roles to permission blocks
     for (AccessControlEntry entry : entries) {
       if (!entry.isAllow()) {
-        logger.info("Event index does not support denial via ACL, ignoring {}", entry);
+        // The index cannot express denial, so the entry is dropped. Record the event rather than
+        // logging here: during a rebuild this fires once per deny entry per event, which floods
+        // the log. IndexRebuildService reports the collected events once the rebuild finishes.
+        DenyAclCollector.record(eventId);
         continue;
       }
       List<String> actionPermissions = permissions.get(entry.getAction());

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/series/SeriesIndexUtils.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/series/SeriesIndexUtils.java
@@ -23,6 +23,7 @@ package org.opencastproject.elasticsearch.index.objects.series;
 
 import org.opencastproject.elasticsearch.api.SearchMetadata;
 import org.opencastproject.elasticsearch.impl.SearchMetadataCollection;
+import org.opencastproject.elasticsearch.index.rebuild.DenyAclCollector;
 import org.opencastproject.security.api.AccessControlEntry;
 import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.security.api.AccessControlParser;
@@ -128,7 +129,7 @@ public final class SeriesIndexUtils {
 
     if (StringUtils.trimToNull(series.getAccessPolicy()) != null) {
       metadata.addField(SeriesIndexSchema.ACCESS_POLICY, series.getAccessPolicy());
-      addAuthorization(metadata, series.getAccessPolicy());
+      addAuthorization(metadata, series.getAccessPolicy(), series.getIdentifier());
     }
     if (series.getTheme() != null) {
       metadata.addField(SeriesIndexSchema.THEME, series.getTheme());
@@ -163,8 +164,10 @@ public final class SeriesIndexUtils {
    *          the input document
    * @param aclString
    *          the access control list string
+   * @param seriesId
+   *          the identifier of the series being indexed
    */
-  private static void addAuthorization(SearchMetadataCollection doc, String aclString) {
+  private static void addAuthorization(SearchMetadataCollection doc, String aclString, String seriesId) {
     Map<String, List<String>> permissions = new HashMap<>();
 
     // Define containers for common permissions
@@ -175,7 +178,10 @@ public final class SeriesIndexUtils {
     AccessControlList acl = AccessControlParser.parseAclSilent(aclString);
     for (AccessControlEntry entry : acl.getEntries()) {
       if (!entry.isAllow()) {
-        logger.info("Series index does not support denial via ACL, ignoring {}", entry);
+        // The index cannot express denial, so the entry is dropped. Record the series rather than
+        // logging here: during a rebuild this fires once per deny entry per series, which floods
+        // the log. IndexRebuildService reports the collected series once the rebuild finishes.
+        DenyAclCollector.record(seriesId);
         continue;
       }
       List<String> actionPermissions = permissions.get(entry.getAction());

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/rebuild/DenyAclCollector.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/rebuild/DenyAclCollector.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.elasticsearch.index.rebuild;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Collects the identifiers of objects whose ACL contains deny rules, so that an index rebuild can
+ * report them once at the end instead of logging a line per entry.
+ *
+ * <p>The search index cannot express denial, so such entries are dropped when an object is indexed.
+ * That is worth telling an administrator about, but the per-entry message it used to produce fired
+ * once per deny entry per object and drowned the rebuild log.
+ *
+ * <p>Collection is only active between {@link #start()} and {@link #stop()}, which
+ * {@link IndexRebuildService} brackets a rebuild with. Outside a rebuild — during ordinary
+ * indexing — {@link #record} does nothing beyond a volatile read, so nothing accumulates in a
+ * long-running instance.
+ *
+ * <p>State is held per thread. A rebuild runs on the thread that called it, and keeping the
+ * collected ids thread-local means concurrent ordinary indexing on other threads cannot add to a
+ * rebuild's report, nor can two rebuilds interfere.
+ */
+public final class DenyAclCollector {
+
+  /** Ids collected for the rebuild running on this thread, or null when no rebuild is running. */
+  private static final ThreadLocal<Set<String>> COLLECTED = new ThreadLocal<>();
+
+  private DenyAclCollector() {
+  }
+
+  /**
+   * Start collecting on the current thread, discarding anything previously collected.
+   */
+  public static void start() {
+    COLLECTED.set(new LinkedHashSet<>());
+  }
+
+  /**
+   * Note that the object with the given identifier carries at least one deny entry. Does nothing
+   * when no rebuild is running on this thread.
+   *
+   * @param identifier
+   *          the identifier of the event or series, may be null
+   */
+  public static void record(String identifier) {
+    Set<String> collected = COLLECTED.get();
+    if (collected != null && identifier != null) {
+      collected.add(identifier);
+    }
+  }
+
+  /**
+   * Return the identifiers collected on this thread, in encounter order.
+   *
+   * @return the identifiers, empty if no rebuild is running
+   */
+  public static Set<String> collected() {
+    Set<String> collected = COLLECTED.get();
+    return collected == null ? Collections.emptySet() : Collections.unmodifiableSet(collected);
+  }
+
+  /**
+   * Stop collecting on the current thread and release the collected identifiers.
+   */
+  public static void stop() {
+    COLLECTED.remove();
+  }
+
+}

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/rebuild/IndexRebuildService.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/rebuild/IndexRebuildService.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -209,14 +210,43 @@ public class IndexRebuildService implements BundleActivator {
     Service service = indexProducer.getService();
     logger.info("Starting to rebuild the {} index", service);
     setRebuildState(service, IndexRebuildService.State.RUNNING);
+    DenyAclCollector.start();
     try {
       indexProducer.repopulate(dataType);
       setRebuildState(service, IndexRebuildService.State.OK);
     } catch (IndexRebuildException e) {
       setRebuildState(service, IndexRebuildService.State.ERROR);
       throw e;
+    } finally {
+      reportDeniedAcls(service);
+      DenyAclCollector.stop();
     }
     logger.info("Finished rebuilding the {} index", service);
+  }
+
+  /**
+   * Report objects whose ACL contains deny rules, which the index cannot express and therefore
+   * dropped while indexing.
+   *
+   * <p>Deny entries mean the data in Opencast should be corrected, so the summary is a warning.
+   * It is emitted once per rebuilt service rather than once per entry, which is what used to
+   * flood the rebuild log. The affected identifiers follow at debug level so they remain
+   * obtainable on the fly without turning the summary itself into a wall of text.
+   *
+   * @param service
+   *          the service that was rebuilt
+   */
+  private void reportDeniedAcls(Service service) {
+    Set<String> denied = DenyAclCollector.collected();
+    if (denied.isEmpty()) {
+      return;
+    }
+    logger.warn("Rebuilding the {} index ignored deny rules in the access control lists of {} object(s). "
+            + "The index cannot express denial, so those rules have no effect and the data should be corrected. "
+            + "Enable debug logging for {} to list the affected identifiers.",
+        service, denied.size(), IndexRebuildService.class.getName());
+    logger.debug("Objects with deny rules in their access control list while rebuilding the {} index: {}",
+        service, String.join(", ", denied));
   }
 
   /**

--- a/modules/elasticsearch-index/src/test/java/org/opencastproject/elasticsearch/index/rebuild/DenyAclCollectorTest.java
+++ b/modules/elasticsearch-index/src/test/java/org/opencastproject/elasticsearch/index/rebuild/DenyAclCollectorTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.elasticsearch.index.rebuild;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.List;
+
+public class DenyAclCollectorTest {
+
+  @After
+  public void tearDown() {
+    DenyAclCollector.stop();
+  }
+
+  /**
+   * Outside a rebuild nothing is collected, so ordinary indexing in a long-running instance does
+   * not accumulate identifiers.
+   */
+  @Test
+  public void testRecordsNothingWhileNoRebuildIsRunning() {
+    DenyAclCollector.record("event-1");
+    assertTrue(DenyAclCollector.collected().isEmpty());
+  }
+
+  /**
+   * Each affected object is reported once regardless of how many deny entries its ACL carries,
+   * which is the flooding this replaces.
+   */
+  @Test
+  public void testCollectsEachIdentifierOnceInEncounterOrder() {
+    DenyAclCollector.start();
+    DenyAclCollector.record("event-2");
+    DenyAclCollector.record("event-1");
+    DenyAclCollector.record("event-2");
+
+    assertEquals(List.of("event-2", "event-1"), List.copyOf(DenyAclCollector.collected()));
+  }
+
+  /**
+   * A null identifier must not be collected or cause a failure while indexing.
+   */
+  @Test
+  public void testIgnoresNullIdentifier() {
+    DenyAclCollector.start();
+    DenyAclCollector.record(null);
+    assertTrue(DenyAclCollector.collected().isEmpty());
+  }
+
+  /**
+   * Stopping releases the collected identifiers, so a later rebuild does not inherit them.
+   */
+  @Test
+  public void testStopClearsCollectedIdentifiers() {
+    DenyAclCollector.start();
+    DenyAclCollector.record("event-1");
+    DenyAclCollector.stop();
+
+    assertTrue(DenyAclCollector.collected().isEmpty());
+  }
+
+  /**
+   * Collection is per thread, so ordinary indexing running concurrently on another thread cannot
+   * add to a rebuild's report.
+   */
+  @Test
+  public void testCollectionIsIsolatedPerThread() throws Exception {
+    DenyAclCollector.start();
+    DenyAclCollector.record("event-1");
+
+    Thread other = new Thread(() -> DenyAclCollector.record("event-from-other-thread"));
+    other.start();
+    other.join();
+
+    assertEquals(List.of("event-1"), List.copyOf(DenyAclCollector.collected()));
+  }
+
+}


### PR DESCRIPTION
Reworked per @gregorydlogan's review: this now reports a once-per-rebuild summary rather than lowering the log level.

## The problem

`EventIndexUtils` and `SeriesIndexUtils` logged an `info` message for every non-allow ACL entry. During a full index rebuild that fires **once per deny entry per object**, which is what the reporter of #6560 hit.

The original patch simply lowered both to `debug`. @lkiesow pointed out that the level was deliberate — a deny entry means the data in Opencast is faulty and should be corrected, because the search index cannot express denial and silently drops such rules. Demoting to `debug` would have hidden that signal entirely.

## What this does instead

- Collects the identifiers of affected objects while indexing.
- Emits **one `warn` per rebuilt service**: how many objects carry deny rules, and that the data should be corrected.
- Immediately follows it with the **list of affected identifiers at `debug`**, so the detail stays obtainable on the fly without turning the summary into a wall of text.

That is @gregorydlogan's suggestion as written — warning or higher for the summary, identifiers at debug right after.

Example on an installation with three affected events:

```
WARN  Rebuilding the AssetManager index ignored deny rules in the access control lists
      of 3 object(s). The index cannot express denial, so those rules have no effect and
      the data should be corrected. Enable debug logging for
      org.opencastproject.elasticsearch.index.rebuild.IndexRebuildService to list the
      affected identifiers.
DEBUG Objects with deny rules in their access control list while rebuilding the
      AssetManager index: 8f5a..., 91cd..., a034...
```

## Design notes

`DenyAclCollector` is deliberately inert outside a rebuild. `IndexRebuildService.rebuildIndexInternal` — the single funnel all three rebuild entry points pass through — brackets the rebuild with `start()`/`stop()` in a `finally`, so:

- **Ordinary indexing accumulates nothing.** These util methods are also reached during normal operation, so an unconditional static collector would grow without bound in a long-running instance. Outside a rebuild, `record()` does nothing beyond a volatile read.
- **State is per thread.** Concurrent ordinary indexing on other threads cannot add to a rebuild's report, and two rebuilds cannot interfere.
- **The summary is emitted even if the rebuild fails**, since it is in the `finally` — a rebuild that dies partway still reports what it found.

## On the broader ACL question

@lkiesow raised two larger ideas — providing a way to repair ACLs, and preventing deny rules from being ingested. I have deliberately kept both out of this PR, and I still think that is right: `isAllow()` is honoured across `authorization-xacml`, `AccessControlUtil`, the asset manager, the external API and playlists, so forbidding deny rules is a semantic change to the ACL model with a migration story for existing data. It deserves its own issue rather than riding along on a logging fix. @gregorydlogan's "+1 ... I'm not picky on who does the work" reads to me as agreement that it is separable.

Worth recording for whoever picks that up: where deny *is* honoured it appears already broken. `AccessControlUtil.isAuthorized` returns on the **first** entry whose action and role match, so a deny does not override a matching allow — whichever comes first in the list wins, making deny entries order-dependent rather than restrictive.

## How to test this patch

Reviewing the diff is probably faster than reproducing, since triggering it needs an installation with deny rules in its ACLs. If you want to see it live: add a non-allow entry to an event or series ACL, then trigger a rebuild with `curl -u admin:opencast -X POST localhost:8080/index/rebuild` and watch `opencast.log` for the `warn` line. Set `org.opencastproject.elasticsearch.index.rebuild` to `DEBUG` in `etc/org.ops4j.pax.logging.cfg` to also see the identifier list.

`DenyAclCollectorTest` covers the collector's five behaviours: nothing collected outside a rebuild, each identifier collected once in encounter order, null identifiers ignored, `stop()` clearing state, and per-thread isolation. Each was confirmed to fail against a deliberately broken collector before being kept — for example, making collection unconditional fails `testRecordsNothingWhileNoRebuildIsRunning`.

Module suite: 10 tests, 0 failures. Repo-wide `./mvnw checkstyle:check`: 0 violations.

## AI Usage

This change was prepared with the assistance of Claude Code (model Claude Opus 5, provider Anthropic). The tool was used to trace the rebuild entry points and the deny-rule handling, write the collector and its tests, verify the tests fail against broken implementations, and draft this description. A human reviewed the change and approved sending it.

## Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
