### PR TITLE
Reject series/event creation with missing required metadata

### DIFF
--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
@@ -1089,6 +1089,9 @@ public class SeriesEndpoint {
       JsonObject json = new JsonObject();
       json.addProperty("identifier", safeString(seriesId));
       return ApiResponseBuilder.Json.created(acceptHeader, URI.create(getSeriesUrl(seriesId)), json);
+    } catch (IllegalArgumentException e) {
+      logger.debug("Unable to create series with metadata '{}'", metadataParam, e);
+      return R.badRequest(e.getMessage());
     } catch (IndexServiceException e) {
       logger.error("Unable to create series with metadata '{}', acl '{}', theme '{}'",
               metadataParam, aclParam, themeIdParam, e);

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/DublinCoreMetadataUtil.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/DublinCoreMetadataUtil.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Dictionary;
@@ -70,6 +71,13 @@ public final class DublinCoreMetadataUtil {
    */
   public static void updateDublincoreCatalog(DublinCoreCatalog dc, DublinCoreMetadataCollection metadata) {
     for (MetadataField field : metadata.getOutputFields().values()) {
+      // Check this regardless of whether the field was actually touched by the caller: an untouched required
+      // field can still be blank, e.g. because it uses its default value or was never submitted at all.
+      if (field.isRequired() && isBlankValue(field.getValue())) {
+        throw new IllegalArgumentException(String.format(
+                "The event metadata field with id '%s' and the metadata type '%s' is required and can not be empty!.",
+                field.getInputID(), field.getType()));
+      }
       if (field.isUpdated() && field.getValue() != null) {
         final String namespace = field.getNamespace() == null ? DublinCore.TERMS_NS_URI : field.getNamespace();
         final EName ename = new EName(namespace, field.getInputID());
@@ -87,19 +95,28 @@ public final class DublinCoreMetadataUtil {
         } else if (field.getType() == MetadataField.Type.MIXED_TEXT || field.getType() == Type.ITERABLE_TEXT) {
           setIterableString(dc, field, ename);
         } else {
-          if (field.isRequired() && StringUtils.isBlank(field.getValue().toString())) {
-            throw new IllegalArgumentException(String.format(
-                "The event metadata field with id '%s' and the metadata type '%s' is required and can not be empty!.",
-                field.getInputID(), field.getType()));
-          }
           dc.set(ename, field.getValue().toString());
         }
-      } else if (field.getValue() == null && field.isRequired()) {
-        throw new IllegalArgumentException(String.format(
-                "The event metadata field with id '%s' and the metadata type '%s' is required and can not be empty!.",
-                field.getInputID(), field.getType()));
       }
     }
+  }
+
+  /**
+   * @param value
+   *          The value of a {@link MetadataField}.
+   * @return True if the value is missing, i.e. null, a blank string or an empty collection of values.
+   */
+  private static boolean isBlankValue(final Object value) {
+    if (value == null) {
+      return true;
+    }
+    if (value instanceof String) {
+      return StringUtils.isBlank((String) value);
+    }
+    if (value instanceof Collection) {
+      return ((Collection<?>) value).isEmpty();
+    }
+    return false;
   }
 
   /**

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -870,6 +870,12 @@ public class IndexServiceImpl implements IndexService {
 
     DublinCoreMetadataCollection eventMetadata = eventHttpServletRequest.getMetadataList().get()
             .getMetadataByAdapter(getCommonEventCatalogUIAdapter());
+    if (eventMetadata == null) {
+      // No common event metadata catalog was submitted at all, e.g. an empty metadata list.
+      // Fall back to the raw (empty) fields so that missing required fields (e.g. title) are rejected below
+      // instead of silently creating an event without them.
+      eventMetadata = getCommonEventCatalogUIAdapter().getRawFields();
+    }
 
     Date currentStartDate = null;
     JSONObject sourceMetadata = (JSONObject) eventHttpServletRequest.getSource().get().get("metadata");
@@ -1846,9 +1852,13 @@ public class IndexServiceImpl implements IndexService {
 
     DublinCoreMetadataCollection seriesMetadata = metadataList.getMetadataByFlavor(
         MediaPackageElements.SERIES.toString());
-    if (seriesMetadata != null) {
-      DublinCoreMetadataUtil.updateDublincoreCatalog(dc, seriesMetadata);
+    if (seriesMetadata == null) {
+      // No series metadata catalog was submitted at all, e.g. an empty metadata list.
+      // Validate against the raw (empty) fields anyway so that missing required fields (e.g. title) are rejected
+      // instead of silently creating a series without them.
+      seriesMetadata = getCommonSeriesCatalogUIAdapter().getRawFields();
     }
+    DublinCoreMetadataUtil.updateDublincoreCatalog(dc, seriesMetadata);
 
     AccessControlList acl;
     if (optAcl.isPresent()) {

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/impl/IndexServiceImplTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/impl/IndexServiceImplTest.java
@@ -36,6 +36,7 @@ import org.opencastproject.elasticsearch.index.ElasticsearchIndex;
 import org.opencastproject.elasticsearch.index.objects.event.Event;
 import org.opencastproject.elasticsearch.index.objects.event.EventSearchQuery;
 import org.opencastproject.index.service.catalog.adapter.events.CommonEventCatalogUIAdapter;
+import org.opencastproject.index.service.catalog.adapter.series.CommonSeriesCatalogUIAdapter;
 import org.opencastproject.index.service.exception.IndexServiceException;
 import org.opencastproject.ingest.api.IngestException;
 import org.opencastproject.ingest.api.IngestService;
@@ -233,6 +234,64 @@ public class IndexServiceImplTest {
     commonEventCatalogUIAdapter.updated(PropertiesUtil.toDictionary(episodeCatalogProperties));
     commonEventCatalogUIAdapter.setWorkspace(workspace);
     return Tuple.tuple(commonEventCatalogUIAdapter, metadataCell);
+  }
+
+  private CommonSeriesCatalogUIAdapter setupCommonSeriesCatalogUIAdapter()
+          throws org.osgi.service.cm.ConfigurationException {
+    CommonSeriesCatalogUIAdapter commonSeriesCatalogUIAdapter = new CommonSeriesCatalogUIAdapter();
+
+    Properties seriesCatalogProperties = new Properties();
+    InputStream in = null;
+    try {
+      in = getClass().getResourceAsStream("/series-catalog.properties");
+      seriesCatalogProperties.load(in);
+    } catch (IOException e) {
+      throw new ComponentException(e);
+    } finally {
+      IoSupport.closeQuietly(in);
+    }
+
+    commonSeriesCatalogUIAdapter.updated(PropertiesUtil.toDictionary(seriesCatalogProperties));
+    return commonSeriesCatalogUIAdapter;
+  }
+
+  /**
+   *
+   *
+   * Test Create Series
+   *
+   *
+   */
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCreateSeriesWithoutMetadataExpectsIllegalArgumentException() throws Exception {
+    IndexServiceImpl indexServiceImpl = new IndexServiceImpl();
+    indexServiceImpl.setSecurityService(setupSecurityService("akm220", "mh_default_org"));
+    indexServiceImpl.addCatalogUIAdapter(setupCommonSeriesCatalogUIAdapter());
+
+    // No metadata for the required title field was submitted at all (e.g. the "dublincore/series" catalog was
+    // omitted from the request), so this must be rejected instead of silently creating a series without a title.
+    indexServiceImpl.createSeries(new MetadataList(), new LinkedHashMap<>(), Optional.empty(), Optional.empty());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCreateSeriesWithBlankTitleExpectsIllegalArgumentException() throws Exception {
+    IndexServiceImpl indexServiceImpl = new IndexServiceImpl();
+    indexServiceImpl.setSecurityService(setupSecurityService("akm220", "mh_default_org"));
+    CommonSeriesCatalogUIAdapter commonSeriesCatalogUIAdapter = setupCommonSeriesCatalogUIAdapter();
+    indexServiceImpl.addCatalogUIAdapter(commonSeriesCatalogUIAdapter);
+
+    DublinCoreMetadataCollection seriesMetadata = commonSeriesCatalogUIAdapter.getRawFields();
+    MetadataField title = seriesMetadata.getOutputFields().get("title");
+    seriesMetadata.removeField(title);
+    MetadataField newTitle = new MetadataField(title);
+    newTitle.setValue("");
+    seriesMetadata.addField(newTitle);
+
+    MetadataList metadataList = new MetadataList();
+    metadataList.add(commonSeriesCatalogUIAdapter, seriesMetadata);
+
+    indexServiceImpl.createSeries(metadataList, new LinkedHashMap<>(), Optional.empty(), Optional.empty());
   }
 
   /**


### PR DESCRIPTION
Fixes #6032.

The External API silently created series and events without a title when the request omitted the metadata catalog entirely (e.g. an empty metadata array), because the required-field check in DublinCoreMetadataUtil only fired for fields that were explicitly touched and blank, or exactly null -- not for untouched fields whose default value is an empty string. 

### How to test this patch

Try to create an event or series through the API without a title.

### AI Usage

Vibe-coded with Claude, reviewed by human.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
