### PR TITLE
Include WhisperC++ output when it produces no subtitles

### DIFF
--- a/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/WhisperCppEngine.java
+++ b/modules/speech-to-text-impl/src/main/java/org/opencastproject/speechtotext/impl/engine/WhisperCppEngine.java
@@ -70,6 +70,12 @@ public class WhisperCppEngine implements SpeechToTextEngine {
   /** Name of the engine. */
   private static final String engineName = "WhisperC++";
 
+  /**
+   * Matches WhisperC++ output reporting that a result file could not be written, e.g.
+   * {@code output_vtt: failed to open '/path/to/file.vtt' for writing}. WhisperC++ still exits
+   * with status 0 in that case, so its output is the only indication that something went wrong.
+   */
+
   /** Config key for setting the path to WhisperC++. */
   private static final String WHISPERCPP_EXECUTABLE_PATH_CONFIG_KEY = "whispercpp.root.path";
 
@@ -533,11 +539,16 @@ public class WhisperCppEngine implements SpeechToTextEngine {
     File vtt;
 
     try {
-      execCommand(command);
+      List<String> output = execCommand(command);
 
       vtt = new File(workingDirectory, outputName + ".vtt");
       if (!vtt.isFile()) {
-        throw new SpeechToTextEngineException("WhisperC++ produced no output");
+        // WhisperC++ exits with status 0 even when it could not write its output files, reporting
+        // the reason on stdout only. Include that output, or this failure is indistinguishable
+        // from any other cause and the reason is left sitting in a debug log.
+        throw new SpeechToTextEngineException(
+            "WhisperC++ produced no output. Its output was:" + System.lineSeparator()
+                + String.join(System.lineSeparator(), output));
       }
       logger.info("Subtitles file generated successfully: {}", vtt);
     } catch (Exception e) {
@@ -569,7 +580,20 @@ public class WhisperCppEngine implements SpeechToTextEngine {
     return new Result(subtitleLanguage, vtt);
   }
 
-  private void execCommand(List<String> command) throws IOException, InterruptedException, SpeechToTextEngineException {
+  /**
+   * Run a command, returning everything it wrote to stdout and stderr.
+   *
+   * <p>The output is returned rather than only logged at debug so that a caller which detects a
+   * failure afterwards can put it in the exception. WhisperC++ reports an unwritable output file
+   * on stdout and still exits with status 0, so the reason a result is missing is only ever found
+   * there.
+   *
+   * @param command
+   *          the command to run
+   * @return the process output, one line per element
+   */
+  private List<String> execCommand(List<String> command)
+          throws IOException, InterruptedException, SpeechToTextEngineException {
     logger.info("Executing command: {}", command);
     Process process = null;
 
@@ -581,10 +605,12 @@ public class WhisperCppEngine implements SpeechToTextEngine {
           .redirectOutput(ProcessBuilder.Redirect.PIPE);
       process = processBuilder.start();
 
+      List<String> output = new ArrayList<>();
       try (BufferedReader in = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
         String line;
         while ((line = in.readLine()) != null) { // consume process output
           logger.debug(line);
+          output.add(line.trim());
         }
       }
 
@@ -600,6 +626,8 @@ public class WhisperCppEngine implements SpeechToTextEngine {
         throw new SpeechToTextEngineException(
             String.format("Process exited abnormally with status %d (command: %s) %s", exitCode, command, error));
       }
+
+      return output;
     } finally {
       IoSupport.closeQuietly(process);
     }


### PR DESCRIPTION
Relates to #5747 (does not close it — the underlying bug is upstream).

## The problem

WhisperC++ exits with status **0** even when it cannot write its output files, reporting the reason on stdout:

```
output_vtt:  failed to open '/srv/opencast/workspace/collection/subtitles/job-12146265/example.vtt' for writing
output_json: failed to open '/srv/opencast/workspace/collection/subtitles/job-12146265/example.json' for writing
```

Those two lines are from the reporter's log on #5747.

The missing file was **already detected** — `WhisperCppEngine` throws `"WhisperC++ produced no output"` when the vtt is absent. So this was never a silent failure, and an earlier revision of this PR described it as one; that was wrong. What actually went wrong is narrower: the exception named no cause, while the explanation was logged at `debug`, a level the operator was unlikely to have enabled. Everything needed to diagnose it was present and invisible.

## What this does

`execCommand` now returns the process output it already reads, and the existing missing-vtt guard includes it in the exception:

```
WhisperC++ produced no output. Its output was:
...
output_vtt: failed to open '/srv/.../example.vtt' for writing
```

An earlier revision matched those lines with a regex instead. @lkiesow pointed out the real fix belongs upstream, and he is right — parsing another project's output format goes stale silently on a whisper.cpp update and can only recognise causes that were anticipated. Passing the output through needs no knowledge of the format and covers causes nobody predicted.

Per @gregorydlogan's "do *both*": this is the Opencast-side half, since adopters run whatever whisper.cpp version their distro ships and cannot wait for an upstream fix. The upstream issue is the other half.

## How to test this patch

**There is no automated coverage for this, and I want to be explicit about that.** The earlier revision's tests exercised the regex by reflection; the regex is gone, so they were deleted with it. `modules/speech-to-text-impl` has a single test which is `@Ignore`d, so a green build here proves compilation, not behaviour.

To see it by hand, make the output directory unwritable so whisper.cpp cannot write its result, and run a transcription. Before this change the job fails with `WhisperC++ produced no output`; after it, the same exception carries the `output_vtt: failed to open ... for writing` line explaining why.

Reviewing the diff is probably faster: it is one file, `+31/-3`, and the behavioural change is confined to what goes into an exception message that was already being thrown.

## AI Usage

This change was prepared with the assistance of Claude Code (model Claude Opus 5, provider Anthropic). The tool was used to trace the engine's failure handling against the reporter's logs, correct the earlier overstated framing, write the change, and draft this description. A human reviewed the change and approved sending it.

## Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
