### PR TITLE
Centralize global/org admin bypass check for permission checking

### DIFF
--- a/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/StatisticsEndpoint.java
+++ b/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/StatisticsEndpoint.java
@@ -21,7 +21,6 @@
 
 package org.opencastproject.adminui.endpoint;
 
-import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
 import static org.opencastproject.util.data.functions.Misc.chuck;
 import static org.opencastproject.util.doc.rest.RestParameter.Type.STRING;
 
@@ -36,6 +35,7 @@ import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.security.api.User;
+import org.opencastproject.security.util.SecurityUtil;
 import org.opencastproject.statistics.api.DataResolution;
 import org.opencastproject.statistics.api.ResourceType;
 import org.opencastproject.statistics.api.StatisticsProvider;
@@ -360,13 +360,12 @@ public class StatisticsEndpoint {
   private void checkOrganizationAccess(final String orgId) throws UnauthorizedException {
     final User currentUser = securityService.getUser();
     final Organization currentOrg = securityService.getOrganization();
-    final String currentOrgAdminRole = currentOrg.getAdminRole();
     final String currentOrgId = currentOrg.getId();
 
     final boolean userIsInOrg = currentOrgId.equals(orgId);
 
-    boolean userIsAdmin = currentUser.hasRole(GLOBAL_ADMIN_ROLE)
-        || (currentUser.hasRole(currentOrgAdminRole) && userIsInOrg);
+    boolean userIsAdmin = SecurityUtil.isGlobalAdmin(currentUser)
+        || (userIsInOrg && SecurityUtil.isOrganizationAdmin(currentUser, currentOrg));
 
     boolean userIsAuthorized = currentUser.hasRole(STATISTICS_ORGANIZATION_UI_ROLE) && userIsInOrg;
 

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
@@ -25,7 +25,6 @@ import static org.opencastproject.mediapackage.MediaPackageSupport.Filters.hasNo
 import static org.opencastproject.mediapackage.MediaPackageSupport.Filters.isNotPublication;
 import static org.opencastproject.mediapackage.MediaPackageSupport.getFileName;
 import static org.opencastproject.metadata.dublincore.CatalogUIAdapter.ORGANIZATION_WILDCARD;
-import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
 import static org.opencastproject.security.api.SecurityConstants.GLOBAL_CAPTURE_AGENT_ROLE;
 import static org.opencastproject.security.util.SecurityUtil.getEpisodeRoleId;
 import static org.opencastproject.util.data.functions.Misc.chuck;
@@ -1223,9 +1222,9 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
 
   private AdminRole isAdmin() {
     final User user = securityService.getUser();
-    if (user.hasRole(GLOBAL_ADMIN_ROLE)) {
+    if (SecurityUtil.isGlobalAdmin(user)) {
       return AdminRole.GLOBAL;
-    } else if (user.hasRole(securityService.getOrganization().getAdminRole())
+    } else if (SecurityUtil.isOrganizationAdmin(user, securityService.getOrganization())
             || user.hasRole(GLOBAL_CAPTURE_AGENT_ROLE)) {
       // In this context, we treat capture agents the same way as organization admins, allowing them access so that
       // they can ingest new media without requiring them to be explicitly specified in the ACLs.

--- a/modules/asset-manager-static-file-authorization/src/main/java/org/opencastproject/assetmanager/auth/AssetManagerStaticFileAuthorization.java
+++ b/modules/asset-manager-static-file-authorization/src/main/java/org/opencastproject/assetmanager/auth/AssetManagerStaticFileAuthorization.java
@@ -21,12 +21,11 @@
 
 package org.opencastproject.assetmanager.auth;
 
-import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
-
 import org.opencastproject.security.api.Role;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.StaticFileAuthorization;
 import org.opencastproject.security.api.User;
+import org.opencastproject.security.util.SecurityUtil;
 
 import org.apache.commons.lang3.BooleanUtils;
 import org.osgi.service.component.ComponentContext;
@@ -108,7 +107,7 @@ public class AssetManagerStaticFileAuthorization implements StaticFileAuthorizat
   public boolean verifyUrlAccess(final String path) {
     // Always allow access for admin
     final User user = securityService.getUser();
-    if (user.hasRole(GLOBAL_ADMIN_ROLE)) {
+    if (SecurityUtil.isGlobalAdmin(user)) {
       logger.debug("Allow access for admin `{}`", user);
       return true;
     }

--- a/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/impl/CaptureAgentStateServiceImpl.java
+++ b/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/impl/CaptureAgentStateServiceImpl.java
@@ -34,9 +34,9 @@ import org.opencastproject.db.DBSession;
 import org.opencastproject.db.DBSessionFactory;
 import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.Role;
-import org.opencastproject.security.api.SecurityConstants;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.User;
+import org.opencastproject.security.util.SecurityUtil;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.data.Tuple3;
 import org.opencastproject.util.function.ThrowingFunction;
@@ -390,7 +390,6 @@ public class CaptureAgentStateServiceImpl implements CaptureAgentStateService, M
     User user = securityService.getUser();
     Organization org = securityService.getOrganization();
 
-    String orgAdmin = org.getAdminRole();
     Set<Role> roles = user.getRoles();
 
     List<AgentImpl> agents = db.exec(namedQuery.findAll(
@@ -400,7 +399,7 @@ public class CaptureAgentStateServiceImpl implements CaptureAgentStateService, M
     ));
 
     // Filter the results in memory if this user is not an administrator
-    if (!user.hasRole(SecurityConstants.GLOBAL_ADMIN_ROLE) && !user.hasRole(orgAdmin)) {
+    if (!SecurityUtil.isAdmin(user, org)) {
       for (Iterator<AgentImpl> iter = agents.iterator(); iter.hasNext();) {
         AgentImpl agent = iter.next();
         Set<String> schedulerRoles = agent.getSchedulerRoles();

--- a/modules/common/src/main/java/org/opencastproject/security/util/SecurityUtil.java
+++ b/modules/common/src/main/java/org/opencastproject/security/util/SecurityUtil.java
@@ -171,6 +171,27 @@ public final class SecurityUtil {
   }
 
   /**
+   * Check if the given user has the global admin role.
+   */
+  public static boolean isGlobalAdmin(final User user) {
+    return user.hasRole(SecurityConstants.GLOBAL_ADMIN_ROLE);
+  }
+
+  /**
+   * Check if the given user has the admin role of the given organization.
+   */
+  public static boolean isOrganizationAdmin(final User user, final Organization organization) {
+    return user.hasRole(organization.getAdminRole());
+  }
+
+  /**
+   * Check if the given user is a global admin, or an admin of the given organization.
+   */
+  public static boolean isAdmin(final User user, final Organization organization) {
+    return isGlobalAdmin(user) || isOrganizationAdmin(user, organization);
+  }
+
+  /**
    * Check if the current user has access to the capture agent with the given id.
    * @param agentId
    *           The agent id to check.
@@ -183,7 +204,7 @@ public final class SecurityUtil {
       return;
     }
     final User user = securityService.getUser();
-    if (user.hasRole(SecurityConstants.GLOBAL_ADMIN_ROLE) || user.hasRole(user.getOrganization().getAdminRole())) {
+    if (isAdmin(user, user.getOrganization())) {
       return;
     }
     if (!user.hasRole(SecurityUtil.getCaptureAgentRole(agentId))) {

--- a/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
+++ b/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
@@ -60,13 +60,13 @@ import org.opencastproject.metadata.dublincore.MetadataJson;
 import org.opencastproject.metadata.dublincore.MetadataList;
 import org.opencastproject.security.api.AuthorizationService;
 import org.opencastproject.security.api.Organization;
-import org.opencastproject.security.api.SecurityConstants;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.security.api.User;
 import org.opencastproject.security.urlsigning.exception.UrlSigningException;
 import org.opencastproject.security.urlsigning.service.UrlSigningService;
 import org.opencastproject.security.urlsigning.utils.UrlSigningServiceOsgiUtil;
+import org.opencastproject.security.util.SecurityUtil;
 import org.opencastproject.smil.api.SmilException;
 import org.opencastproject.smil.api.SmilResponse;
 import org.opencastproject.smil.api.SmilService;
@@ -1079,15 +1079,13 @@ public class EditorServiceImpl implements EditorService {
   private boolean isAdmin() {
     final User currentUser = securityService.getUser();
 
-    // Global admin
-    if (currentUser.hasRole(SecurityConstants.GLOBAL_ADMIN_ROLE)) {
+    if (SecurityUtil.isGlobalAdmin(currentUser)) {
       return true;
     }
 
-    // Organization admin
     final Organization currentOrg = securityService.getOrganization();
     return currentUser.getOrganization().getId().equals(currentOrg.getId())
-            && currentUser.hasRole(currentOrg.getAdminRole());
+            && SecurityUtil.isOrganizationAdmin(currentUser, currentOrg);
   }
 
   private MediaPackage getMediaPackage(Event event) throws EditorServiceException {

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/event/EventQueryBuilder.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/event/EventQueryBuilder.java
@@ -22,13 +22,13 @@
 package org.opencastproject.elasticsearch.index.objects.event;
 
 import static org.opencastproject.elasticsearch.impl.IndexSchema.SEARCH_FIELD_NAME_EXTENSION;
-import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
 
 import org.opencastproject.elasticsearch.api.SearchTerms;
 import org.opencastproject.elasticsearch.api.SearchTerms.Quantifier;
 import org.opencastproject.elasticsearch.impl.AbstractElasticsearchQueryBuilder;
 import org.opencastproject.security.api.Role;
 import org.opencastproject.security.api.User;
+import org.opencastproject.security.util.SecurityUtil;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,7 +81,7 @@ public class EventQueryBuilder extends AbstractElasticsearchQueryBuilder<EventSe
     // Action
     if (query.getActions() != null && query.getActions().length > 0) {
       User user = query.getUser();
-      if (!user.hasRole(GLOBAL_ADMIN_ROLE) && !user.hasRole(user.getOrganization().getAdminRole())) {
+      if (!SecurityUtil.isAdmin(user, user.getOrganization())) {
         for (Role role : user.getRoles()) {
           for (String action : query.getActions()) {
             and(EventIndexSchema.ACL_PERMISSION_PREFIX.concat(action), role.getName());

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/series/SeriesQueryBuilder.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/series/SeriesQueryBuilder.java
@@ -22,13 +22,13 @@
 package org.opencastproject.elasticsearch.index.objects.series;
 
 import static org.opencastproject.elasticsearch.impl.IndexSchema.SEARCH_FIELD_NAME_EXTENSION;
-import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
 
 import org.opencastproject.elasticsearch.api.SearchTerms;
 import org.opencastproject.elasticsearch.api.SearchTerms.Quantifier;
 import org.opencastproject.elasticsearch.impl.AbstractElasticsearchQueryBuilder;
 import org.opencastproject.security.api.Role;
 import org.opencastproject.security.api.User;
+import org.opencastproject.security.util.SecurityUtil;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,7 +76,7 @@ public class SeriesQueryBuilder extends AbstractElasticsearchQueryBuilder<Series
     // Action
     if (query.getActions() != null && query.getActions().length > 0) {
       User user = query.getUser();
-      if (!user.hasRole(GLOBAL_ADMIN_ROLE) && !user.hasRole(user.getOrganization().getAdminRole())) {
+      if (!SecurityUtil.isAdmin(user, user.getOrganization())) {
         for (Role role : user.getRoles()) {
           for (String action : query.getActions()) {
             and(SeriesIndexSchema.ACL_PERMISSION_PREFIX.concat(action), role.getName());

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/StatisticsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/StatisticsEndpoint.java
@@ -21,7 +21,6 @@
 
 package org.opencastproject.external.endpoint;
 
-import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
 import static org.opencastproject.util.data.functions.Misc.chuck;
 
 import org.opencastproject.elasticsearch.api.SearchIndexException;
@@ -38,6 +37,7 @@ import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.security.api.User;
+import org.opencastproject.security.util.SecurityUtil;
 import org.opencastproject.statistics.api.ResourceType;
 import org.opencastproject.statistics.api.StatisticsProvider;
 import org.opencastproject.statistics.api.StatisticsService;
@@ -401,11 +401,10 @@ public class StatisticsEndpoint {
   private void checkOrganizationAccess(final String orgId) throws UnauthorizedException {
     final User currentUser = securityService.getUser();
     final Organization currentOrg = securityService.getOrganization();
-    final String currentOrgAdminRole = currentOrg.getAdminRole();
     final String currentOrgId = currentOrg.getId();
 
-    boolean authorized = currentUser.hasRole(GLOBAL_ADMIN_ROLE)
-            || (currentUser.hasRole(currentOrgAdminRole) && currentOrgId.equals(orgId));
+    boolean authorized = SecurityUtil.isGlobalAdmin(currentUser)
+            || (currentOrgId.equals(orgId) && SecurityUtil.isOrganizationAdmin(currentUser, currentOrg));
 
     if (!authorized) {
       throw new UnauthorizedException(currentUser, "read");

--- a/modules/playlists/src/main/java/org/opencastproject/playlists/PlaylistService.java
+++ b/modules/playlists/src/main/java/org/opencastproject/playlists/PlaylistService.java
@@ -20,8 +20,6 @@
  */
 package org.opencastproject.playlists;
 
-import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
-
 import org.opencastproject.elasticsearch.api.SearchIndexException;
 import org.opencastproject.elasticsearch.api.SearchResult;
 import org.opencastproject.elasticsearch.index.ElasticsearchIndex;
@@ -39,6 +37,7 @@ import org.opencastproject.security.api.Permissions;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.security.api.User;
+import org.opencastproject.security.util.SecurityUtil;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.requests.SortCriterion;
 
@@ -170,8 +169,7 @@ public class PlaylistService {
   public List<Playlist> getAllForAdministrativeRead(Date from, Date to, int limit)
           throws IllegalStateException, UnauthorizedException {
     final var user = securityService.getUser();
-    final var orgAdminRole = securityService.getOrganization().getAdminRole();
-    if (!user.hasRole(GLOBAL_ADMIN_ROLE) && !user.hasRole(orgAdminRole)) {
+    if (!SecurityUtil.isAdmin(user, securityService.getOrganization())) {
       throw new UnauthorizedException("Only (org-)admins can call this method");
     }
 
@@ -456,11 +454,10 @@ public class PlaylistService {
   private boolean checkPermission(Playlist playlist, Permissions.Action action) {
     User currentUser = securityService.getUser();
     Organization currentOrg = securityService.getOrganization();
-    String currentOrgAdminRole = currentOrg.getAdminRole();
-    String currentOrgId = currentOrg.getId();
 
-    return currentUser.hasRole(GLOBAL_ADMIN_ROLE)
-        || (currentUser.hasRole(currentOrgAdminRole) && currentOrgId.equals(playlist.getOrganization()))
+    return SecurityUtil.isGlobalAdmin(currentUser)
+        || (currentOrg.getId().equals(playlist.getOrganization())
+            && SecurityUtil.isOrganizationAdmin(currentUser, currentOrg))
         || authorizationService.hasPermission(getAccessControlList(playlist), action.toString());
   }
 

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -22,7 +22,6 @@ package org.opencastproject.scheduler.impl;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.opencastproject.scheduler.impl.SchedulerUtil.calculateChecksum;
-import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
 import static org.opencastproject.util.EqualsUtil.ne;
 import static org.opencastproject.util.RequireUtil.notEmpty;
 import static org.opencastproject.util.RequireUtil.notNull;
@@ -817,8 +816,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
   }
 
   private boolean isAdmin() {
-    return (securityService.getUser().hasRole(GLOBAL_ADMIN_ROLE)
-            || securityService.getUser().hasRole(securityService.getOrganization().getAdminRole()));
+    return SecurityUtil.isAdmin(securityService.getUser(), securityService.getOrganization());
   }
 
   private Optional<DublinCoreCatalog> loadEpisodeDublinCoreFromAsset(Snapshot snapshot) {

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
@@ -40,12 +40,12 @@ import org.opencastproject.search.api.SearchService;
 import org.opencastproject.search.impl.SearchServiceImpl;
 import org.opencastproject.search.impl.SearchServiceIndex;
 import org.opencastproject.security.api.Role;
-import org.opencastproject.security.api.SecurityConstants;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.security.urlsigning.exception.UrlSigningException;
 import org.opencastproject.security.urlsigning.service.UrlSigningService;
 import org.opencastproject.security.urlsigning.utils.UrlSigningServiceOsgiUtil;
+import org.opencastproject.security.util.SecurityUtil;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.doc.rest.RestParameter;
@@ -201,8 +201,7 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
         .filter(QueryBuilders.termQuery(SearchResult.TYPE, type))
         .filter(QueryBuilders.boolQuery().mustNot(QueryBuilders.existsQuery(SearchResult.DELETED_DATE)));
     final var user = securityService.getUser();
-    final var orgAdminRole = securityService.getOrganization().getAdminRole();
-    if (!user.hasRole(SecurityConstants.GLOBAL_ADMIN_ROLE) && !user.hasRole(orgAdminRole)) {
+    if (!SecurityUtil.isAdmin(user, securityService.getOrganization())) {
       query.filter(QueryBuilders.termsQuery(
           SearchResult.INDEX_ACL + ".read",
           user.getRoles().stream().map(Role::getName).collect(Collectors.toList())
@@ -394,8 +393,7 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
     }
 
     var user = securityService.getUser();
-    var orgAdminRole = securityService.getOrganization().getAdminRole();
-    var admin = user.hasRole(SecurityConstants.GLOBAL_ADMIN_ROLE) || user.hasRole(orgAdminRole);
+    var admin = SecurityUtil.isAdmin(user, securityService.getOrganization());
     var query = QueryBuilders.boolQuery()
         .filter(QueryBuilders.termQuery(SearchResult.ORG, org))
         .filter(QueryBuilders.termQuery(SearchResult.TYPE, type))

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceImpl.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceImpl.java
@@ -21,7 +21,6 @@
 
 package org.opencastproject.search.impl;
 
-import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
 import static org.opencastproject.util.data.functions.Misc.chuck;
 
 import org.opencastproject.job.api.AbstractJobProducer;
@@ -404,7 +403,7 @@ public final class SearchServiceImpl extends AbstractJobProducer implements Sear
   public boolean verifyUrlAccess(final String path) {
     // Always allow access for admin
     final User user = securityService.getUser();
-    if (user.hasRole(GLOBAL_ADMIN_ROLE)) {
+    if (SecurityUtil.isGlobalAdmin(user)) {
       logger.debug("Allow access for admin `{}`", user);
       return true;
     }

--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Harvest.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Harvest.java
@@ -26,9 +26,9 @@ import org.opencastproject.search.api.SearchResult;
 import org.opencastproject.search.api.SearchResultList;
 import org.opencastproject.search.api.SearchService;
 import org.opencastproject.security.api.AuthorizationService;
-import org.opencastproject.security.api.SecurityConstants;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
+import org.opencastproject.security.util.SecurityUtil;
 import org.opencastproject.series.api.SeriesException;
 import org.opencastproject.series.api.SeriesService;
 import org.opencastproject.util.Jsons;
@@ -87,8 +87,7 @@ final class Harvest {
     final var org = securityService.getOrganization().getId();
 
     var user = securityService.getUser();
-    var orgAdminRole = securityService.getOrganization().getAdminRole();
-    var isAdmin = user.hasRole(SecurityConstants.GLOBAL_ADMIN_ROLE) || user.hasRole(orgAdminRole);
+    var isAdmin = SecurityUtil.isAdmin(user, securityService.getOrganization());
     if (!isAdmin) {
       throw new UnauthorizedException(user, "Only (org-) admins can access the Tobira harvest API");
     }

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/utils/UserDirectoryUtils.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/utils/UserDirectoryUtils.java
@@ -26,6 +26,7 @@ import org.opencastproject.security.api.Role;
 import org.opencastproject.security.api.SecurityConstants;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.User;
+import org.opencastproject.security.util.SecurityUtil;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -58,12 +59,11 @@ public final class UserDirectoryUtils {
 
     for (Role role : roles) {
       if (StringUtils.equals(SecurityConstants.GLOBAL_ADMIN_ROLE, role.getName())) {
-        return user.hasRole(SecurityConstants.GLOBAL_ADMIN_ROLE);
+        return SecurityUtil.isGlobalAdmin(user);
       }
 
       if (org != null && StringUtils.equals(org.getAdminRole(), role.getName())) {
-        return user.hasRole(SecurityConstants.GLOBAL_ADMIN_ROLE)
-                || user.hasRole(org.getAdminRole());
+        return SecurityUtil.isAdmin(user, org);
       }
     }
     return true;

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowDefinitionScanner.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowDefinitionScanner.java
@@ -21,13 +21,13 @@
 
 package org.opencastproject.workflow.impl;
 
-import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
 import static org.opencastproject.util.ReadinessIndicator.ARTIFACT;
 
 import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.OrganizationDirectoryListener;
 import org.opencastproject.security.api.OrganizationDirectoryService;
 import org.opencastproject.security.api.User;
+import org.opencastproject.security.util.SecurityUtil;
 import org.opencastproject.util.ReadinessIndicator;
 import org.opencastproject.workflow.api.WorkflowDefinition;
 import org.opencastproject.workflow.api.WorkflowIdentifier;
@@ -259,7 +259,7 @@ public class WorkflowDefinitionScanner implements ArtifactInstaller, Organizatio
   }
 
   private boolean userCanAccessWorkflowDefinition(final User user, final WorkflowDefinition wd) {
-    return wd.getRoles().isEmpty() || user.hasRole(GLOBAL_ADMIN_ROLE) || wd.getRoles().stream()
+    return wd.getRoles().isEmpty() || SecurityUtil.isGlobalAdmin(user) || wd.getRoles().stream()
             .anyMatch(user::hasRole);
   }
 


### PR DESCRIPTION
*The main commit in this PR is part of #7873. Putting this up as a separate pull request, because it is less controversial and so Lars can be happy.*

Several services independently reimplemented the same "is this user a global or organization admin" check before falling back to an ACL, role, or query-filter check, as noted in #5692. Add SecurityUtil.isGlobalAdmin/isOrganizationAdmin/isAdmin as the single shared implementation and migrate the call sites onto it, preserving each site's existing behavior:

- PlaylistService, SchedulerServiceImpl, EditorServiceImpl
- Tobira's Harvest
- the elasticsearch-index event/series query builders
- both StatisticsEndpoints (admin-service, external-api)
- CaptureAgentStateServiceImpl, UserDirectoryUtils
- SearchRestService's two ACL-filter bypass checks
- AssetManagerImpl.isAdmin() (kept its AdminRole enum return type, delegated its two boolean checks)

Also swap the remaining global-admin-only checks (no org-admin branch to harmonize, but same underlying primitive) in
AssetManagerStaticFileAuthorization, SearchServiceImpl, and WorkflowDefinitionScanner onto SecurityUtil.isGlobalAdmin for consistency.

### How to test this patch


### AI Usage

Generated by CLaude, reviewed by human.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
