### PR TITLE
Add debug ports to multinode config

### DIFF
--- a/.github/multi-node-test-setup
+++ b/.github/multi-node-test-setup
@@ -26,10 +26,11 @@ sed -i 's_port=8080_port=8082_' opencast-dist-worker/etc/org.ops4j.pax.web.cfg
 
 sed -i 's!# export KARAF_DEBUG.*!export KARAF_DEBUG=1!' opencast-dist-admin/bin/setenv
 sed -i 's!# export JAVA_DEBUG_PORT.*!export JAVA_DEBUG_PORT=5005!' opencast-dist-admin/bin/setenv
-sed -i 's!# export KARAF_DEBUG.*!export KARAF_DEBUG=1!' opencast-dist-worker/bin/setenv
-sed -i 's!# export JAVA_DEBUG_PORT.*!export JAVA_DEBUG_PORT=5006!' opencast-dist-worker/bin/setenv
+#Note: Presentation has the lower debug port because it also has the lower http port (8081)!
 sed -i 's!# export KARAF_DEBUG.*!export KARAF_DEBUG=1!' opencast-dist-presentation/bin/setenv
-sed -i 's!# export JAVA_DEBUG_PORT.*!export JAVA_DEBUG_PORT=5007!' opencast-dist-presentation/bin/setenv
+sed -i 's!# export JAVA_DEBUG_PORT.*!export JAVA_DEBUG_PORT=5006!' opencast-dist-presentation/bin/setenv
+sed -i 's!# export KARAF_DEBUG.*!export KARAF_DEBUG=1!' opencast-dist-worker/bin/setenv
+sed -i 's!# export JAVA_DEBUG_PORT.*!export JAVA_DEBUG_PORT=5007!' opencast-dist-worker/bin/setenv
 
 for node in admin presentation worker; do
   # configure database

--- a/.github/multi-node-test-setup
+++ b/.github/multi-node-test-setup
@@ -24,6 +24,13 @@ sed -i 's_localhost:8080_localhost:8082_' opencast-dist-worker/etc/custom.proper
 sed -i 's_port=8080_port=8081_' opencast-dist-presentation/etc/org.ops4j.pax.web.cfg
 sed -i 's_port=8080_port=8082_' opencast-dist-worker/etc/org.ops4j.pax.web.cfg
 
+sed -i 's!# export KARAF_DEBUG.*!export KARAF_DEBUG=1!' opencast-dist-admin/bin/setenv
+sed -i 's!# export JAVA_DEBUG_PORT.*!export JAVA_DEBUG_PORT=5005!' opencast-dist-admin/bin/setenv
+sed -i 's!# export KARAF_DEBUG.*!export KARAF_DEBUG=1!' opencast-dist-worker/bin/setenv
+sed -i 's!# export JAVA_DEBUG_PORT.*!export JAVA_DEBUG_PORT=5006!' opencast-dist-worker/bin/setenv
+sed -i 's!# export KARAF_DEBUG.*!export KARAF_DEBUG=1!' opencast-dist-presentation/bin/setenv
+sed -i 's!# export JAVA_DEBUG_PORT.*!export JAVA_DEBUG_PORT=5007!' opencast-dist-presentation/bin/setenv
+
 for node in admin presentation worker; do
   # configure database
   sed -i 's_^.*db.jdbc.driver=.*$_org.opencastproject.db.jdbc.driver=org.postgresql.Driver_' \


### PR DESCRIPTION
This PR adds debug ports (5005, 5006, 5007) to the various nodes running in the multi node test config.  Makes zero difference to the GHA use, but if you're using that script to test locally it can be handy to be able to get into the JVMs with a debugger.

### How to test this patch

Run the script, then start admin, worker, and presentation to make sure each one is listening on its port

<!--
Explain how to test this patch. If this requires a particular set-up or configuration, explain that as well and provide
the necessary configuration if possible. The easier it is for others to test the patch, the faster this will get
reviewed and merged.

For more information, see https://docs.opencast.org/develop/#participate/development-process/#ai-policy-for-pull-requests
-->

### AI Usage

N/A
<!--
If you used AI in a significant way to create this pull request, please explain how you used it and what you used it for. This is for us to better understand and deal with AI contributions. Your pull request will not be declined just becasue of AI usage.
-->

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] ~explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch~
* [ ] ~include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)~
