### PR TITLE
Fix intermittent SchedulerServiceImplTest failures

### DIFF
--- a/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
+++ b/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
@@ -140,7 +140,6 @@ import net.fortuna.ical4j.model.property.RRule;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
 import org.junit.After;
@@ -238,16 +237,21 @@ public class SchedulerServiceImplTest {
     EasyMock.expect(episodeAdapter.getFlavor()).andReturn(new MediaPackageElementFlavor("dublincore", "episode"))
             .anyTimes();
     EasyMock.expect(episodeAdapter.getOrganization()).andReturn(new DefaultOrganization().getId()).anyTimes();
-    final Capture<String> stringCapture = EasyMock.newCapture();
-    EasyMock.expect(episodeAdapter.handlesOrganization(EasyMock.capture(stringCapture)))
-        .andAnswer(() -> DefaultOrganization.DEFAULT_ORGANIZATION_ID.equals(stringCapture.getValue())).anyTimes();
+    // Read the argument of the current invocation instead of capturing it. addMultipleEventInternal() calls
+    // getEventCatalogUIAdapterFlavors() from a parallel stream, which queries both adapters below. A Capture
+    // shared between them is mutable state without a common lock, so one adapter's answer could observe the
+    // Capture while the other was rewriting it and fail with "Nothing captured yet".
+    EasyMock.expect(episodeAdapter.handlesOrganization(EasyMock.anyString()))
+        .andAnswer(() -> DefaultOrganization.DEFAULT_ORGANIZATION_ID.equals(EasyMock.getCurrentArguments()[0]))
+        .anyTimes();
 
     EventCatalogUIAdapter extendedAdapter = EasyMock.createMock(EventCatalogUIAdapter.class);
     EasyMock.expect(extendedAdapter.getFlavor()).andReturn(new MediaPackageElementFlavor("extended", "episode"))
             .anyTimes();
     EasyMock.expect(extendedAdapter.getOrganization()).andReturn(new DefaultOrganization().getId()).anyTimes();
-    EasyMock.expect(extendedAdapter.handlesOrganization(EasyMock.capture(stringCapture)))
-        .andAnswer(() -> DefaultOrganization.DEFAULT_ORGANIZATION_ID.equals(stringCapture.getValue())).anyTimes();
+    EasyMock.expect(extendedAdapter.handlesOrganization(EasyMock.anyString()))
+        .andAnswer(() -> DefaultOrganization.DEFAULT_ORGANIZATION_ID.equals(EasyMock.getCurrentArguments()[0]))
+        .anyTimes();
 
     BundleContext bundleContext = EasyMock.createNiceMock(BundleContext.class);
     EasyMock.expect(bundleContext.getProperty(EasyMock.anyString())).andReturn("adminuser").anyTimes();


### PR DESCRIPTION
`SchedulerServiceImplTest` mocked two `EventCatalogUIAdapter`s that shared a
single EasyMock `Capture`, with both `andAnswer()` callbacks reading it back:

```java
final Capture<String> stringCapture = EasyMock.newCapture();
EasyMock.expect(episodeAdapter.handlesOrganization(EasyMock.capture(stringCapture)))
    .andAnswer(() -> DefaultOrganization.DEFAULT_ORGANIZATION_ID.equals(stringCapture.getValue())).anyTimes();
// ...
EasyMock.expect(extendedAdapter.handlesOrganization(EasyMock.capture(stringCapture)))
    .andAnswer(() -> DefaultOrganization.DEFAULT_ORGANIZATION_ID.equals(stringCapture.getValue())).anyTimes();
```

`addMultipleEventInternal()` processes events on a `parallelStream()`, and each
thread calls `getEventCatalogUIAdapterFlavors()`, which streams over *both*
adapters.

The subtlety is why this races at all: EasyMock's `ReplayState.invoke()` holds a
`ReentrantLock` for the whole invocation, so capture and answer are atomic
*within one mock* — a single mock cannot race with itself. But these are two
distinct mocks with two distinct locks, so their critical sections interleave.
One adapter's answer can run while the other has just reset the shared
`Capture`, and `getValue()` then fails with `Nothing captured yet`. That surfaces
as the `AssertionError` reported in #7758, thrown out of the ForkJoin pool via
`ForkJoinTask.reportException`.

This replaces the shared `Capture` with `EasyMock.getCurrentArguments()[0]`,
which is per-invocation state and needs no sharing between the two mocks.

This fixes the test, not the production `parallelStream()`. The parallel stream
is not at fault — serialising it would hide a test defect by changing production
behaviour.

Fixes #7758

### How to test this patch

The race is timing dependent and does not reproduce reliably by looping the
suite — I saw 0 failures in 25 runs of the unpatched test on a 10-core machine,
which is why this needed the mechanism nailed down rather than a repro count.

Isolating the exact mock pattern in a standalone harness (two mocks, one shared
`Capture`, 200-element parallel stream, 300 iterations) makes it reproduce
consistently:

| | failures / 300 iterations |
|---|---|
| shared `Capture` (before) | **20**, all `AssertionError: Nothing captured yet` |
| `getCurrentArguments()` (after) | **0** |

For the suite itself:

```
mvn test -pl modules/scheduler-impl
```

43/43 tests pass, and `SchedulerServiceImplTest` passed 30 consecutive runs
after the change. Repo-wide `mvn checkstyle:check` reports 0 violations across
all 229 modules.

Reviewers wanting to confirm the mechanism rather than take it on trust can
check `ReplayState.invoke()` in EasyMock 5.5.0: the `ReentrantLock` there is
what makes the single-mock case safe and the two-mock case unsafe.

### AI Usage

This patch was produced almost entirely by AI: Claude (Opus 5, Anthropic) run
through Claude Code, as part of a sprint evaluating agent-assisted contribution
to Opencast.

The AI diagnosed the race, decompiled EasyMock to establish that per-mock
locking makes the single-mock case safe and the two-mock case unsafe, built the
standalone harness that reproduces it 20/300, applied the fix, verified it
0/300, and ran the suites and checkstyle. A human reviewed the change and
approved sending it.

Worth flagging for reviewers: the AI's first diagnosis was that a single mock
raced with itself across threads. That was wrong, and the 25 clean runs are what
exposed it. The two-mock explanation above is the corrected one and is what the
harness actually demonstrates.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate — n/a
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch — n/a, targets `develop`
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature — n/a, test-only bugfix
