### PR TITLE
Harmonize permission checking

### DIFF
--- a/docs/guides/admin/docs/releasenotes/harmonize-permission-checking.txt
+++ b/docs/guides/admin/docs/releasenotes/harmonize-permission-checking.txt
@@ -1,0 +1,12 @@
+PR #7873 changed two permission-checking behaviors as part of harmonizing Opencast's ACL evaluation:
+
+- `WorkflowService.start()` now requires the caller to be a global/organization admin, hold the capture agent
+  role, or have WRITE permission on the media package's ACL. Previously no permission was checked at all when
+  starting a workflow. If you have deployed XACML policies that rely on `start()` being unrestricted for some
+  role, that role now needs an explicit WRITE (or admin/capture-agent) grant.
+- `AuthorizationService.hasPermission(AccessControlList, String)` (used by, among others, the Workflow, Editor,
+  and Playlist services) now stops at the first ACL entry matching both the action and one of the current user's
+  roles, instead of always letting an explicit `deny` entry win regardless of entry order. If a deployed XACML
+  file mixes `allow` and `deny` entries for the same action across different roles held by the same user, the
+  outcome can change: a `deny` entry no longer automatically overrides an `allow` entry for a different role that
+  appears later in the file.

--- a/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/StatisticsEndpoint.java
+++ b/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/StatisticsEndpoint.java
@@ -21,7 +21,6 @@
 
 package org.opencastproject.adminui.endpoint;
 
-import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
 import static org.opencastproject.util.data.functions.Misc.chuck;
 import static org.opencastproject.util.doc.rest.RestParameter.Type.STRING;
 
@@ -36,6 +35,7 @@ import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.security.api.User;
+import org.opencastproject.security.util.SecurityUtil;
 import org.opencastproject.statistics.api.DataResolution;
 import org.opencastproject.statistics.api.ResourceType;
 import org.opencastproject.statistics.api.StatisticsProvider;
@@ -360,13 +360,12 @@ public class StatisticsEndpoint {
   private void checkOrganizationAccess(final String orgId) throws UnauthorizedException {
     final User currentUser = securityService.getUser();
     final Organization currentOrg = securityService.getOrganization();
-    final String currentOrgAdminRole = currentOrg.getAdminRole();
     final String currentOrgId = currentOrg.getId();
 
     final boolean userIsInOrg = currentOrgId.equals(orgId);
 
-    boolean userIsAdmin = currentUser.hasRole(GLOBAL_ADMIN_ROLE)
-        || (currentUser.hasRole(currentOrgAdminRole) && userIsInOrg);
+    boolean userIsAdmin = SecurityUtil.isGlobalAdmin(currentUser)
+        || (userIsInOrg && SecurityUtil.isOrganizationAdmin(currentUser, currentOrg));
 
     boolean userIsAuthorized = currentUser.hasRole(STATISTICS_ORGANIZATION_UI_ROLE) && userIsInOrg;
 

--- a/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/AssetManagerSecurityUtils.java
+++ b/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/AssetManagerSecurityUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.opencastproject.assetmanager.api;
+
+/**
+ * Shared constants and logic for how the AssetManager flattens a media package's ACL into properties for its own
+ * permission checks. This is used both by the AssetManager implementation itself and by the static file
+ * authorization handler, which reads the same underlying data directly rather than through the AssetManager
+ * service, since it needs to run on every node while the AssetManager implementation only runs on the admin node.
+ */
+public final class AssetManagerSecurityUtils {
+
+  private AssetManagerSecurityUtils() {
+  }
+
+  /** The namespace under which ACL-derived permission properties are stored. */
+  public static final String SECURITY_NAMESPACE = "org.opencastproject.assetmanager.security";
+
+  /** Builds the name of the property under which permission for the given role and action is stored. */
+  public static String mkPropertyName(String role, String action) {
+    return role + " | " + action;
+  }
+
+  /**
+   * Determines whether a role should be considered when evaluating permission, based on the configured role-type
+   * filters. Some role types (API, capture agent, UI) are excluded by default since they are not meant to carry
+   * per-object permissions.
+   */
+  public static boolean isRoleAllowed(String roleName, boolean includeAPIRoles, boolean includeCARoles,
+      boolean includeUIRoles) {
+    return (includeAPIRoles || !roleName.startsWith("ROLE_API_"))
+        && (includeCARoles || !roleName.startsWith("ROLE_CAPTURE_AGENT_"))
+        && (includeUIRoles || !roleName.startsWith("ROLE_UI_"));
+  }
+}

--- a/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/AssetManagerSecurityUtils.java
+++ b/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/AssetManagerSecurityUtils.java
@@ -18,6 +18,7 @@
  * the License.
  *
  */
+
 package org.opencastproject.assetmanager.api;
 
 /**

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
@@ -25,7 +25,6 @@ import static org.opencastproject.mediapackage.MediaPackageSupport.Filters.hasNo
 import static org.opencastproject.mediapackage.MediaPackageSupport.Filters.isNotPublication;
 import static org.opencastproject.mediapackage.MediaPackageSupport.getFileName;
 import static org.opencastproject.metadata.dublincore.CatalogUIAdapter.ORGANIZATION_WILDCARD;
-import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
 import static org.opencastproject.security.api.SecurityConstants.GLOBAL_CAPTURE_AGENT_ROLE;
 import static org.opencastproject.security.util.SecurityUtil.getEpisodeRoleId;
 import static org.opencastproject.util.data.functions.Misc.chuck;
@@ -1223,9 +1222,9 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
 
   private AdminRole isAdmin() {
     final User user = securityService.getUser();
-    if (user.hasRole(GLOBAL_ADMIN_ROLE)) {
+    if (SecurityUtil.isGlobalAdmin(user)) {
       return AdminRole.GLOBAL;
-    } else if (user.hasRole(securityService.getOrganization().getAdminRole())
+    } else if (SecurityUtil.isOrganizationAdmin(user, securityService.getOrganization())
             || user.hasRole(GLOBAL_CAPTURE_AGENT_ROLE)) {
       // In this context, we treat capture agents the same way as organization admins, allowing them access so that
       // they can ingest new media without requiring them to be explicitly specified in the ACLs.

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
@@ -33,6 +33,7 @@ import org.opencastproject.assetmanager.api.Asset;
 import org.opencastproject.assetmanager.api.AssetId;
 import org.opencastproject.assetmanager.api.AssetManager;
 import org.opencastproject.assetmanager.api.AssetManagerException;
+import org.opencastproject.assetmanager.api.AssetManagerSecurityUtils;
 import org.opencastproject.assetmanager.api.Availability;
 import org.opencastproject.assetmanager.api.Property;
 import org.opencastproject.assetmanager.api.PropertyId;
@@ -150,7 +151,6 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
 
   public static final String WRITE_ACTION = "write";
   public static final String READ_ACTION = "read";
-  public static final String SECURITY_NAMESPACE = "org.opencastproject.assetmanager.security";
 
   private static final int EXPEXTED_HANDLERS_COUNT = 2;
 
@@ -451,11 +451,13 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
       final AccessControlList acl = authorizationService.getActiveAcl(mp).getA();
       // store acl as properties
       // Drop old ACL rules
-      deleteProperties(mediaPackageId, SECURITY_NAMESPACE);
+      deleteProperties(mediaPackageId, AssetManagerSecurityUtils.SECURITY_NAMESPACE);
       // Set new ACL rules
       for (final AccessControlEntry ace : acl.getEntries()) {
-        getDatabase().saveProperty(Property.mk(PropertyId.mk(mediaPackageId, SECURITY_NAMESPACE,
-                mkPropertyName(ace.getRole(), ace.getAction())), Value.mk(ace.isAllow())));
+        String propertyName = AssetManagerSecurityUtils.mkPropertyName(ace.getRole(), ace.getAction());
+        PropertyId propertyId = PropertyId.mk(mediaPackageId, AssetManagerSecurityUtils.SECURITY_NAMESPACE,
+                propertyName);
+        getDatabase().saveProperty(Property.mk(propertyId, Value.mk(ace.isAllow())));
       }
 
       updateEventInIndex(snapshot);
@@ -1205,9 +1207,10 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
         // return authorizationService.hasPermission(getDatabase().getMediaPackage(mediaPackageId).get(), action);
         final List<String> roles = user.getRoles().parallelStream()
                 .filter(roleFilter)
-                .map((role) -> mkPropertyName(role.getName(), action))
+                .map((role) -> AssetManagerSecurityUtils.mkPropertyName(role.getName(), action))
                 .collect(Collectors.toList());
-        return getDatabase().selectProperties(mediaPackageId, SECURITY_NAMESPACE).parallelStream()
+        return getDatabase().selectProperties(mediaPackageId, AssetManagerSecurityUtils.SECURITY_NAMESPACE)
+                .parallelStream()
                 .map(p -> p.getId().getName())
                 .filter(p -> p.endsWith(action))
                 .anyMatch(p -> roles.stream().anyMatch(r -> r.equals(p)));
@@ -1234,19 +1237,11 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
     }
   }
 
-  private String mkPropertyName(String role, String action) {
-    return role + " | " + action;
-  }
-
   /**
    * Configurable filter for roles
    */
-  private final java.util.function.Predicate<Role> roleFilter = (role) -> {
-    final String name = role.getName();
-    return (includeAPIRoles || !name.startsWith("ROLE_API_"))
-            && (includeCARoles  || !name.startsWith("ROLE_CAPTURE_AGENT_"))
-            && (includeUIRoles  || !name.startsWith("ROLE_UI_"));
-  };
+  private final java.util.function.Predicate<Role> roleFilter = (role) ->
+      AssetManagerSecurityUtils.isRoleAllowed(role.getName(), includeAPIRoles, includeCARoles, includeUIRoles);
 
   /*
    * Utility

--- a/modules/asset-manager-static-file-authorization/pom.xml
+++ b/modules/asset-manager-static-file-authorization/pom.xml
@@ -16,6 +16,11 @@
   <dependencies>
     <dependency>
       <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-asset-manager-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-common</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/modules/asset-manager-static-file-authorization/src/main/java/org/opencastproject/assetmanager/auth/AssetManagerStaticFileAuthorization.java
+++ b/modules/asset-manager-static-file-authorization/src/main/java/org/opencastproject/assetmanager/auth/AssetManagerStaticFileAuthorization.java
@@ -21,6 +21,7 @@
 
 package org.opencastproject.assetmanager.auth;
 
+import org.opencastproject.assetmanager.api.AssetManagerSecurityUtils;
 import org.opencastproject.security.api.Role;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.StaticFileAuthorization;
@@ -144,7 +145,7 @@ public class AssetManagerStaticFileAuthorization implements StaticFileAuthorizat
     final List<String> roles = user.getRoles().parallelStream()
         .map(Role::getName)
         .filter(roleFilter)
-        .map((role) -> role + " | read")
+        .map((role) -> AssetManagerSecurityUtils.mkPropertyName(role, "read"))
         .collect(Collectors.toList());  // ["ROLE_XY | read", ...]
 
     StringBuilder properties = new StringBuilder("property_name = ?");
@@ -158,7 +159,7 @@ public class AssetManagerStaticFileAuthorization implements StaticFileAuthorizat
         + "and (" + properties + ")";
     EntityManager entityManager = entityManagerFactory.createEntityManager();
     Query q = entityManager.createNativeQuery(sql);
-    q.setParameter(1, "org.opencastproject.assetmanager.security");
+    q.setParameter(1, AssetManagerSecurityUtils.SECURITY_NAMESPACE);
     q.setParameter(2, m.group(2));
     for (int i = 0; i < roles.size(); i++) {
       q.setParameter(i + 3, roles.get(i));
@@ -183,8 +184,6 @@ public class AssetManagerStaticFileAuthorization implements StaticFileAuthorizat
   /**
    * Filter for removing user interface roles from access control
    */
-  private final java.util.function.Predicate<String> roleFilter = (name) -> (
-      includeAPIRoles || !name.startsWith("ROLE_API_"))
-      && (includeCARoles  || !name.startsWith("ROLE_CAPTURE_AGENT_"))
-      && (includeUIRoles  || !name.startsWith("ROLE_UI_"));
+  private final java.util.function.Predicate<String> roleFilter = (name) ->
+      AssetManagerSecurityUtils.isRoleAllowed(name, includeAPIRoles, includeCARoles, includeUIRoles);
 }

--- a/modules/asset-manager-static-file-authorization/src/main/java/org/opencastproject/assetmanager/auth/AssetManagerStaticFileAuthorization.java
+++ b/modules/asset-manager-static-file-authorization/src/main/java/org/opencastproject/assetmanager/auth/AssetManagerStaticFileAuthorization.java
@@ -21,12 +21,11 @@
 
 package org.opencastproject.assetmanager.auth;
 
-import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
-
 import org.opencastproject.security.api.Role;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.StaticFileAuthorization;
 import org.opencastproject.security.api.User;
+import org.opencastproject.security.util.SecurityUtil;
 
 import org.apache.commons.lang3.BooleanUtils;
 import org.osgi.service.component.ComponentContext;
@@ -108,7 +107,7 @@ public class AssetManagerStaticFileAuthorization implements StaticFileAuthorizat
   public boolean verifyUrlAccess(final String path) {
     // Always allow access for admin
     final User user = securityService.getUser();
-    if (user.hasRole(GLOBAL_ADMIN_ROLE)) {
+    if (SecurityUtil.isGlobalAdmin(user)) {
       logger.debug("Allow access for admin `{}`", user);
       return true;
     }

--- a/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
+++ b/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
@@ -311,11 +311,11 @@ public class XACMLAuthorizationService implements AuthorizationService {
 
   public boolean hasPermission(final MediaPackage mp, final String action) {
     AccessControlList acl = getActiveAcl(mp).getA();
-    return hasPermission(acl, mp.getIdentifier().toString(), action);
+    return hasPermissionForMediaPackage(acl, mp.getIdentifier().toString(), action);
   }
 
   @Override
-  public boolean hasPermission(AccessControlList acl, String mediaPackageId, final String action) {
+  public boolean hasPermissionForMediaPackage(AccessControlList acl, String mediaPackageId, final String action) {
     // Check special ROLE_EPISODE_<ID>_<ACTION> permissions
     final User user = securityService.getUser();
     var episodeRole = getEpisodeRoleId(mediaPackageId, action);

--- a/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
+++ b/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
@@ -36,9 +36,11 @@ import org.opencastproject.security.api.AccessControlEntry;
 import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.security.api.AclScope;
 import org.opencastproject.security.api.AuthorizationService;
+import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.Role;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.User;
+import org.opencastproject.security.util.SecurityUtil;
 import org.opencastproject.util.MimeTypes;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.data.Tuple;
@@ -309,10 +311,14 @@ public class XACMLAuthorizationService implements AuthorizationService {
 
   public boolean hasPermission(final MediaPackage mp, final String action) {
     AccessControlList acl = getActiveAcl(mp).getA();
+    return hasPermission(acl, mp.getIdentifier().toString(), action);
+  }
 
+  @Override
+  public boolean hasPermission(AccessControlList acl, String mediaPackageId, final String action) {
     // Check special ROLE_EPISODE_<ID>_<ACTION> permissions
     final User user = securityService.getUser();
-    var episodeRole = getEpisodeRoleId(mp.getIdentifier().toString(), action);
+    var episodeRole = getEpisodeRoleId(mediaPackageId, action);
     logger.debug("Checking for role: {}", episodeRole);
     var allowed = user.getRoles().stream().map(Role::getName).anyMatch(r -> r.equals(episodeRole));
 
@@ -322,28 +328,24 @@ public class XACMLAuthorizationService implements AuthorizationService {
   @Override
   public boolean hasPermission(AccessControlList acl, final String action) {
     final User user = securityService.getUser();
-    var allowed = false;
+    final Organization organization = securityService.getOrganization();
+    if (SecurityUtil.isAdmin(user, organization)) {
+      return true;
+    }
 
-    // Check ACL
+    // Check ACL. The first entry matching both the action and one of the user's roles decides the outcome.
     for (AccessControlEntry entry: acl.getEntries()) {
-      // ignore entries for other actions
       if (!entry.getAction().equals(action)) {
         continue;
       }
       for (Role role : user.getRoles()) {
         if (entry.getRole().equals(role.getName())) {
-          // immediately abort on matching deny rules
-          // (never allow if a deny rule matches, even if another allow rule matches)
-          if (!entry.isAllow()) {
-            logger.debug("Access explicitly denied for role({}), action({})", role.getName(), action);
-            return false;
-          }
-          allowed = true;
+          return entry.isAllow();
         }
       }
     }
-    logger.debug("XACML file allowed access");
-    return allowed;
+    logger.debug("No matching ACL entry found for action({})", action);
+    return false;
   }
 
   /**

--- a/modules/authorization-xacml/src/test/java/org/opencastproject/authorization/xacml/XACMLSecurityTest.java
+++ b/modules/authorization-xacml/src/test/java/org/opencastproject/authorization/xacml/XACMLSecurityTest.java
@@ -83,6 +83,7 @@ public class XACMLSecurityTest {
     securityService = EasyMock.createMock(SecurityService.class);
     EasyMock.expect(securityService.getUser()).andAnswer(
             () -> new JaxbUser(currentUser, "test", organization, currentRoles)).anyTimes();
+    EasyMock.expect(securityService.getOrganization()).andReturn(organization).anyTimes();
 
     // Mock workspace
     Workspace workspace = EasyMock.createMock(Workspace.class);

--- a/modules/authorization-xacml/src/test/java/org/opencastproject/authorization/xacml/XACMLSecurityTest.java
+++ b/modules/authorization-xacml/src/test/java/org/opencastproject/authorization/xacml/XACMLSecurityTest.java
@@ -202,4 +202,45 @@ public class XACMLSecurityTest {
     Assert.assertTrue(authzService.hasPermission(mediapackage, "read"));
     Assert.assertFalse(authzService.hasPermission(mediapackage, "comment"));
   }
+
+  /**
+   * An organization admin (holding the organization's actual admin role, unlike the "admin"-named ACL role used in
+   * {@link #testSecurity()}) must be granted permission regardless of what the ACL says, including on an ACL that
+   * explicitly denies their role or has no entries at all.
+   */
+  @Test
+  public void testOrganizationAdminBypassesAcl() {
+    AccessControlList acl = new AccessControlList();
+    acl.getEntries().add(new AccessControlEntry(DefaultOrganization.DEFAULT_ORGANIZATION_ADMIN, "write", false));
+
+    currentRoles.clear();
+    currentRoles.add(new JaxbRole(DefaultOrganization.DEFAULT_ORGANIZATION_ADMIN, organization, ""));
+    Assert.assertTrue("org admin should bypass an explicit deny entry for their own role",
+            authzService.hasPermission(acl, "write"));
+    Assert.assertTrue("org admin should bypass an ACL with no matching entries",
+            authzService.hasPermission(new AccessControlList(), "write"));
+  }
+
+  /**
+   * When a user holds two roles that both have entries for the same action, the outcome is decided by whichever
+   * entry appears first in the ACL, not by an explicit deny always winning regardless of order.
+   */
+  @Test
+  public void testFirstMatchingAclEntryWins() {
+    currentRoles.clear();
+    currentRoles.add(new JaxbRole("ROLE_GROUP_X", organization, ""));
+    currentRoles.add(new JaxbRole("ROLE_USER_BOB", organization, ""));
+
+    AccessControlList allowFirst = new AccessControlList();
+    allowFirst.getEntries().add(new AccessControlEntry("ROLE_GROUP_X", "write", true));
+    allowFirst.getEntries().add(new AccessControlEntry("ROLE_USER_BOB", "write", false));
+    Assert.assertTrue("the allow entry for ROLE_GROUP_X comes first, so it decides the outcome",
+            authzService.hasPermission(allowFirst, "write"));
+
+    AccessControlList denyFirst = new AccessControlList();
+    denyFirst.getEntries().add(new AccessControlEntry("ROLE_USER_BOB", "write", false));
+    denyFirst.getEntries().add(new AccessControlEntry("ROLE_GROUP_X", "write", true));
+    Assert.assertFalse("the deny entry for ROLE_USER_BOB comes first, so it decides the outcome",
+            authzService.hasPermission(denyFirst, "write"));
+  }
 }

--- a/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/impl/CaptureAgentStateServiceImpl.java
+++ b/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/impl/CaptureAgentStateServiceImpl.java
@@ -34,9 +34,9 @@ import org.opencastproject.db.DBSession;
 import org.opencastproject.db.DBSessionFactory;
 import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.Role;
-import org.opencastproject.security.api.SecurityConstants;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.User;
+import org.opencastproject.security.util.SecurityUtil;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.data.Tuple3;
 import org.opencastproject.util.function.ThrowingFunction;
@@ -390,7 +390,6 @@ public class CaptureAgentStateServiceImpl implements CaptureAgentStateService, M
     User user = securityService.getUser();
     Organization org = securityService.getOrganization();
 
-    String orgAdmin = org.getAdminRole();
     Set<Role> roles = user.getRoles();
 
     List<AgentImpl> agents = db.exec(namedQuery.findAll(
@@ -400,7 +399,7 @@ public class CaptureAgentStateServiceImpl implements CaptureAgentStateService, M
     ));
 
     // Filter the results in memory if this user is not an administrator
-    if (!user.hasRole(SecurityConstants.GLOBAL_ADMIN_ROLE) && !user.hasRole(orgAdmin)) {
+    if (!SecurityUtil.isAdmin(user, org)) {
       for (Iterator<AgentImpl> iter = agents.iterator(); iter.hasNext();) {
         AgentImpl agent = iter.next();
         Set<String> schedulerRoles = agent.getSchedulerRoles();

--- a/modules/common/src/main/java/org/opencastproject/security/api/AccessControlUtil.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/AccessControlUtil.java
@@ -112,8 +112,8 @@ public final class AccessControlUtil {
    * @return whether this action should be allowed
    * @throws IllegalArgumentException
    *           if any of the arguments are null
-   * @deprecated use {@link AuthorizationService#hasPermission(AccessControlList, String, String)} instead, which
-   *             checks against the current user rather than an explicitly passed one
+   * @deprecated use {@link AuthorizationService#hasPermissionForMediaPackage(AccessControlList, String, String)}
+   *             instead, which checks against the current user rather than an explicitly passed one
    */
   @Deprecated
   public static boolean isAuthorized(AccessControlList acl, User user, Organization org, Object action,

--- a/modules/common/src/main/java/org/opencastproject/security/api/AccessControlUtil.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/AccessControlUtil.java
@@ -78,7 +78,10 @@ public final class AccessControlUtil {
    * @return whether this action should be allowed
    * @throws IllegalArgumentException
    *           if any of the arguments are null
+   * @deprecated use {@link AuthorizationService#hasPermission(AccessControlList, String)} instead, which checks
+   *             against the current user rather than an explicitly passed one
    */
+  @Deprecated
   public static boolean isAuthorized(AccessControlList acl, User user, Organization org, Object action) {
     return isAuthorized(acl, user, org, action, null);
   }
@@ -109,7 +112,10 @@ public final class AccessControlUtil {
    * @return whether this action should be allowed
    * @throws IllegalArgumentException
    *           if any of the arguments are null
+   * @deprecated use {@link AuthorizationService#hasPermission(AccessControlList, String, String)} instead, which
+   *             checks against the current user rather than an explicitly passed one
    */
+  @Deprecated
   public static boolean isAuthorized(AccessControlList acl, User user, Organization org, Object action,
       String mediaPackageId) {
     if (action == null || user == null || acl == null || org == null) {

--- a/modules/common/src/main/java/org/opencastproject/security/api/AuthorizationService.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/AuthorizationService.java
@@ -48,6 +48,10 @@ public interface AuthorizationService {
    * This is not restricted to access control lists in media packages, but works regardless of which entity the
    * access control list belongs to.
    *
+   * Global and organization admins are always granted permission. Otherwise, the access control list entries are
+   * evaluated in order, and the first entry matching both the action and one of the current user's roles decides
+   * the outcome.
+   *
    * @param acl
    *          the access control list
    * @param action
@@ -55,6 +59,22 @@ public interface AuthorizationService {
    * @return whether the current user has the correct privileges to take this action
    */
   boolean hasPermission(AccessControlList acl, String action);
+
+  /**
+   * Determines whether the current user can take the specified action given the access control list, additionally
+   * granting access if the user has the special per-mediapackage
+   * <code>ROLE_EPISODE_&lt;mediaPackageId&gt;_&lt;action&gt;</code> role.
+   *
+   * @param acl
+   *          the access control list
+   * @param mediaPackageId
+   *          the id of the media package the access control list belongs to
+   * @param action
+   *          the action (e.g. read, modify, delete)
+   * @return whether the current user has the correct privileges to take this action
+   * @see #hasPermission(AccessControlList, String)
+   */
+  boolean hasPermission(AccessControlList acl, String mediaPackageId, String action);
 
   /**
    * Gets the active access control list associated with the given media package, as specified by its XACML

--- a/modules/common/src/main/java/org/opencastproject/security/api/AuthorizationService.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/AuthorizationService.java
@@ -74,7 +74,9 @@ public interface AuthorizationService {
    * @return whether the current user has the correct privileges to take this action
    * @see #hasPermission(AccessControlList, String)
    */
-  boolean hasPermission(AccessControlList acl, String mediaPackageId, String action);
+  default boolean hasPermissionForMediaPackage(AccessControlList acl, String mediaPackageId, String action) {
+    return hasPermission(acl, action);
+  }
 
   /**
    * Gets the active access control list associated with the given media package, as specified by its XACML

--- a/modules/common/src/main/java/org/opencastproject/security/util/SecurityUtil.java
+++ b/modules/common/src/main/java/org/opencastproject/security/util/SecurityUtil.java
@@ -171,6 +171,27 @@ public final class SecurityUtil {
   }
 
   /**
+   * Check if the given user has the global admin role.
+   */
+  public static boolean isGlobalAdmin(final User user) {
+    return user.hasRole(SecurityConstants.GLOBAL_ADMIN_ROLE);
+  }
+
+  /**
+   * Check if the given user has the admin role of the given organization.
+   */
+  public static boolean isOrganizationAdmin(final User user, final Organization organization) {
+    return user.hasRole(organization.getAdminRole());
+  }
+
+  /**
+   * Check if the given user is a global admin, or an admin of the given organization.
+   */
+  public static boolean isAdmin(final User user, final Organization organization) {
+    return isGlobalAdmin(user) || isOrganizationAdmin(user, organization);
+  }
+
+  /**
    * Check if the current user has access to the capture agent with the given id.
    * @param agentId
    *           The agent id to check.
@@ -183,7 +204,7 @@ public final class SecurityUtil {
       return;
     }
     final User user = securityService.getUser();
-    if (user.hasRole(SecurityConstants.GLOBAL_ADMIN_ROLE) || user.hasRole(user.getOrganization().getAdminRole())) {
+    if (isAdmin(user, user.getOrganization())) {
       return;
     }
     if (!user.hasRole(SecurityUtil.getCaptureAgentRole(agentId))) {

--- a/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
+++ b/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
@@ -60,13 +60,13 @@ import org.opencastproject.metadata.dublincore.MetadataJson;
 import org.opencastproject.metadata.dublincore.MetadataList;
 import org.opencastproject.security.api.AuthorizationService;
 import org.opencastproject.security.api.Organization;
-import org.opencastproject.security.api.SecurityConstants;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.security.api.User;
 import org.opencastproject.security.urlsigning.exception.UrlSigningException;
 import org.opencastproject.security.urlsigning.service.UrlSigningService;
 import org.opencastproject.security.urlsigning.utils.UrlSigningServiceOsgiUtil;
+import org.opencastproject.security.util.SecurityUtil;
 import org.opencastproject.smil.api.SmilException;
 import org.opencastproject.smil.api.SmilResponse;
 import org.opencastproject.smil.api.SmilService;
@@ -1079,15 +1079,13 @@ public class EditorServiceImpl implements EditorService {
   private boolean isAdmin() {
     final User currentUser = securityService.getUser();
 
-    // Global admin
-    if (currentUser.hasRole(SecurityConstants.GLOBAL_ADMIN_ROLE)) {
+    if (SecurityUtil.isGlobalAdmin(currentUser)) {
       return true;
     }
 
-    // Organization admin
     final Organization currentOrg = securityService.getOrganization();
     return currentUser.getOrganization().getId().equals(currentOrg.getId())
-            && currentUser.hasRole(currentOrg.getAdminRole());
+            && SecurityUtil.isOrganizationAdmin(currentUser, currentOrg);
   }
 
   private MediaPackage getMediaPackage(Event event) throws EditorServiceException {

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/event/EventQueryBuilder.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/event/EventQueryBuilder.java
@@ -22,13 +22,13 @@
 package org.opencastproject.elasticsearch.index.objects.event;
 
 import static org.opencastproject.elasticsearch.impl.IndexSchema.SEARCH_FIELD_NAME_EXTENSION;
-import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
 
 import org.opencastproject.elasticsearch.api.SearchTerms;
 import org.opencastproject.elasticsearch.api.SearchTerms.Quantifier;
 import org.opencastproject.elasticsearch.impl.AbstractElasticsearchQueryBuilder;
 import org.opencastproject.security.api.Role;
 import org.opencastproject.security.api.User;
+import org.opencastproject.security.util.SecurityUtil;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,7 +81,7 @@ public class EventQueryBuilder extends AbstractElasticsearchQueryBuilder<EventSe
     // Action
     if (query.getActions() != null && query.getActions().length > 0) {
       User user = query.getUser();
-      if (!user.hasRole(GLOBAL_ADMIN_ROLE) && !user.hasRole(user.getOrganization().getAdminRole())) {
+      if (!SecurityUtil.isAdmin(user, user.getOrganization())) {
         for (Role role : user.getRoles()) {
           for (String action : query.getActions()) {
             and(EventIndexSchema.ACL_PERMISSION_PREFIX.concat(action), role.getName());

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/series/SeriesQueryBuilder.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/series/SeriesQueryBuilder.java
@@ -22,13 +22,13 @@
 package org.opencastproject.elasticsearch.index.objects.series;
 
 import static org.opencastproject.elasticsearch.impl.IndexSchema.SEARCH_FIELD_NAME_EXTENSION;
-import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
 
 import org.opencastproject.elasticsearch.api.SearchTerms;
 import org.opencastproject.elasticsearch.api.SearchTerms.Quantifier;
 import org.opencastproject.elasticsearch.impl.AbstractElasticsearchQueryBuilder;
 import org.opencastproject.security.api.Role;
 import org.opencastproject.security.api.User;
+import org.opencastproject.security.util.SecurityUtil;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,7 +76,7 @@ public class SeriesQueryBuilder extends AbstractElasticsearchQueryBuilder<Series
     // Action
     if (query.getActions() != null && query.getActions().length > 0) {
       User user = query.getUser();
-      if (!user.hasRole(GLOBAL_ADMIN_ROLE) && !user.hasRole(user.getOrganization().getAdminRole())) {
+      if (!SecurityUtil.isAdmin(user, user.getOrganization())) {
         for (Role role : user.getRoles()) {
           for (String action : query.getActions()) {
             and(SeriesIndexSchema.ACL_PERMISSION_PREFIX.concat(action), role.getName());

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/StatisticsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/StatisticsEndpoint.java
@@ -21,7 +21,6 @@
 
 package org.opencastproject.external.endpoint;
 
-import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
 import static org.opencastproject.util.data.functions.Misc.chuck;
 
 import org.opencastproject.elasticsearch.api.SearchIndexException;
@@ -38,6 +37,7 @@ import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.security.api.User;
+import org.opencastproject.security.util.SecurityUtil;
 import org.opencastproject.statistics.api.ResourceType;
 import org.opencastproject.statistics.api.StatisticsProvider;
 import org.opencastproject.statistics.api.StatisticsService;
@@ -401,11 +401,10 @@ public class StatisticsEndpoint {
   private void checkOrganizationAccess(final String orgId) throws UnauthorizedException {
     final User currentUser = securityService.getUser();
     final Organization currentOrg = securityService.getOrganization();
-    final String currentOrgAdminRole = currentOrg.getAdminRole();
     final String currentOrgId = currentOrg.getId();
 
-    boolean authorized = currentUser.hasRole(GLOBAL_ADMIN_ROLE)
-            || (currentUser.hasRole(currentOrgAdminRole) && currentOrgId.equals(orgId));
+    boolean authorized = SecurityUtil.isGlobalAdmin(currentUser)
+            || (currentOrgId.equals(orgId) && SecurityUtil.isOrganizationAdmin(currentUser, currentOrg));
 
     if (!authorized) {
       throw new UnauthorizedException(currentUser, "read");

--- a/modules/live-schedule-impl/src/test/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImplTest.java
+++ b/modules/live-schedule-impl/src/test/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImplTest.java
@@ -862,6 +862,11 @@ public class LiveScheduleServiceImplTest {
     }
 
     @Override
+    public boolean hasPermission(AccessControlList acl, String mediaPackageId, String action) {
+      return false;
+    }
+
+    @Override
     public Tuple<AccessControlList, AclScope> getActiveAcl(MediaPackage mp) {
       return null;
     }

--- a/modules/live-schedule-impl/src/test/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImplTest.java
+++ b/modules/live-schedule-impl/src/test/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImplTest.java
@@ -862,11 +862,6 @@ public class LiveScheduleServiceImplTest {
     }
 
     @Override
-    public boolean hasPermission(AccessControlList acl, String mediaPackageId, String action) {
-      return false;
-    }
-
-    @Override
     public Tuple<AccessControlList, AclScope> getActiveAcl(MediaPackage mp) {
       return null;
     }

--- a/modules/playlists/src/main/java/org/opencastproject/playlists/PlaylistService.java
+++ b/modules/playlists/src/main/java/org/opencastproject/playlists/PlaylistService.java
@@ -20,8 +20,6 @@
  */
 package org.opencastproject.playlists;
 
-import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
-
 import org.opencastproject.elasticsearch.api.SearchIndexException;
 import org.opencastproject.elasticsearch.api.SearchResult;
 import org.opencastproject.elasticsearch.index.ElasticsearchIndex;
@@ -39,6 +37,7 @@ import org.opencastproject.security.api.Permissions;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.security.api.User;
+import org.opencastproject.security.util.SecurityUtil;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.requests.SortCriterion;
 
@@ -170,8 +169,7 @@ public class PlaylistService {
   public List<Playlist> getAllForAdministrativeRead(Date from, Date to, int limit)
           throws IllegalStateException, UnauthorizedException {
     final var user = securityService.getUser();
-    final var orgAdminRole = securityService.getOrganization().getAdminRole();
-    if (!user.hasRole(GLOBAL_ADMIN_ROLE) && !user.hasRole(orgAdminRole)) {
+    if (!SecurityUtil.isAdmin(user, securityService.getOrganization())) {
       throw new UnauthorizedException("Only (org-)admins can call this method");
     }
 
@@ -456,11 +454,10 @@ public class PlaylistService {
   private boolean checkPermission(Playlist playlist, Permissions.Action action) {
     User currentUser = securityService.getUser();
     Organization currentOrg = securityService.getOrganization();
-    String currentOrgAdminRole = currentOrg.getAdminRole();
-    String currentOrgId = currentOrg.getId();
 
-    return currentUser.hasRole(GLOBAL_ADMIN_ROLE)
-        || (currentUser.hasRole(currentOrgAdminRole) && currentOrgId.equals(playlist.getOrganization()))
+    return SecurityUtil.isGlobalAdmin(currentUser)
+        || (currentOrg.getId().equals(playlist.getOrganization())
+            && SecurityUtil.isOrganizationAdmin(currentUser, currentOrg))
         || authorizationService.hasPermission(getAccessControlList(playlist), action.toString());
   }
 

--- a/modules/playlists/src/main/java/org/opencastproject/playlists/PlaylistService.java
+++ b/modules/playlists/src/main/java/org/opencastproject/playlists/PlaylistService.java
@@ -455,9 +455,15 @@ public class PlaylistService {
     User currentUser = securityService.getUser();
     Organization currentOrg = securityService.getOrganization();
 
-    return SecurityUtil.isGlobalAdmin(currentUser)
-        || (currentOrg.getId().equals(playlist.getOrganization())
-            && SecurityUtil.isOrganizationAdmin(currentUser, currentOrg))
+    if (SecurityUtil.isGlobalAdmin(currentUser)) {
+      return true;
+    }
+    // authorizationService.hasPermission() grants any org admin of the *current* organization, so if the playlist
+    // belongs to a different organization it must be rejected here rather than falling through to that check.
+    if (!currentOrg.getId().equals(playlist.getOrganization())) {
+      return false;
+    }
+    return SecurityUtil.isOrganizationAdmin(currentUser, currentOrg)
         || authorizationService.hasPermission(getAccessControlList(playlist), action.toString());
   }
 

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -22,7 +22,6 @@ package org.opencastproject.scheduler.impl;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.opencastproject.scheduler.impl.SchedulerUtil.calculateChecksum;
-import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
 import static org.opencastproject.util.EqualsUtil.ne;
 import static org.opencastproject.util.RequireUtil.notEmpty;
 import static org.opencastproject.util.RequireUtil.notNull;
@@ -817,8 +816,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
   }
 
   private boolean isAdmin() {
-    return (securityService.getUser().hasRole(GLOBAL_ADMIN_ROLE)
-            || securityService.getUser().hasRole(securityService.getOrganization().getAdminRole()));
+    return SecurityUtil.isAdmin(securityService.getUser(), securityService.getOrganization());
   }
 
   private Optional<DublinCoreCatalog> loadEpisodeDublinCoreFromAsset(Snapshot snapshot) {

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
@@ -40,12 +40,12 @@ import org.opencastproject.search.api.SearchService;
 import org.opencastproject.search.impl.SearchServiceImpl;
 import org.opencastproject.search.impl.SearchServiceIndex;
 import org.opencastproject.security.api.Role;
-import org.opencastproject.security.api.SecurityConstants;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.security.urlsigning.exception.UrlSigningException;
 import org.opencastproject.security.urlsigning.service.UrlSigningService;
 import org.opencastproject.security.urlsigning.utils.UrlSigningServiceOsgiUtil;
+import org.opencastproject.security.util.SecurityUtil;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.doc.rest.RestParameter;
@@ -201,8 +201,7 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
         .filter(QueryBuilders.termQuery(SearchResult.TYPE, type))
         .filter(QueryBuilders.boolQuery().mustNot(QueryBuilders.existsQuery(SearchResult.DELETED_DATE)));
     final var user = securityService.getUser();
-    final var orgAdminRole = securityService.getOrganization().getAdminRole();
-    if (!user.hasRole(SecurityConstants.GLOBAL_ADMIN_ROLE) && !user.hasRole(orgAdminRole)) {
+    if (!SecurityUtil.isAdmin(user, securityService.getOrganization())) {
       query.filter(QueryBuilders.termsQuery(
           SearchResult.INDEX_ACL + ".read",
           user.getRoles().stream().map(Role::getName).collect(Collectors.toList())
@@ -394,8 +393,7 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
     }
 
     var user = securityService.getUser();
-    var orgAdminRole = securityService.getOrganization().getAdminRole();
-    var admin = user.hasRole(SecurityConstants.GLOBAL_ADMIN_ROLE) || user.hasRole(orgAdminRole);
+    var admin = SecurityUtil.isAdmin(user, securityService.getOrganization());
     var query = QueryBuilders.boolQuery()
         .filter(QueryBuilders.termQuery(SearchResult.ORG, org))
         .filter(QueryBuilders.termQuery(SearchResult.TYPE, type))

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceImpl.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceImpl.java
@@ -21,7 +21,6 @@
 
 package org.opencastproject.search.impl;
 
-import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
 import static org.opencastproject.util.data.functions.Misc.chuck;
 
 import org.opencastproject.job.api.AbstractJobProducer;
@@ -404,7 +403,7 @@ public final class SearchServiceImpl extends AbstractJobProducer implements Sear
   public boolean verifyUrlAccess(final String path) {
     // Always allow access for admin
     final User user = securityService.getUser();
-    if (user.hasRole(GLOBAL_ADMIN_ROLE)) {
+    if (SecurityUtil.isGlobalAdmin(user)) {
       logger.debug("Allow access for admin `{}`", user);
       return true;
     }

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
@@ -46,7 +46,6 @@ import org.opencastproject.search.impl.persistence.SearchServiceDatabase;
 import org.opencastproject.search.impl.persistence.SearchServiceDatabaseException;
 import org.opencastproject.security.api.AccessControlEntry;
 import org.opencastproject.security.api.AccessControlList;
-import org.opencastproject.security.api.AccessControlUtil;
 import org.opencastproject.security.api.AuthorizationService;
 import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.OrganizationDirectoryService;
@@ -387,8 +386,7 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
         throw new NotFoundException();
       }
       AccessControlList acl = persistence.getAccessControlList(mediaPackageId);
-      if (!AccessControlUtil.isAuthorized(acl, user, securityService.getOrganization(), WRITE.toString(),
-          mediaPackageId)) {
+      if (!authorizationService.hasPermission(acl, mediaPackageId, WRITE.toString())) {
         throw new UnauthorizedException(user, "Write permission denied for " + mediaPackageId, acl);
       }
     } catch (NotFoundException e) {

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceIndex.java
@@ -386,7 +386,7 @@ public final class SearchServiceIndex extends AbstractIndexProducer implements I
         throw new NotFoundException();
       }
       AccessControlList acl = persistence.getAccessControlList(mediaPackageId);
-      if (!authorizationService.hasPermission(acl, mediaPackageId, WRITE.toString())) {
+      if (!authorizationService.hasPermissionForMediaPackage(acl, mediaPackageId, WRITE.toString())) {
         throw new UnauthorizedException(user, "Write permission denied for " + mediaPackageId, acl);
       }
     } catch (NotFoundException e) {

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
@@ -187,7 +187,7 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
         // allow ca users to retract live publications without putting them into the ACL
         if (!(searchMp.isLive() && currentUser.hasRole(GLOBAL_CAPTURE_AGENT_ROLE)) && accessControlXml != null) {
           AccessControlList acl = AccessControlParser.parseAcl(accessControlXml);
-          if (!authorizationService.hasPermission(acl, mediaPackageId, WRITE.toString())) {
+          if (!authorizationService.hasPermissionForMediaPackage(acl, mediaPackageId, WRITE.toString())) {
             throw new UnauthorizedException(
                 currentUser + " is not authorized to delete media package " + mediaPackageId);
           }
@@ -368,7 +368,7 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
           if (accessControlXml != null && entity.get().getDeletionDate() == null) {
             AccessControlList accessList = AccessControlParser.parseAcl(accessControlXml);
             User currentUser = securityService.getUser();
-            if (!authorizationService.hasPermission(accessList, mediaPackageId, WRITE.toString())) {
+            if (!authorizationService.hasPermissionForMediaPackage(accessList, mediaPackageId, WRITE.toString())) {
               throw new UnauthorizedException(currentUser + " is not authorized to update media package "
                   + mediaPackageId);
             }
@@ -411,9 +411,9 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
           AccessControlList acl = AccessControlParser.parseAcl(accessControlXml);
           User currentUser = securityService.getUser();
           // There are several reasons a user may need to load a episode: to read content, to edit it, or add content
-          if (!authorizationService.hasPermission(acl, mediaPackageId, READ.toString())
-                  && !authorizationService.hasPermission(acl, mediaPackageId, CONTRIBUTE.toString())
-                  && !authorizationService.hasPermission(acl, mediaPackageId, WRITE.toString())) {
+          if (!authorizationService.hasPermissionForMediaPackage(acl, mediaPackageId, READ.toString())
+                  && !authorizationService.hasPermissionForMediaPackage(acl, mediaPackageId, CONTRIBUTE.toString())
+                  && !authorizationService.hasPermissionForMediaPackage(acl, mediaPackageId, WRITE.toString())) {
             throw new UnauthorizedException(currentUser + " is not authorized to see episode " + mediaPackageId);
           }
         }
@@ -445,7 +445,7 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
         if (accessControlXml != null) {
           AccessControlList acl = AccessControlParser.parseAcl(accessControlXml);
           User currentUser = securityService.getUser();
-          if (!authorizationService.hasPermission(acl, mediaPackageId, READ.toString())) {
+          if (!authorizationService.hasPermissionForMediaPackage(acl, mediaPackageId, READ.toString())) {
             throw new UnauthorizedException(
                 currentUser + " is not authorized to read media package " + mediaPackageId);
           }
@@ -478,7 +478,7 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
         if (accessControlXml != null) {
           AccessControlList acl = AccessControlParser.parseAcl(accessControlXml);
           User currentUser = securityService.getUser();
-          if (!authorizationService.hasPermission(acl, mediaPackageId, READ.toString())) {
+          if (!authorizationService.hasPermissionForMediaPackage(acl, mediaPackageId, READ.toString())) {
             throw new UnauthorizedException(
                 currentUser + " is not authorized to read media package " + mediaPackageId);
           }
@@ -528,7 +528,7 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
         if (accessControlXml != null) {
           AccessControlList acl = AccessControlParser.parseAcl(accessControlXml);
           User currentUser = securityService.getUser();
-          if (!authorizationService.hasPermission(acl, mediaPackageId, READ.toString())) {
+          if (!authorizationService.hasPermissionForMediaPackage(acl, mediaPackageId, READ.toString())) {
             throw new UnauthorizedException(
                 currentUser + " is not authorized to read media package " + mediaPackageId);
           }

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
@@ -35,7 +35,7 @@ import org.opencastproject.mediapackage.MediaPackageParser;
 import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.security.api.AccessControlParser;
 import org.opencastproject.security.api.AccessControlParsingException;
-import org.opencastproject.security.api.AccessControlUtil;
+import org.opencastproject.security.api.AuthorizationService;
 import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
@@ -94,6 +94,9 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
   /** The security service */
   protected SecurityService securityService;
 
+  /** The authorization service */
+  protected AuthorizationService authorizationService;
+
   /** OSGi DI */
   @Reference(target = "(osgi.unit.name=org.opencastproject.search.impl.persistence)")
   public void setEntityManagerFactory(EntityManagerFactory emf) {
@@ -127,6 +130,17 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
   @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
+  }
+
+  /**
+   * OSGi callback to set the authorization service.
+   *
+   * @param authorizationService
+   *          the authorizationService to set
+   */
+  @Reference
+  public void setAuthorizationService(AuthorizationService authorizationService) {
+    this.authorizationService = authorizationService;
   }
 
   private void populateSeriesData() throws SearchServiceDatabaseException {
@@ -167,14 +181,13 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
 
         // Ensure this user is allowed to delete this episode
         User currentUser = securityService.getUser();
-        Organization currentOrg = securityService.getOrganization();
         MediaPackage searchMp = MediaPackageParser.getFromXml(searchEntity.get().getMediaPackageXML());
         String accessControlXml = searchEntity.get().getAccessControl();
 
         // allow ca users to retract live publications without putting them into the ACL
         if (!(searchMp.isLive() && currentUser.hasRole(GLOBAL_CAPTURE_AGENT_ROLE)) && accessControlXml != null) {
           AccessControlList acl = AccessControlParser.parseAcl(accessControlXml);
-          if (!AccessControlUtil.isAuthorized(acl, currentUser, currentOrg, WRITE.toString(), mediaPackageId)) {
+          if (!authorizationService.hasPermission(acl, mediaPackageId, WRITE.toString())) {
             throw new UnauthorizedException(
                 currentUser + " is not authorized to delete media package " + mediaPackageId);
           }
@@ -355,9 +368,7 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
           if (accessControlXml != null && entity.get().getDeletionDate() == null) {
             AccessControlList accessList = AccessControlParser.parseAcl(accessControlXml);
             User currentUser = securityService.getUser();
-            Organization currentOrg = securityService.getOrganization();
-            if (!AccessControlUtil.isAuthorized(accessList, currentUser, currentOrg, WRITE.toString(),
-                mediaPackageId)) {
+            if (!authorizationService.hasPermission(accessList, mediaPackageId, WRITE.toString())) {
               throw new UnauthorizedException(currentUser + " is not authorized to update media package "
                   + mediaPackageId);
             }
@@ -399,12 +410,10 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
         if (accessControlXml != null) {
           AccessControlList acl = AccessControlParser.parseAcl(accessControlXml);
           User currentUser = securityService.getUser();
-          Organization currentOrg = securityService.getOrganization();
           // There are several reasons a user may need to load a episode: to read content, to edit it, or add content
-          if (!AccessControlUtil.isAuthorized(acl, currentUser, currentOrg, READ.toString(), mediaPackageId)
-                  && !AccessControlUtil.isAuthorized(acl, currentUser, currentOrg, CONTRIBUTE.toString(),
-              mediaPackageId)
-                  && !AccessControlUtil.isAuthorized(acl, currentUser, currentOrg, WRITE.toString(), mediaPackageId)) {
+          if (!authorizationService.hasPermission(acl, mediaPackageId, READ.toString())
+                  && !authorizationService.hasPermission(acl, mediaPackageId, CONTRIBUTE.toString())
+                  && !authorizationService.hasPermission(acl, mediaPackageId, WRITE.toString())) {
             throw new UnauthorizedException(currentUser + " is not authorized to see episode " + mediaPackageId);
           }
         }
@@ -436,8 +445,7 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
         if (accessControlXml != null) {
           AccessControlList acl = AccessControlParser.parseAcl(accessControlXml);
           User currentUser = securityService.getUser();
-          Organization currentOrg = securityService.getOrganization();
-          if (!AccessControlUtil.isAuthorized(acl, currentUser, currentOrg, READ.toString(), mediaPackageId)) {
+          if (!authorizationService.hasPermission(acl, mediaPackageId, READ.toString())) {
             throw new UnauthorizedException(
                 currentUser + " is not authorized to read media package " + mediaPackageId);
           }
@@ -470,8 +478,7 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
         if (accessControlXml != null) {
           AccessControlList acl = AccessControlParser.parseAcl(accessControlXml);
           User currentUser = securityService.getUser();
-          Organization currentOrg = securityService.getOrganization();
-          if (!AccessControlUtil.isAuthorized(acl, currentUser, currentOrg, READ.toString(), mediaPackageId)) {
+          if (!authorizationService.hasPermission(acl, mediaPackageId, READ.toString())) {
             throw new UnauthorizedException(
                 currentUser + " is not authorized to read media package " + mediaPackageId);
           }
@@ -521,8 +528,7 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
         if (accessControlXml != null) {
           AccessControlList acl = AccessControlParser.parseAcl(accessControlXml);
           User currentUser = securityService.getUser();
-          Organization currentOrg = securityService.getOrganization();
-          if (!AccessControlUtil.isAuthorized(acl, currentUser, currentOrg, READ.toString(), mediaPackageId)) {
+          if (!authorizationService.hasPermission(acl, mediaPackageId, READ.toString())) {
             throw new UnauthorizedException(
                 currentUser + " is not authorized to read media package " + mediaPackageId);
           }

--- a/modules/search-service-impl/src/test/java/org/opencastproject/search/impl/persistence/SearchServicePersistenceTest.java
+++ b/modules/search-service-impl/src/test/java/org/opencastproject/search/impl/persistence/SearchServicePersistenceTest.java
@@ -28,6 +28,7 @@ import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageBuilderFactory;
 import org.opencastproject.security.api.AccessControlEntry;
 import org.opencastproject.security.api.AccessControlList;
+import org.opencastproject.security.api.AuthorizationService;
 import org.opencastproject.security.api.DefaultOrganization;
 import org.opencastproject.security.api.JaxbRole;
 import org.opencastproject.security.api.JaxbUser;
@@ -86,6 +87,13 @@ public class SearchServicePersistenceTest {
     EasyMock.expect(securityService.getUser()).andReturn(user).anyTimes();
     EasyMock.replay(securityService);
 
+    // Mock up an authorization service that always grants access, mirroring the real service's admin bypass
+    // for the global admin user used throughout this test
+    AuthorizationService authorizationService = EasyMock.createNiceMock(AuthorizationService.class);
+    EasyMock.expect(authorizationService.hasPermission(EasyMock.anyObject(AccessControlList.class),
+        EasyMock.anyString(), EasyMock.anyString())).andReturn(true).anyTimes();
+    EasyMock.replay(authorizationService);
+
     BundleContext bc = EasyMock.createNiceMock(BundleContext.class);
     ComponentContext cc = EasyMock.createNiceMock(ComponentContext.class);
     EasyMock.expect(cc.getBundleContext()).andReturn(bc).anyTimes();
@@ -95,6 +103,7 @@ public class SearchServicePersistenceTest {
     searchDatabase.setEntityManagerFactory(emf);
     searchDatabase.setDBSessionFactory(getDbSessionFactory());
     searchDatabase.setSecurityService(securityService);
+    searchDatabase.setAuthorizationService(authorizationService);
     searchDatabase.activate(cc);
 
     mediaPackage = MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder().createNew();

--- a/modules/search-service-impl/src/test/java/org/opencastproject/search/impl/persistence/SearchServicePersistenceTest.java
+++ b/modules/search-service-impl/src/test/java/org/opencastproject/search/impl/persistence/SearchServicePersistenceTest.java
@@ -87,11 +87,24 @@ public class SearchServicePersistenceTest {
     EasyMock.expect(securityService.getUser()).andReturn(user).anyTimes();
     EasyMock.replay(securityService);
 
-    // Mock up an authorization service that always grants access, mirroring the real service's admin bypass
-    // for the global admin user used throughout this test
+    // Mock up an authorization service that evaluates the ACL the same way the real XACML-backed implementation
+    // does (first matching entry for the user's roles wins, with a bypass for the global admin user used
+    // throughout this test), rather than blindly granting access regardless of the ACL passed in.
     AuthorizationService authorizationService = EasyMock.createNiceMock(AuthorizationService.class);
-    EasyMock.expect(authorizationService.hasPermission(EasyMock.anyObject(AccessControlList.class),
-        EasyMock.anyString(), EasyMock.anyString())).andReturn(true).anyTimes();
+    EasyMock.expect(authorizationService.hasPermissionForMediaPackage(EasyMock.anyObject(AccessControlList.class),
+        EasyMock.anyString(), EasyMock.anyString())).andAnswer(() -> {
+          AccessControlList acl = (AccessControlList) EasyMock.getCurrentArguments()[0];
+          String action = (String) EasyMock.getCurrentArguments()[2];
+          if (user.hasRole(SecurityConstants.GLOBAL_ADMIN_ROLE)) {
+            return true;
+          }
+          for (AccessControlEntry entry : acl.getEntries()) {
+            if (entry.getAction().equals(action) && user.hasRole(entry.getRole())) {
+              return entry.isAllow();
+            }
+          }
+          return false;
+        }).anyTimes();
     EasyMock.replay(authorizationService);
 
     BundleContext bc = EasyMock.createNiceMock(BundleContext.class);

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesServiceDatabaseImpl.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesServiceDatabaseImpl.java
@@ -33,8 +33,7 @@ import org.opencastproject.metadata.dublincore.DublinCoreXmlFormat;
 import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.security.api.AccessControlParser;
 import org.opencastproject.security.api.AccessControlParsingException;
-import org.opencastproject.security.api.AccessControlUtil;
-import org.opencastproject.security.api.Organization;
+import org.opencastproject.security.api.AuthorizationService;
 import org.opencastproject.security.api.Permissions;
 import org.opencastproject.security.api.SecurityConstants;
 import org.opencastproject.security.api.SecurityService;
@@ -100,6 +99,9 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
   /** The security service */
   protected SecurityService securityService;
 
+  /** The authorization service */
+  protected AuthorizationService authorizationService;
+
   /** OSGi DI */
   @Reference(target = "(osgi.unit.name=org.opencastproject.series.impl.persistence)")
   public void setEntityManagerFactory(EntityManagerFactory emf) {
@@ -131,6 +133,17 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
   @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
+  }
+
+  /**
+   * OSGi callback to set the authorization service.
+   *
+   * @param authorizationService
+   *          the authorizationService to set
+   */
+  @Reference
+  public void setAuthorizationService(AuthorizationService authorizationService) {
+    this.authorizationService = authorizationService;
   }
 
   /**
@@ -180,8 +193,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
         if (accessControlXml != null) {
           AccessControlList acl = AccessControlParser.parseAcl(accessControlXml);
           User currentUser = securityService.getUser();
-          Organization currentOrg = securityService.getOrganization();
-          if (!AccessControlUtil.isAuthorized(acl, currentUser, currentOrg, Permissions.Action.WRITE.toString())) {
+          if (!authorizationService.hasPermission(acl, Permissions.Action.WRITE.toString())) {
             throw new UnauthorizedException(currentUser + " is not authorized to update series " + seriesId);
           }
         }
@@ -330,8 +342,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
           if (accessControlXml != null) {
             AccessControlList acl = AccessControlParser.parseAcl(accessControlXml);
             User currentUser = securityService.getUser();
-            Organization currentOrg = securityService.getOrganization();
-            if (!AccessControlUtil.isAuthorized(acl, currentUser, currentOrg, Permissions.Action.WRITE.toString())) {
+            if (!authorizationService.hasPermission(acl, Permissions.Action.WRITE.toString())) {
               throw new UnauthorizedException(currentUser + " is not authorized to update series " + seriesId);
             }
           }
@@ -497,9 +508,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
     String accessControlXml = entity.getAccessControl();
     if (accessControlXml != null) {
       AccessControlList acl = AccessControlParser.parseAcl(accessControlXml);
-      User currentUser = securityService.getUser();
-      Organization currentOrg = securityService.getOrganization();
-      return AccessControlUtil.isAuthorized(acl, currentUser, currentOrg, Permissions.Action.WRITE.toString());
+      return authorizationService.hasPermission(acl, Permissions.Action.WRITE.toString());
     }
     return true;
   }
@@ -510,15 +519,14 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
     if (accessControlXml != null) {
       AccessControlList acl = AccessControlParser.parseAcl(accessControlXml);
       User currentUser = securityService.getUser();
-      Organization currentOrg = securityService.getOrganization();
 
       if (currentUser.hasRole(SecurityConstants.GLOBAL_CAPTURE_AGENT_ROLE)) {
         return true;
       }
       // There are several reasons a user may need to load a series: to read content, to edit it, or add content
-      return AccessControlUtil.isAuthorized(acl, currentUser, currentOrg, Permissions.Action.READ.toString())
-          || AccessControlUtil.isAuthorized(acl, currentUser, currentOrg, Permissions.Action.CONTRIBUTE.toString())
-          || AccessControlUtil.isAuthorized(acl, currentUser, currentOrg, Permissions.Action.WRITE.toString());
+      return authorizationService.hasPermission(acl, Permissions.Action.READ.toString())
+          || authorizationService.hasPermission(acl, Permissions.Action.CONTRIBUTE.toString())
+          || authorizationService.hasPermission(acl, Permissions.Action.WRITE.toString());
     }
     return true;
   }
@@ -559,8 +567,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
           if (accessControlXml != null) {
             AccessControlList acl = AccessControlParser.parseAcl(accessControlXml);
             User currentUser = securityService.getUser();
-            Organization currentOrg = securityService.getOrganization();
-            if (!AccessControlUtil.isAuthorized(acl, currentUser, currentOrg, Permissions.Action.WRITE.toString())) {
+            if (!authorizationService.hasPermission(acl, Permissions.Action.WRITE.toString())) {
               throw new UnauthorizedException(currentUser + " is not authorized to update ACLs on series " + seriesId);
             }
           }

--- a/modules/series-service-impl/src/test/java/org/opencastproject/series/impl/SeriesServiceImplTest.java
+++ b/modules/series-service-impl/src/test/java/org/opencastproject/series/impl/SeriesServiceImplTest.java
@@ -105,11 +105,24 @@ public class SeriesServiceImplTest {
     EasyMock.expect(securityService.getUser()).andReturn(user).anyTimes();
     EasyMock.replay(securityService);
 
-    // Mock up an authorization service that always grants access, mirroring the real service's admin bypass
-    // for the global admin user used throughout this test
+    // Mock up an authorization service that evaluates the ACL the same way the real XACML-backed implementation
+    // does (first matching entry for the user's roles wins, with a bypass for the global admin user used
+    // throughout this test), rather than blindly granting access regardless of the ACL passed in.
     AuthorizationService authorizationService = EasyMock.createNiceMock(AuthorizationService.class);
     EasyMock.expect(authorizationService.hasPermission(EasyMock.anyObject(AccessControlList.class),
-        EasyMock.anyString())).andReturn(true).anyTimes();
+        EasyMock.anyString())).andAnswer(() -> {
+          AccessControlList acl = (AccessControlList) EasyMock.getCurrentArguments()[0];
+          String action = (String) EasyMock.getCurrentArguments()[1];
+          if (user.hasRole(SecurityConstants.GLOBAL_ADMIN_ROLE)) {
+            return true;
+          }
+          for (AccessControlEntry entry : acl.getEntries()) {
+            if (entry.getAction().equals(action) && user.hasRole(entry.getRole())) {
+              return entry.isAllow();
+            }
+          }
+          return false;
+        }).anyTimes();
     EasyMock.replay(authorizationService);
 
     seriesDatabase = new SeriesServiceDatabaseImpl();

--- a/modules/series-service-impl/src/test/java/org/opencastproject/series/impl/SeriesServiceImplTest.java
+++ b/modules/series-service-impl/src/test/java/org/opencastproject/series/impl/SeriesServiceImplTest.java
@@ -40,6 +40,7 @@ import org.opencastproject.metadata.dublincore.DublinCores;
 import org.opencastproject.security.api.AccessControlEntry;
 import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.security.api.AccessControlUtil;
+import org.opencastproject.security.api.AuthorizationService;
 import org.opencastproject.security.api.DefaultOrganization;
 import org.opencastproject.security.api.JaxbRole;
 import org.opencastproject.security.api.JaxbUser;
@@ -104,12 +105,20 @@ public class SeriesServiceImplTest {
     EasyMock.expect(securityService.getUser()).andReturn(user).anyTimes();
     EasyMock.replay(securityService);
 
+    // Mock up an authorization service that always grants access, mirroring the real service's admin bypass
+    // for the global admin user used throughout this test
+    AuthorizationService authorizationService = EasyMock.createNiceMock(AuthorizationService.class);
+    EasyMock.expect(authorizationService.hasPermission(EasyMock.anyObject(AccessControlList.class),
+        EasyMock.anyString())).andReturn(true).anyTimes();
+    EasyMock.replay(authorizationService);
+
     seriesDatabase = new SeriesServiceDatabaseImpl();
     seriesDatabase.setEntityManagerFactory(newEntityManagerFactory(SeriesServiceDatabaseImpl.PERSISTENCE_UNIT));
     seriesDatabase.setDBSessionFactory(getDbSessionFactory());
     dcService = new DublinCoreCatalogService();
     seriesDatabase.setDublinCoreService(dcService);
     seriesDatabase.setSecurityService(securityService);
+    seriesDatabase.setAuthorizationService(authorizationService);
     seriesDatabase.activate(null);
 
     root = PathSupport.concat("target", Long.toString(currentTime));

--- a/modules/series-service-impl/src/test/java/org/opencastproject/series/impl/persistence/SeriesServicePersistenceTest.java
+++ b/modules/series-service-impl/src/test/java/org/opencastproject/series/impl/persistence/SeriesServicePersistenceTest.java
@@ -35,6 +35,7 @@ import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalogService;
 import org.opencastproject.security.api.AccessControlEntry;
 import org.opencastproject.security.api.AccessControlList;
+import org.opencastproject.security.api.AuthorizationService;
 import org.opencastproject.security.api.DefaultOrganization;
 import org.opencastproject.security.api.JaxbRole;
 import org.opencastproject.security.api.JaxbUser;
@@ -81,12 +82,20 @@ public class SeriesServicePersistenceTest {
     EasyMock.expect(securityService.getUser()).andReturn(user).anyTimes();
     EasyMock.replay(securityService);
 
+    // Mock up an authorization service that always grants access, mirroring the real service's admin bypass
+    // for the global admin user used throughout this test
+    AuthorizationService authorizationService = EasyMock.createNiceMock(AuthorizationService.class);
+    EasyMock.expect(authorizationService.hasPermission(EasyMock.anyObject(AccessControlList.class),
+        EasyMock.anyString())).andReturn(true).anyTimes();
+    EasyMock.replay(authorizationService);
+
     seriesDatabase = new SeriesServiceDatabaseImpl();
     seriesDatabase.setEntityManagerFactory(newEntityManagerFactory(SeriesServiceDatabaseImpl.PERSISTENCE_UNIT));
     seriesDatabase.setDBSessionFactory(getDbSessionFactory());
     DublinCoreCatalogService dcService = new DublinCoreCatalogService();
     seriesDatabase.setDublinCoreService(dcService);
     seriesDatabase.setSecurityService(securityService);
+    seriesDatabase.setAuthorizationService(authorizationService);
     seriesDatabase.activate(null);
 
     InputStream in = null;

--- a/modules/series-service-impl/src/test/java/org/opencastproject/series/impl/persistence/SeriesServicePersistenceTest.java
+++ b/modules/series-service-impl/src/test/java/org/opencastproject/series/impl/persistence/SeriesServicePersistenceTest.java
@@ -82,11 +82,24 @@ public class SeriesServicePersistenceTest {
     EasyMock.expect(securityService.getUser()).andReturn(user).anyTimes();
     EasyMock.replay(securityService);
 
-    // Mock up an authorization service that always grants access, mirroring the real service's admin bypass
-    // for the global admin user used throughout this test
+    // Mock up an authorization service that evaluates the ACL the same way the real XACML-backed implementation
+    // does (first matching entry for the user's roles wins, with a bypass for the global admin user used
+    // throughout this test), rather than blindly granting access regardless of the ACL passed in.
     AuthorizationService authorizationService = EasyMock.createNiceMock(AuthorizationService.class);
     EasyMock.expect(authorizationService.hasPermission(EasyMock.anyObject(AccessControlList.class),
-        EasyMock.anyString())).andReturn(true).anyTimes();
+        EasyMock.anyString())).andAnswer(() -> {
+          AccessControlList acl = (AccessControlList) EasyMock.getCurrentArguments()[0];
+          String action = (String) EasyMock.getCurrentArguments()[1];
+          if (user.hasRole(SecurityConstants.GLOBAL_ADMIN_ROLE)) {
+            return true;
+          }
+          for (AccessControlEntry entry : acl.getEntries()) {
+            if (entry.getAction().equals(action) && user.hasRole(entry.getRole())) {
+              return entry.isAllow();
+            }
+          }
+          return false;
+        }).anyTimes();
     EasyMock.replay(authorizationService);
 
     seriesDatabase = new SeriesServiceDatabaseImpl();

--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Harvest.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Harvest.java
@@ -26,9 +26,9 @@ import org.opencastproject.search.api.SearchResult;
 import org.opencastproject.search.api.SearchResultList;
 import org.opencastproject.search.api.SearchService;
 import org.opencastproject.security.api.AuthorizationService;
-import org.opencastproject.security.api.SecurityConstants;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
+import org.opencastproject.security.util.SecurityUtil;
 import org.opencastproject.series.api.SeriesException;
 import org.opencastproject.series.api.SeriesService;
 import org.opencastproject.util.Jsons;
@@ -87,8 +87,7 @@ final class Harvest {
     final var org = securityService.getOrganization().getId();
 
     var user = securityService.getUser();
-    var orgAdminRole = securityService.getOrganization().getAdminRole();
-    var isAdmin = user.hasRole(SecurityConstants.GLOBAL_ADMIN_ROLE) || user.hasRole(orgAdminRole);
+    var isAdmin = SecurityUtil.isAdmin(user, securityService.getOrganization());
     if (!isAdmin) {
       throw new UnauthorizedException(user, "Only (org-) admins can access the Tobira harvest API");
     }

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/utils/UserDirectoryUtils.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/utils/UserDirectoryUtils.java
@@ -26,6 +26,7 @@ import org.opencastproject.security.api.Role;
 import org.opencastproject.security.api.SecurityConstants;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.User;
+import org.opencastproject.security.util.SecurityUtil;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -58,12 +59,11 @@ public final class UserDirectoryUtils {
 
     for (Role role : roles) {
       if (StringUtils.equals(SecurityConstants.GLOBAL_ADMIN_ROLE, role.getName())) {
-        return user.hasRole(SecurityConstants.GLOBAL_ADMIN_ROLE);
+        return SecurityUtil.isGlobalAdmin(user);
       }
 
       if (org != null && StringUtils.equals(org.getAdminRole(), role.getName())) {
-        return user.hasRole(SecurityConstants.GLOBAL_ADMIN_ROLE)
-                || user.hasRole(org.getAdminRole());
+        return SecurityUtil.isAdmin(user, org);
       }
     }
     return true;

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowDefinitionScanner.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowDefinitionScanner.java
@@ -21,13 +21,13 @@
 
 package org.opencastproject.workflow.impl;
 
-import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
 import static org.opencastproject.util.ReadinessIndicator.ARTIFACT;
 
 import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.OrganizationDirectoryListener;
 import org.opencastproject.security.api.OrganizationDirectoryService;
 import org.opencastproject.security.api.User;
+import org.opencastproject.security.util.SecurityUtil;
 import org.opencastproject.util.ReadinessIndicator;
 import org.opencastproject.workflow.api.WorkflowDefinition;
 import org.opencastproject.workflow.api.WorkflowIdentifier;
@@ -259,7 +259,7 @@ public class WorkflowDefinitionScanner implements ArtifactInstaller, Organizatio
   }
 
   private boolean userCanAccessWorkflowDefinition(final User user, final WorkflowDefinition wd) {
-    return wd.getRoles().isEmpty() || user.hasRole(GLOBAL_ADMIN_ROLE) || wd.getRoles().stream()
+    return wd.getRoles().isEmpty() || SecurityUtil.isGlobalAdmin(user) || wd.getRoles().stream()
             .anyMatch(user::hasRole);
   }
 

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -61,6 +61,7 @@ import org.opencastproject.security.api.AuthorizationService;
 import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.OrganizationDirectoryService;
 import org.opencastproject.security.api.Permissions;
+import org.opencastproject.security.api.SecurityConstants;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.security.api.User;
@@ -499,6 +500,27 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
           Long parentWorkflowId, Map<String, String> originalProperties) throws WorkflowDatabaseException,
           NotFoundException, UnauthorizedException, WorkflowParsingException, IllegalStateException {
     final String mediaPackageId = sourceMediaPackage.getIdentifier().toString();
+
+    // Get the current user
+    User currentUser = securityService.getUser();
+    validUserOrThrow(currentUser);
+
+    // Get the current organization
+    Organization organization = securityService.getOrganization();
+    if (organization == null) {
+      throw new SecurityException("Current organization is unknown");
+    }
+
+    // Check that the current user has the right to start a workflow on this media package, before taking an
+    // AssetManager snapshot or the per-media-package lock below.
+    // Capture agents are allowed through without an explicit ACL entry, mirroring the same carve-out
+    // AssetManagerImpl makes for ingest.
+    if (!SecurityUtil.isAdmin(currentUser, organization)
+            && !currentUser.hasRole(SecurityConstants.GLOBAL_CAPTURE_AGENT_ROLE)
+            && !authorizationService.hasPermission(sourceMediaPackage, Permissions.Action.WRITE.toString())) {
+      throw new UnauthorizedException(currentUser, Permissions.Action.WRITE.toString());
+    }
+
     Map<String, String> properties = null;
 
     // WorkflowPropertiesUtil.storeProperties will take a snapshot if there isn't one
@@ -536,22 +558,6 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
                   workflowDefinition.getTitle(),
                   sourceMediaPackage.getIdentifier().toString()));
         }
-      }
-
-      // Get the current user
-      User currentUser = securityService.getUser();
-      validUserOrThrow(currentUser);
-
-      // Get the current organization
-      Organization organization = securityService.getOrganization();
-      if (organization == null) {
-        throw new SecurityException("Current organization is unknown");
-      }
-
-      // Check that the current user has the right to start a workflow on this media package
-      if (!SecurityUtil.isAdmin(currentUser, organization)
-              && !authorizationService.hasPermission(sourceMediaPackage, Permissions.Action.WRITE.toString())) {
-        throw new UnauthorizedException(currentUser, Permissions.Action.WRITE.toString());
       }
 
       WorkflowInstance workflowInstance = new WorkflowInstance(workflowDefinition, sourceMediaPackage,

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -21,7 +21,6 @@
 
 package org.opencastproject.workflow.impl;
 
-import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
 import static org.opencastproject.workflow.api.WorkflowInstance.WorkflowState.FAILED;
 import static org.opencastproject.workflow.api.WorkflowInstance.WorkflowState.FAILING;
 import static org.opencastproject.workflow.api.WorkflowInstance.WorkflowState.INSTANTIATED;
@@ -66,6 +65,7 @@ import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.security.api.User;
 import org.opencastproject.security.api.UserDirectoryService;
+import org.opencastproject.security.util.SecurityUtil;
 import org.opencastproject.series.api.SeriesException;
 import org.opencastproject.series.api.SeriesService;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
@@ -546,6 +546,12 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
       Organization organization = securityService.getOrganization();
       if (organization == null) {
         throw new SecurityException("Current organization is unknown");
+      }
+
+      // Check that the current user has the right to start a workflow on this media package
+      if (!SecurityUtil.isAdmin(currentUser, organization)
+              && !authorizationService.hasPermission(sourceMediaPackage, Permissions.Action.WRITE.toString())) {
+        throw new UnauthorizedException(currentUser, Permissions.Action.WRITE.toString());
       }
 
       WorkflowInstance workflowInstance = new WorkflowInstance(workflowDefinition, sourceMediaPackage,
@@ -1135,7 +1141,6 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
           throws UnauthorizedException {
     User currentUser = securityService.getUser();
     Organization currentOrg = securityService.getOrganization();
-    String currentOrgAdminRole = currentOrg.getAdminRole();
     String currentOrgId = currentOrg.getId();
 
     MediaPackage mediapackage = workflow.getMediaPackage();
@@ -1150,8 +1155,8 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
 
     var creatorName = workflow.getCreatorName();
     var workflowCreator = creatorName == null ? null : userDirectoryService.loadUser(creatorName);
-    boolean authorized = currentUser.hasRole(GLOBAL_ADMIN_ROLE)
-            || (currentUser.hasRole(currentOrgAdminRole) && currentOrgId.equals(workflowOrgId))
+    boolean authorized = SecurityUtil.isGlobalAdmin(currentUser)
+            || (currentOrgId.equals(workflowOrgId) && SecurityUtil.isOrganizationAdmin(currentUser, currentOrg))
             || (currentUser.equals(workflowCreator))
             || (authorizationService.hasPermission(mediapackage, action) && currentOrgId.equals(workflowOrgId));
 
@@ -1167,8 +1172,8 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
     // asset manager already checks if user is admin, org admin for same org as mp, or has explicit read rights
     // global admins can still get workflow instances if mp is gone from asset manager
     // org admins can't because then we don't know if mp belonged to same org as user
-    return currentUser.hasRole(GLOBAL_ADMIN_ROLE)
-            || mp.isPresent() && currentUser.hasRole(securityService.getOrganization().getAdminRole())
+    return SecurityUtil.isGlobalAdmin(currentUser)
+            || mp.isPresent() && SecurityUtil.isOrganizationAdmin(currentUser, securityService.getOrganization())
             || mp.isPresent() && authorizationService.hasPermission(mp.get(), action);
   }
 

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceImplAuthzTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceImplAuthzTest.java
@@ -336,20 +336,21 @@ public class WorkflowServiceImplAuthzTest {
     def.add(new WorkflowOperationDefinitionImpl("op1", "op1", null, true));
     MediaPackage mp = MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder().createNew();
 
-    // As an instructor, create a workflow
+    // An instructor with no security policy granting them access must not be able to start a workflow
     userResponder.setResponse(instructor1);
+    try {
+      service.start(def, mp);
+      fail();
+    } catch (UnauthorizedException e) {
+      // expected
+    }
+
+    // The organization admin can start the workflow regardless of the (missing) security policy
+    userResponder.setResponse(DEFAULT_ORG_ADMIN);
     WorkflowInstance workflow = service.start(def, mp);
     service.suspend(workflow.getId());
 
-    // Ensure that this instructor can access the workflow
-    try {
-      service.getWorkflowById(workflow.getId());
-    } catch (Exception e) {
-      fail(e.getMessage());
-    }
-
     // Ensure the organization admin can access that workflow
-    userResponder.setResponse(DEFAULT_ORG_ADMIN);
     try {
       service.getWorkflowById(workflow.getId());
     } catch (Exception e) {
@@ -364,7 +365,7 @@ public class WorkflowServiceImplAuthzTest {
       fail(e.getMessage());
     }
 
-    // Ensure the other instructor can not see the workflow, since there is no security policy granting access
+    // Ensure an instructor can not see the workflow, since there is no security policy granting access
     userResponder.setResponse(instructor2);
     try {
       service.getWorkflowById(workflow.getId());

--- a/modules/workflow-service-remote/src/main/java/org/opencastproject/workflow/remote/WorkflowServiceRemoteImpl.java
+++ b/modules/workflow-service-remote/src/main/java/org/opencastproject/workflow/remote/WorkflowServiceRemoteImpl.java
@@ -247,7 +247,7 @@ public class WorkflowServiceRemoteImpl extends RemoteBase implements WorkflowSer
    */
   @Override
   public WorkflowInstance start(WorkflowDefinition workflowDefinition, MediaPackage mediaPackage,
-          Map<String, String> properties) throws WorkflowDatabaseException {
+          Map<String, String> properties) throws WorkflowDatabaseException, UnauthorizedException {
     try {
       return start(workflowDefinition, mediaPackage, null, properties);
     } catch (NotFoundException e) {
@@ -282,7 +282,8 @@ public class WorkflowServiceRemoteImpl extends RemoteBase implements WorkflowSer
    */
   @Override
   public WorkflowInstance start(WorkflowDefinition workflowDefinition, MediaPackage mediaPackage,
-          Long parentWorkflowId, Map<String, String> properties) throws WorkflowDatabaseException, NotFoundException {
+          Long parentWorkflowId, Map<String, String> properties) throws WorkflowDatabaseException, NotFoundException,
+          UnauthorizedException {
     HttpPost post = new HttpPost("/start");
     try {
       List<BasicNameValuePair> params = new ArrayList<>();
@@ -300,16 +301,18 @@ public class WorkflowServiceRemoteImpl extends RemoteBase implements WorkflowSer
     } catch (Exception e) {
       throw new IllegalStateException("Unable to assemble a remote workflow request", e);
     }
-    HttpResponse response = getResponse(post, SC_NOT_FOUND, SC_OK);
+    HttpResponse response = getResponse(post, SC_NOT_FOUND, SC_OK, SC_UNAUTHORIZED);
     try {
       if (response != null) {
         if (SC_NOT_FOUND == response.getStatusLine().getStatusCode()) {
           throw new NotFoundException("Workflow instance " + parentWorkflowId + " does not exist.");
+        } else if (SC_UNAUTHORIZED == response.getStatusLine().getStatusCode()) {
+          throw new UnauthorizedException("You do not have permission to start this workflow");
         } else {
           return XmlWorkflowParser.parseWorkflowInstance(response.getEntity().getContent());
         }
       }
-    } catch (NotFoundException e) {
+    } catch (NotFoundException | UnauthorizedException e) {
       throw e;
     } catch (Exception e) {
       throw new WorkflowDatabaseException("Unable to build a workflow from xml", e);
@@ -327,7 +330,7 @@ public class WorkflowServiceRemoteImpl extends RemoteBase implements WorkflowSer
    */
   @Override
   public WorkflowInstance start(WorkflowDefinition workflowDefinition, MediaPackage mediaPackage)
-          throws WorkflowDatabaseException {
+          throws WorkflowDatabaseException, UnauthorizedException {
     try {
       return start(workflowDefinition, mediaPackage, null, null);
     } catch (NotFoundException e) {


### PR DESCRIPTION
## Summary

Partial progress on #5692 ("Harmonize permission checking"). Four independent, incrementally-reviewable pieces:

- **Centralize the global/org admin bypass check.** Several services independently reimplemented `hasRole(GLOBAL_ADMIN_ROLE) || hasRole(orgAdminRole)` before falling back to an ACL, role, or query-filter check. Added `SecurityUtil.isGlobalAdmin`/`isOrganizationAdmin`/`isAdmin` as the single shared implementation and migrated ~15 call sites onto it across playlists, scheduler, editor-service, Tobira, elasticsearch-index, admin-service/external-api statistics endpoints, capture-admin-service, userdirectory, search-service, and the AssetManager, preserving each site's existing behavior.
- **Enforce write permission when starting a workflow.** `WorkflowServiceImpl.start()` only checked that the current user was valid, with no ACL check at all — the "right to start workflow" gap named in the issue. It now requires admin or `WRITE` permission on the media package, matching the check already used for `stop()`.
- **Unify `AccessControlUtil.isAuthorized` and `AuthorizationService.hasPermission`.** These two implemented the same "does this ACL grant this action" decision with diverging semantics (admin bypass presence, deny-precedence order). `hasPermission` now matches `isAuthorized`'s semantics (first matching ACL entry wins, admin bypass included) and gained an episode-role-aware overload. Series and Search Service are migrated off `AccessControlUtil` onto `AuthorizationService`; `AccessControlUtil.isAuthorized` itself is left as-is but marked `@Deprecated`.
- **Share AssetManager's ACL-property encoding** between `AssetManagerImpl` and `AssetManagerStaticFileAuthorization`, which had ended up with independent copies of the same property-name encoding and role-type filter.

## Deliberately out of scope

- AssetManager's core permission check (the flattened per-`(role,action)` DB-property mechanism) — a performance-sensitive design choice flagged in the issue thread, not touched here.
- The elasticsearch-index query builders (`EventQueryBuilder`/`SeriesQueryBuilder`) — these build ACL-based query *filters* for Admin UI/External API listings, a structurally different mechanism from a per-call permission decision.


### How to test this patch

Run workflows with non-admin users?

### AI Usage

The code was generated with Claude Sonnet.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
