### PR TITLE
Add the anonymous role to every user

### DIFF
--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
@@ -381,6 +381,13 @@ public class UserAndRoleDirectoryServiceImpl implements UserDirectoryService, Us
     }
     roles.addAll(derivedRoles);
 
+    // Every user has the anonymous role: being logged in does not stop you from also being part of
+    // the anonymous audience. It is already granted to the Spring authorities in
+    // loadUserByUsername(), so without adding it here the roles of a User would disagree with the
+    // authorities actually being evaluated, and it would be missing from /info/me.json.
+    roles.add(new JaxbRole(user.getOrganization().getAnonymousRole(),
+            JaxbOrganization.fromOrganization(user.getOrganization()), "", Role.Type.SYSTEM));
+
     // Create and return the final user
     JaxbUser mergedUser = new JaxbUser(user.getUsername(), user.getPassword(), user.getName(), user.getEmail(),
             user.getProvider(), JaxbOrganization.fromOrganization(user.getOrganization()), roles);

--- a/modules/userdirectory/src/test/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImplTest.java
+++ b/modules/userdirectory/src/test/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImplTest.java
@@ -42,6 +42,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -173,6 +174,22 @@ public class UserAndRoleDirectoryServiceImplTest {
     assertEquals("matterhorn,test", mergedUser.getProvider());
     assertTrue(mergedUser.isManageable());
     assertTrue(((JaxbUser) mergedUser).isManageable());
+  }
+
+  /**
+   * Every user carries the organization's anonymous role, matching the Spring authorities granted
+   * in loadUserByUsername(). Without it the roles reported by a User disagree with the authorities
+   * actually evaluated, which is what made ROLE_ANONYMOUS missing from /info/me.json under HTTP
+   * basic auth.
+   */
+  @Test
+  public void testUserHasAnonymousRole() throws Exception {
+    User user = directory.loadUser(userName);
+    Set<String> roleNames = new HashSet<>();
+    for (Role role : user.getRoles()) {
+      roleNames.add(role.getName());
+    }
+    assertTrue(roleNames.contains(org.getAnonymousRole()));
   }
 
   @Test


### PR DESCRIPTION
`loadUserByUsername()` grants the organization's anonymous role to the Spring
`authorities`:

https://github.com/opencast/opencast/blob/develop/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java#L431

but the Opencast `User` assembled by `loadUser()` never carried it. So the two disagreed:
authorization evaluated `ROLE_ANONYMOUS`, while anything reading `User.getRoles()` did not
see it.

The visible symptom, reported in #5920 and narrowed down by @LukasKalbertodt in #6691, is
that `/info/me.json` omits `ROLE_ANONYMOUS` when authenticating with HTTP basic auth while
showing it for a session login. `/info/me.json` serialises `user.getRoles()`
([RuntimeInfo:288](https://github.com/opencast/opencast/blob/develop/modules/runtime-info/src/main/java/org/opencastproject/runtimeinfo/RuntimeInfo.java#L288)),
which is the side that was missing the role.

This adds the role where the merged user is assembled, so `getRoles()` reports the same
roles that are actually being evaluated. Per @gregorydlogan
[in #5920](https://github.com/opencast/opencast/issues/5920#issuecomment-5240576637):

> Every user should always have `ROLE_ANONYMOUS`, since... well, if you're not logged in
> then you're anonymous. It's assumed to be there, and its lack is what triggered this
> report in the first place.

and on where it belongs:

> I would put it into the `loadUser` method. At the base of it, each *user* should have
> `ROLE_ANONYMOUS`, so I would expect the `User` coming out of `loadUser` to have all of
> its roles.

Note this only changes what a `User` *reports*. The effective permissions are unchanged,
since the anonymous role was already in the Spring authorities on both login paths — which
matches what I measured while investigating: `/series/count`, the one path gated on
`ROLE_ANONYMOUS` in `mh_default_org.xml`, already returned 200 for a no-roles user either
way.

Fixes #5920
Refs #6691

I have deliberately not marked this as closing #6691. It fixes the missing role that
@LukasKalbertodt narrowed that report down to, but the same comment also mentions a 403
when requesting static files, and I was never able to reproduce that — `/static/**` is
`permitAll` and returned 403 for every caller including `admin` in my testing, which
suggests something separate. Better to leave #6691 open for someone to confirm that half
than to close it silently.

### How to test this patch

```
./mvnw test -pl modules/userdirectory
```

`testUserHasAnonymousRole` covers it directly. It fails without the change (verified by
reverting the patch and re-running) and passes with it.

End to end, on a running instance: create a user with no roles assigned, then

```
curl -u <user>:<pass> localhost:8080/info/me.json
```

I ran this both ways on a dev instance. Before the patch:

```
roles: ["ROLE_USER", "ROLE_USER_anontest"]
```

after deploying the rebuilt `userdirectory` bundle:

```
roles: ["ROLE_USER", "ROLE_USER_anontest", "ROLE_ANONYMOUS"]
```

`admin` still reports all 7 of its roles including `ROLE_ADMIN`, and `/series/count`,
`/api/info/me` and `/admin-ng/users/users.json` all still return 200, so nothing regressed
on the authorization side.

### AI Usage

Claude (Anthropic) was used to trace the two role paths, write the patch and test, and
draft this description. The test was checked against the unpatched code to confirm it
actually fails without the fix, and the before/after behaviour above was measured on a
running instance rather than inferred. Beyond `modules/userdirectory`, the tests for
`admin-service`, `runtime-info`, `common`, `authorization-manager`, `authorization-xacml`,
`security-jwt` and `security-lti` were run to look for anything depending on the anonymous
role being absent from `User.getRoles()`; all pass. Repo-wide `./mvnw checkstyle:check`
reports 0 violations. Reviewed by me before submitting.
