### PR TITLE
Reject unparsable dates in ingest instead of failing later

### DIFF
--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
@@ -45,6 +45,7 @@ import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalogService;
 import org.opencastproject.metadata.dublincore.DublinCoreXmlFormat;
 import org.opencastproject.metadata.dublincore.DublinCores;
+import org.opencastproject.metadata.dublincore.OpencastMetadataCodec;
 import org.opencastproject.rest.AbstractJobProducerEndpoint;
 import org.opencastproject.scheduler.api.SchedulerConflictException;
 import org.opencastproject.scheduler.api.SchedulerException;
@@ -177,6 +178,13 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
           "isRequiredBy", "issued", "isVersionOf", "language", "license", "mediator", "medium", "modified",
           "provenance", "publisher", "references", "relation", "replaces", "requires", "rights", "rightsHolder",
           "source", "spatial", "subject", "tableOfContents", "temporal", "title", "type", "valid");
+
+  /**
+   * Dublin Core Terms which are interpreted as a single date further down the line and therefore need to be
+   * parsable as one. Note that "temporal" is deliberately absent: it carries a DCMI period
+   * (start=...; end=...;), not a plain date, and is decoded with decodeMandatoryPeriod elsewhere.
+   */
+  private static final List<String> DATE_DCTERMS = Arrays.asList("created", "date");
 
   /** Formatter to for the date into a string */
   private static final DateFormat DATE_FORMAT = new SimpleDateFormat(IngestService.UTC_DATE_FORMAT);
@@ -983,6 +991,14 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
               if ("identifier".equals(fieldName)) {
                 /* Use the identifier for the mediapackage */
                 mp.setIdentifier(new IdImpl(value));
+              }
+              /* Reject unparsable dates here rather than letting them fail much later during indexing */
+              if (DATE_DCTERMS.contains(fieldName)) {
+                try {
+                  OpencastMetadataCodec.decodeDate(value);
+                } catch (IllegalArgumentException e) {
+                  return badRequest(String.format("Could not parse date '%s' for field '%s'", value, fieldName), e);
+                }
               }
               if (dcc == null) {
                 dcc = dublinCoreService.newInstance();

--- a/modules/ingest-service-impl/src/test/java/org/opencastproject/ingest/endpoint/IngestRestServiceTest.java
+++ b/modules/ingest-service-impl/src/test/java/org/opencastproject/ingest/endpoint/IngestRestServiceTest.java
@@ -506,6 +506,43 @@ public class IngestRestServiceTest {
     EasyMock.verify(ingestService);
   }
 
+  @Test
+  public void testAddMediaPackageRejectsUnparsableDate() throws Exception {
+    // An unparsable date used to be accepted here and only blow up much later during indexing, surfacing as a 500.
+    // The validation has to reject it up front, before the catalog is built.
+    Response response = restService.addMediaPackage(newMockRequestWithDate("created", "banana"), null);
+    Assert.assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+  }
+
+  @Test
+  public void testAddMediaPackageDoesNotValidateTemporalAsDate() throws Exception {
+    // "temporal" carries a DCMI period rather than a plain date, so it must not be rejected as an unparsable date.
+    // This request does not reach a 200 because the shared mock has no DublinCoreCatalogService, but it must not
+    // fail with 400 either - that would mean legitimate scheduled recordings were being turned away.
+    String period = "start=2024-01-01T00:00:00Z; end=2024-01-01T01:00:00Z; scheme=W3C-DTF;";
+    Response response = restService.addMediaPackage(newMockRequestWithDate("temporal", period), null);
+    Assert.assertNotEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+  }
+
+  private HttpServletRequest newMockRequestWithDate(String field, String value) throws Exception {
+    StringBuilder requestBody = new StringBuilder();
+    requestBody.append("-----1234\r\n");
+    requestBody.append("Content-Disposition: form-data; name=\"flavor\"\r\n");
+    requestBody.append("\r\ntest/flavor\r\n");
+    requestBody.append("-----1234\r\n");
+    requestBody.append("Content-Disposition: form-data; name=\"" + field + "\"\r\n");
+    requestBody.append("\r\n" + value + "\r\n");
+    requestBody.append("-----1234\r\n");
+    requestBody.append("Content-Disposition: form-data; name=\"BODY\"; filename=\"video.mp4\"\r\n");
+    requestBody.append("Content-Type: video/mp4\r\n");
+    requestBody.append("\r\n");
+    requestBody.append("This is the content of the file\n");
+    requestBody.append("\r\n");
+    requestBody.append("-----1234");
+    return new MockHttpServletRequest(requestBody.toString().getBytes("UTF-8"),
+            "multipart/form-data; boundary=---1234");
+  }
+
   private HttpServletRequest newMockRequest() throws Exception {
     MediaPackage mp = MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder().createNew();
     StringBuilder requestBody = new StringBuilder();


### PR DESCRIPTION
Ingesting a media package with an unparsable date returns HTTP 500:

```
curl -f -i -u admin:opencast localhost:8080/ingest/addMediaPackage/fast \
    -F 'flavor=presenter/source' \
    -F title="Text" \
    -F created="banana" \
    -F BODY=@video.mp4
```

The value is accepted at the REST layer and only fails much later, while
indexing the resulting event:

```
java.lang.NullPointerException: Cannot invoke "java.util.Date.getTime()" because "created" is null
    at org.opencastproject.elasticsearch.index.objects.event.EventIndexUtils.updateEvent(EventIndexUtils.java:479)
    at org.opencastproject.assetmanager.impl.AssetManagerImpl.lambda$getEventUpdateFunction$13(AssetManagerImpl.java:1618)
    ...
    at org.opencastproject.ingest.endpoint.IngestRestService.addMediaPackage(IngestRestService.java:1112)
```

This validates the date-valued Dublin Core terms as they are read and returns
400 with a message naming the offending field and value.

### Two things this patch is deliberately careful about

**It does not add a second pass over the request.** #6008 previously fixed this
issue and had to be reverted, because it validated in a separate
`getItemIterator(request)` loop placed before the main one. As @gregorydlogan
diagnosed on the issue, that iterator is not reusable — the second loop found
nothing, so no media was read and ingest broke. The validation here happens
inline in the existing iteration, next to the flavor and URI checks that already
return `badRequest(...)` the same way.

**It does not validate `temporal`.** #6008 included `temporal` alongside
`created` and `date`. But `temporal` carries a DCMI period
(`start=...; end=...; scheme=W3C-DTF;`), not a plain date — it is written with
`encodePeriod` and read back with `decodeMandatoryPeriod` in the scheduler.
Running it through `decodeDate` would reject valid scheduled recordings, so only
`created` and `date` are checked.

Fixes #5954

### How to test this patch

Verified against a running `-Pdev` instance, before and after:

| request | before | after |
|---|---|---|
| `created=banana` + media | **500** | **400** `Could not parse date 'banana' for field 'created'` |
| `created=2026-01-01T00:00:00Z` + media | 200 | 200 |

The valid case matters as much as the invalid one here, given the #6008
regression: after the patch the response still contains the ingested track
(`<mp:track ... type="presenter/source">`) and the workflow is created, so the
media is still being read.

```
curl -i -u admin:opencast localhost:8080/ingest/addMediaPackage/fast \
    -F 'flavor=presenter/source' -F title="Test" \
    -F created="banana" -F BODY=@some-video.mp4
```

Unit tests: `IngestRestServiceTest.testAddMediaPackageRejectsUnparsableDate`
fails on `develop` with `expected:<400> but was:<500>` and passes with this
patch. `testAddMediaPackageDoesNotValidateTemporalAsDate` covers the period
case.

One limitation worth flagging: the shared mock in `IngestRestServiceTest` has no
`DublinCoreCatalogService`, so any request reaching catalog creation fails with
500 regardless of this change. The two tests are written around that — the
temporal test asserts "not 400" rather than "200". Asserting a full 200 would
mean extending the shared fixture, which the other 25 tests in the class depend
on. Happy to do that if reviewers would prefer it.

`mvn test -pl modules/ingest-service-impl` passes 39/39, repo-wide
`mvn checkstyle:check` reports 0 violations.

### AI Usage

This patch was produced almost entirely by AI: Claude (Opus 5, Anthropic) run
through Claude Code, as part of a sprint evaluating agent-assisted contribution
to Opencast.

The AI reproduced the 500 on a live instance, captured the stack trace, read the
history of the reverted #6008 to find the single-pass constraint, determined that
`temporal` must be excluded, applied the fix, deployed it to the running instance
to confirm both the 400 and that media still ingests, and wrote the tests and
this description. A human reviewed the change and approved sending it.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate — n/a
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch — n/a, targets `develop`
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature — n/a, bugfix
