### PR TITLE
Fix duplicate userEntryPoint bean id for Shibboleth auth

### DIFF
--- a/docs/guides/admin/docs/configuration/security.aai.md
+++ b/docs/guides/admin/docs/configuration/security.aai.md
@@ -129,12 +129,33 @@ Finally be sure to enable the user reference provider to enable support for exte
                   interface="org.opencastproject.userdirectory.api.UserReferenceProvider" />
 
 Since the Opencast login page is not used when Shibboleth authentication is in place, there is no point in redirecting
-unauthenticated requests to the Opencast login form. You can redirect them directly to the administrative user
-interface which is supposed to be protected by Shibboleth.
+unauthenticated requests to the Opencast login form. You can instead redirect them to your Shibboleth login page,
+which will send the user back to the originally requested URL afterwards.
 
-    <!-- Redirects unauthenticated requests to the login form -->
-    <bean id="userEntryPoint" class="org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint">
-      <property name="loginFormUrl" value="/admin-ui/index.html" />
+All necessary changes for this are marked with a `Shibboleth Auth:` tag. You can use the find function of your
+editor to find the parts of the file you need to modify.
+
+In the *Shibboleth Support* section, uncomment the `shibbolethEntryPoint` bean (adjusting the login URL and query
+parameter to match your Shibboleth Service Provider configuration if necessary):
+
+    <!--bean id="shibbolethEntryPoint" class="org.opencastproject.kernel.security.RedirectQueryParamAuthenticationEntryPoint">
+      <constructor-arg index="0" value="/Shibboleth.sso/Login" />
+      <constructor-arg index="1" value="target" />
+    </bean-->
+
+**IMPORTANT:** Do *not* rename this bean to `userEntryPoint`. That id is already used by the default entry point
+bean further up in the file, and defining it twice will break the Spring configuration, causing every request to
+be rejected with `HTTP 403 Forbidden` instead of being redirected. Instead, point the `opencastEntryPoint` bean's
+`userEntryPoint` property to the `shibbolethEntryPoint` bean by swapping the comment on the lines tagged
+`Shibboleth Auth:`, so that the bean ends up looking like this:
+
+    <bean id="opencastEntryPoint" class="org.opencastproject.kernel.security.DelegatingAuthenticationEntryPoint">
+      <!-- Shibboleth Auth:  Comment this if using Shibboleth authentication -->
+      <!-- <property name="userEntryPoint" ref="userEntryPoint" /> -->
+      <!-- Shibboleth Auth:  Uncomment this if using Shibboleth authentication -->
+      <property name="userEntryPoint" ref="shibbolethEntryPoint" />
+      <property name="digestAuthenticationEntryPoint" ref="digestEntryPoint" />
+      <property name="basicAuthenticationEntryPoint" ref="basicEntryPoint" />
     </bean>
 
 Last but not least, you need to add the *preauthAuthProvider* authentication provider to the *authentication-manager*:

--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -525,9 +525,15 @@
   <!-- Differentiates between "normal" user requests and those requesting digest auth -->
   <bean id="opencastEntryPoint" class="org.opencastproject.kernel.security.DelegatingAuthenticationEntryPoint">
     <!-- CAS Auth:  Comment this if using CAS authentication -->
+    <!-- Shibboleth Auth:  Comment this if using Shibboleth authentication -->
+    <!-- Custom Auth:  Comment this if using a custom authentication entry point -->
     <property name="userEntryPoint" ref="userEntryPoint" />
     <!-- CAS Auth:  Uncomment this if using CAS authentication -->
     <!-- <property name="userEntryPoint" ref="casEntryPoint" /> -->
+    <!-- Shibboleth Auth:  Uncomment this if using Shibboleth authentication -->
+    <!-- <property name="userEntryPoint" ref="shibbolethEntryPoint" /> -->
+    <!-- Custom Auth:  Uncomment this if using a custom authentication entry point -->
+    <!-- <property name="userEntryPoint" ref="customUserEntryPoint" /> -->
     <property name="digestAuthenticationEntryPoint" ref="digestEntryPoint" />
     <property name="basicAuthenticationEntryPoint" ref="basicEntryPoint" />
   </bean>
@@ -564,9 +570,9 @@
   </bean>
 
   <!-- Redirect unauthenticated requests to custom login url with configurable redirect query parameter
-       Example: http://localhost/Shibboleth.sso/Login?target=<RELATIVE_REQUEST_URL> -->
-  <!--bean id="userEntryPoint" class="org.opencastproject.kernel.security.RedirectQueryParamAuthenticationEntryPoint">
-    <constructor-arg index="0" value="/Shibboleth.sso/Login" />
+       Example: http://localhost/sso/login?target=<RELATIVE_REQUEST_URL> -->
+  <!--bean id="customUserEntryPoint" class="org.opencastproject.kernel.security.RedirectQueryParamAuthenticationEntryPoint">
+    <constructor-arg index="0" value="/sso/login" />
     <constructor-arg index="1" value="target" />
   </bean-->
 
@@ -695,6 +701,12 @@
   <!-- ###################### -->
   <!-- # Shibboleth Support # -->
   <!-- ###################### -->
+
+  <!--
+  <bean id="shibbolethEntryPoint" class="org.opencastproject.kernel.security.RedirectQueryParamAuthenticationEntryPoint">
+    <constructor-arg index="0" value="/Shibboleth.sso/Login" />
+    <constructor-arg index="1" value="target" />
+  </bean>-->
 
   <!-- General Shibboleth header extration filter
   <bean id="shibbolethHeaderFilter"


### PR DESCRIPTION
The commented-out Shibboleth entry point bean in mh_default_org.xml shared the id "userEntryPoint" with the default entry point bean introduced for #3244. Uncommenting it to enable Shibboleth support therefore defines the same bean id twice, breaking the Spring security config and causing every request to be rejected with HTTP 403 Forbidden instead of being redirected.

Rename the Shibboleth bean to shibbolethEntryPoint, move it into the "Shibboleth Support" section, and wire it up via a "Shibboleth Auth:" tagged property on opencastEntryPoint, mirroring the existing CAS pattern. Also generalize the other pre-existing commented entry point example so it no longer collides with the same id. Update the AAI docs accordingly.

Fixes #7777

### How to test this patch

To reproduce the original issue:

1. Check out `develop` (pre-patch) and open `etc/security/mh_default_org.xml`.
2. Uncomment the Shibboleth `userEntryPoint` bean (the one using `RedirectQueryParamAuthenticationEntryPoint`).
3. Start Opencast and try to access the admin UI → requests are rejected with `HTTP 403 Forbidden` instead of a redirect, because two beans now share the id `userEntryPoint`.

To verify the fix:

1. Apply this patch and confirm the default config is untouched: start Opencast and confirm the admin UI still loads and redirects to the login form as before (no Shibboleth changes made).
2. In `etc/security/mh_default_org.xml`, uncomment the `shibbolethEntryPoint` bean in the "Shibboleth Support" section, then switch the `Shibboleth Auth:` tagged property on `opencastEntryPoint` (comment out the `userEntryPoint` ref, uncomment the `shibbolethEntryPoint` ref).
3. Confirm the config loads without a duplicate-bean error, and that unauthenticated requests are redirected to the configured Shibboleth login URL instead of returning 403.
4. `xmllint --noout etc/security/mh_default_org.xml` should pass.

### AI Usage

Used Claude Code to investigate the root cause (traced the duplicate bean id back to the entry point bean added in #3244), implement the fix in `mh_default_org.xml`, and update the corresponding section of `security.aai.md`. All changes were reviewed and iterated on manually before submission.

### Your pull request should…

* [x] have a concise title
* [x [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
