### PR TITLE
Fix 500 error on GET /api/groups for API versions < 1.6.0

### DIFF
--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/GroupsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/GroupsEndpoint.java
@@ -238,7 +238,9 @@ public class GroupsEndpoint {
         }
         comparators.add(comparator);
       }
-      Collections.sort(results, ComparatorUtils.chainedComparator(comparators));
+      if (!comparators.isEmpty()) {
+        Collections.sort(results, ComparatorUtils.chainedComparator(comparators));
+      }
     }
 
     List<JsonObject> groupsJson = new ArrayList<>();


### PR DESCRIPTION
`GET /api/groups` returns a 500 error when the request's `Accept` header specifies an API version below v1.6.0 (e.g. `application/v1.5.0+json`), because the endpoint tries to sort with an empty comparator chain. This fixes it by only sorting when there's actually something to sort by.

### How to reproduce

Send `GET /api/groups` with header `Accept: application/v1.5.0+json` while at least one group exists. The server throws:

```
java.lang.UnsupportedOperationException: ComparatorChains must contain at least one Comparator
	at org.apache.commons.collections4.comparators.ComparatorChain.checkChainIntegrity
	at org.apache.commons.collections4.comparators.ComparatorChain.compare
	at java.util.TimSort.countRunAndMakeAscending
	...
	at org.opencastproject.external.endpoint.GroupsEndpoint.getGroups(GroupsEndpoint.java:242)
```

**Root cause:** for API versions below v1.6.0, `GroupsEndpoint.getGroups` sorts groups by `members`/`roles` in application code (the database can't do it for those fields). It unconditionally calls `Collections.sort(results, ComparatorUtils.chainedComparator(comparators))`, even when `comparators` is empty — i.e. no `sort` query param was given, or it didn't reference `members`/`roles`. `ComparatorUtils.chainedComparator` on an empty list builds an Apache Commons `ComparatorChain` with zero comparators, which throws `UnsupportedOperationException` as soon as `Collections.sort` tries to compare two elements. This affects any old-version request that returns two or more groups, not just ones that pass `sort=members` or `sort=roles`.

**Fix:** only call `Collections.sort` when there's at least one comparator to apply, matching the existing guarded pattern already used for the same `ComparatorChain` idiom in `WorkflowDefinitionsEndpoint` and `ServicesEndpoint`.

### How to test this patch

1. Start Opencast with at least one group configured (the default groups are enough).
2. Send `GET /api/groups` with header `Accept: application/v1.5.0+json` (or any version < 1.6.0).
3. Before this patch: request fails with a 500 error and the stack trace above in the log.
4. After this patch: request succeeds and returns the groups as JSON, both with and without a `sort` query parameter.

### AI Usage
This fix was investigated and implemented with the assistance of an AI coding agent (Claude Code), including tracing the crash to its root cause in `GroupsEndpoint.java` and applying a minimal guard consistent with existing patterns elsewhere in the codebase. The change and PR description were reviewed before submission.

### Your pull request should…

* [x] have a concise title
* [ ] close an accompanying issue if one exists (no existing issue was filed for this)
* [x] be against the correct branch
* [x] include migration scripts and documentation, if appropriate (none needed — bugfix only)
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] have proper commit messages (title and body) for all commits
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch (not applicable — targeting develop)
* [ ] include a release note if a feature, or supports a feature (bugfix, not a feature)
