### PR TITLE
Fix trailing slash in documented paths of root endpoints

### DIFF
--- a/modules/runtime-info/src/main/java/org/opencastproject/runtimeinfo/rest/RestDocData.java
+++ b/modules/runtime-info/src/main/java/org/opencastproject/runtimeinfo/rest/RestDocData.java
@@ -207,15 +207,17 @@ public class RestDocData extends DocData {
   }
 
   /**
-   * Validates paths: VALID: /sample , /sample/{thing} , /{my}/{path}.xml , /my/fancy_path/is/{awesome}.{FORMAT}
-   * INVALID: sample, /sample/, /sa#$%mple/path
+   * Validates paths: VALID: (empty), /sample , /sample/{thing} , /{my}/{path}.xml ,
+   * /my/fancy_path/is/{awesome}.{FORMAT} INVALID: sample, /sample/, /sa#$%mple/path
+   * <p>
+   * The empty path is valid and denotes an endpoint at the root of its service.
    *
    * @param path
    *          the path value to check
    * @return true if this path is valid, false otherwise
    */
   public static boolean isValidPath(String path) {
-    return path != null && path.matches("^/$|^/[\\w/{}|:.*+]*[\\w}.]$");
+    return path != null && path.matches("^$|^/$|^/[\\w/{}|:.*+]*[\\w}.]$");
   }
 
   /**
@@ -239,7 +241,15 @@ public class RestDocData extends DocData {
    */
   public void addEndpoint(RestQuery restQuery, Class<?> returnType, Produces produces, String httpMethodString,
           Path path) {
-    String pathValue = path.value().startsWith("/") ? path.value() : "/" + path.value();
+    // An endpoint at the root of its service ("" or "/") contributes no path segment of its own:
+    // the documentation renders the service base URL immediately followed by this value, and the
+    // security configuration intercepts those paths without a trailing slash.
+    String pathValue = path.value();
+    if ("/".equals(pathValue)) {
+      pathValue = "";
+    } else if (!pathValue.isEmpty() && !pathValue.startsWith("/")) {
+      pathValue = "/" + pathValue;
+    }
     RestEndpointData endpoint = new RestEndpointData(returnType, restQuery.name(), httpMethodString, pathValue,
             restQuery.description());
     // Add return description if needed

--- a/modules/runtime-info/src/test/java/org/opencastproject/runtimeinfo/rest/RestDocsAnnotationTest.java
+++ b/modules/runtime-info/src/test/java/org/opencastproject/runtimeinfo/rest/RestDocsAnnotationTest.java
@@ -290,6 +290,30 @@ public class RestDocsAnnotationTest {
   }
 
   /**
+   * An endpoint declaring the empty path (or a bare slash) sits at the root of its service. The
+   * documentation renders the endpoint path directly after the service base URL, so such an
+   * endpoint must contribute an empty path rather than a slash. Otherwise the documented path for,
+   * say, the series service reads <code>POST /api/series/</code>, which the security configuration
+   * does not intercept -- it is declared without the trailing slash.
+   */
+  @Test
+  public void testRootPathHasNoTrailingSlash() throws Exception {
+    for (String methodName : new String[] { "methodRootEmptyPath", "methodRootSlashPath" }) {
+      Method testMethod = TestServletSample.class.getMethod(methodName);
+      RestDocData restDocData = new RestDocData("NAME", "TITLE", "URL", null);
+      restDocData.addEndpoint(testMethod.getAnnotation(RestQuery.class), testMethod.getReturnType(),
+              testMethod.getAnnotation(Produces.class), "POST", testMethod.getAnnotation(Path.class));
+
+      RestEndpointData endpoint = restDocData.holders.stream()
+              .flatMap(holder -> holder.getEndpoints().stream())
+              .findFirst()
+              .orElseThrow(() -> new AssertionError("no endpoint was documented for " + methodName));
+      assertEquals("endpoint declared by " + methodName + " must not be documented with a trailing slash",
+              "", endpoint.getPath());
+    }
+  }
+
+  /**
    * This sample class simulates a annotated REST service class.
    */
   @RestService(
@@ -407,6 +431,38 @@ public class RestDocsAnnotationTest {
 
     public String getSchema() {
       return "THIS IS SCHEMA";
+    }
+
+    /** An endpoint at the root of its service, declared the way the External API declares it. */
+    @POST
+    @Produces(MediaType.TEXT_XML)
+    @Path("")
+    @RestQuery(
+        name = "createseriesemptypath",
+        description = "Creates a series.",
+        responses = {
+            @RestResponse(description = "A new series is created", responseCode = HttpServletResponse.SC_CREATED)
+        },
+        returnDescription = "the new series"
+    )
+    public int methodRootEmptyPath() {
+      return 0;
+    }
+
+    /** The same endpoint, declared with a bare slash instead of the empty string. */
+    @POST
+    @Produces(MediaType.TEXT_XML)
+    @Path("/")
+    @RestQuery(
+        name = "createseriesslashpath",
+        description = "Creates a series.",
+        responses = {
+            @RestResponse(description = "A new series is created", responseCode = HttpServletResponse.SC_CREATED)
+        },
+        returnDescription = "the new series"
+    )
+    public int methodRootSlashPath() {
+      return 0;
     }
   }
 


### PR DESCRIPTION
Fixes #6109.

Endpoints sitting at the root of their service declare `@Path("")` — the External API's
`createSeries` is one — or `@Path("/")`. `RestDocData.addEndpoint()` normalised both to `"/"`,
and since the documentation template renders the service base URL immediately followed by the
endpoint path (`${meta.url}${endpoint.path}`), they were documented as `POST /api/series/`
rather than `POST /api/series`.

The Spring security configuration declares those paths without the trailing slash:

```xml
<sec:intercept-url pattern="/api/series" method="POST" access="hasAnyRole('ROLE_ADMIN', 'ROLE_API_SERIES_CREATE')" />
```

so the documented path is not the one that is intercepted. Admin users do not notice, which is
why the forms on the documentation page have always appeared to work for them, but for other
users both the documented path and the test form on the documentation page — which posts to
that same URL — do not work.

The root path is now normalised to the empty string, so it contributes no segment of its own.
`isValidPath()` previously rejected the empty string, so it had to accept it in the same change;
otherwise every root endpoint would fail its `RestEndpointData` constructor check. Note that a
genuine trailing slash such as `sample/` was already rejected as an invalid path, and no
endpoint in the tree declares one, so the bare slash was the only way this could occur.

### How to test this patch

Open the REST documentation for a service with an endpoint at its root, for example
`/docs.html?path=/api/series` on a running instance, and look at the "Method / Path" row for
`createseries`. Before the patch it reads `POST /api/series/`; after it reads `POST /api/series`,
matching the pattern in `etc/security/mh_default_org.xml`. The test form on that page targets
the same URL, so it starts working for non-admin users.

Automated coverage comes with the patch:

```
./mvnw test -pl modules/runtime-info
```

`RestDocsAnnotationTest.testRootPathHasNoTrailingSlash` drives the real `addEndpoint()` with
sample methods annotated `@Path("")` and `@Path("/")` and asserts neither is documented with a
trailing slash. It fails against the unpatched code with `expected:<[]> but was:<[/]>`.

### AI Usage

Claude Code (Claude Opus 5, Anthropic) was used for this pull request: to trace the path from
the `@Path` annotation through `RestDocData` and the `restdocs` template to the rendered page,
to write the fix, and to write the test.

The result was verified before submitting rather than taken on trust. The test was written
first and confirmed to fail against the unpatched code, then confirmed to fail again when the
fix was reverted while the test was left in place, so that it is known to catch a regression
rather than passing regardless. The full `runtime-info` suite and a repo-wide
`./mvnw checkstyle:check` both pass. The initially assumed one-line change to the normalisation
turned out to be incomplete — it would have made every root endpoint throw
`IllegalArgumentException` in the `RestEndpointData` constructor, since `isValidPath()` rejected
the empty string — and that was caught by running the code.

A human reviewed the change and approved sending it.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
