### PR TITLE
Do not overwrite terminal state in WorkflowServiceImpl.stop()

### DIFF
--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -860,7 +860,9 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
     try {
       WorkflowInstance instance = getWorkflowById(workflowInstanceId);
 
-      if (instance.getState() != STOPPED) {
+      // Only workflows which have not yet terminated can be stopped. Overwriting the state of an already terminated
+      // workflow would discard how it actually ended, turning e.g. a SUCCEEDED workflow into a STOPPED one.
+      if (!instance.getState().isTerminated()) {
         // Update the workflow instance
         instance.setState(STOPPED);
         update(instance);

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceImplTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceImplTest.java
@@ -297,6 +297,20 @@ public class WorkflowServiceImplTest {
   }
 
   @Test
+  public void testStopDoesNotOverwriteTerminatedState() throws Exception {
+    // A workflow which ran to completion must keep its SUCCEEDED state when stop() is called on it, so that the
+    // record of how it actually ended is not lost.
+    WorkflowInstance succeeded = startAndWait(workingDefinition, mediapackage1, WorkflowState.SUCCEEDED);
+    Assert.assertEquals(WorkflowState.SUCCEEDED, service.stop(succeeded.getId()).getState());
+    Assert.assertEquals(WorkflowState.SUCCEEDED, service.getWorkflowById(succeeded.getId()).getState());
+
+    // Failed workflows are terminated as well and must be left alone likewise.
+    WorkflowInstance failed = startAndWait(failingDefinitionWithoutErrorHandler, mediapackage2, WorkflowState.FAILED);
+    Assert.assertEquals(WorkflowState.FAILED, service.stop(failed.getId()).getState());
+    Assert.assertEquals(WorkflowState.FAILED, service.getWorkflowById(failed.getId()).getState());
+  }
+
+  @Test
   public void testGetWorkflowByMediaPackageId() throws Exception {
     // Ensure that the database doesn't have a workflow instance with this media package
     Assert.assertEquals(0, service.countWorkflowInstances());


### PR DESCRIPTION
`WorkflowServiceImpl.stop()` guarded its state update with `!= STOPPED` only:

```java
if (instance.getState() != STOPPED) {
  instance.setState(STOPPED);
  update(instance);
}
```

So calling `stop()` on a workflow that had already `SUCCEEDED` or `FAILED`
rewrote that terminal state to `STOPPED`, discarding the record of how the
workflow actually ended. This replaces the check with the existing
`WorkflowState.isTerminated()` predicate, which covers `STOPPED`, `SUCCEEDED`
and `FAILED` — the same predicate `remove()` already uses a few methods below.

`FAILING` is deliberately still stoppable, since it is not yet terminated.

### A note on the interpretation of the issue

The issue says stopping "doesn't make a lot of sense" in some states, which
could also be read as asking `stop()` to *reject* those states, the way
`resume()` throws `IllegalStateException`. I did not do that, because it would
break event deletion: `IndexServiceImpl.removeEvent()` calls `stop()` on every
workflow belonging to an event — including terminated ones — before calling
`remove()`, and a thrown `WorkflowException` there is caught and aborts the
deletion. `WorkflowsEndpoint` also documents `succeeded -> stopped` and
`failed -> stopped` as permitted transitions in the external API.

Making the state update a no-op keeps every existing caller working while
still fixing the data loss. Temporary file cleanup deliberately stays outside
the guard so `stop()` remains usable as a cleanup entry point for workflows in
any state. Happy to switch to the stricter throwing behaviour if that is what
was intended, but it would need those callers updated first.

Fixes #5961

### How to test this patch

`WorkflowServiceImplTest.testStopDoesNotOverwriteTerminatedState` covers it:

```
mvn test -pl modules/workflow-service-impl -Dtest=WorkflowServiceImplTest
```

The test fails on `develop` with `expected:<SUCCEEDED> but was:<STOPPED>` and
passes with this patch.

Manually: run a workflow to completion, then stop it via the admin interface or

```
curl -u admin:opencast -X POST localhost:8080/workflow/stop -d "id=<workflow-id>"
```

Before this patch the workflow's state flips from `SUCCEEDED` to `STOPPED`;
after it, the state is left alone. Deleting an event with completed workflows
should continue to work in both cases.

Test runs: `modules/workflow-service-impl` 36/36 pass, `modules/index-service`
50/50 pass (it is the main caller affected by the change), repo-wide
`mvn checkstyle:check` reports 0 violations.

### AI Usage

This patch was produced almost entirely by AI: Claude (Opus 5, Anthropic) run
through Claude Code, as part of a sprint evaluating agent-assisted contribution
to Opencast.

The AI read the issue, traced the callers of `stop()`, determined that the
literal reading of the issue would break `IndexServiceImpl.removeEvent()`,
chose the non-breaking fix, wrote the regression test, verified it fails
without the change, ran the test suites and checkstyle, and wrote this
description. A human reviewed the change and approved sending it.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate — n/a
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch — n/a, targets `develop`
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature — n/a, bugfix
