### PR TITLE
Remove unused config key from acl.default.create.properties

### DIFF
--- a/etc/listproviders/acl.default.create.properties
+++ b/etc/listproviders/acl.default.create.properties
@@ -29,10 +29,6 @@ list.name=ACL.DEFAULTS
 # Default: None
 #default_template=private
 
-# The prefix for user roles. Should be the same as in org.opencastproject.userdirectory.UserIdRoleProvider.cfg
-# Default: ROLE_USER_
-#role_user_prefix=ROLE_USER_
-
 # When switching to a new template, all roles that don't belong to the new template are removed
 # To keep roles between template switches, specify role prefixes below
 # Example: ROLE_AAI_USER_,ROLE_ADMIN


### PR DESCRIPTION
Closes #5358.

Removes the unused key `role_user_prefix` from the config. This was previously used for differentiating between user and non-user roles in the acl tab. Since this is handled by endpoints now, the config key is unused and can go.

### How to test this patch

Nothing to test really. If you want you can test the ACL tab in the admin ui for good measure.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
