### PR TITLE
Reject JWTs whose algorithm does not match the JWK set's key type

### DIFF
--- a/modules/security-jwt/src/main/java/org/opencastproject/security/jwt/JWTVerifier.java
+++ b/modules/security-jwt/src/main/java/org/opencastproject/security/jwt/JWTVerifier.java
@@ -29,6 +29,7 @@ import com.nimbusds.jose.crypto.Ed25519Verifier;
 import com.nimbusds.jose.crypto.MACVerifier;
 import com.nimbusds.jose.crypto.RSASSAVerifier;
 import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.KeyType;
 import com.nimbusds.jwt.SignedJWT;
 
 import org.apache.commons.lang3.StringUtils;
@@ -78,24 +79,53 @@ public final class JWTVerifier {
 
     List<JWSVerifier> verifiers = new ArrayList<>();
     if (alg.equals(JWSAlgorithm.RS256) || alg.equals(JWSAlgorithm.RS384) || alg.equals(JWSAlgorithm.RS512)) {
-      for (JWK jwk : jwkSet) {
+      for (JWK jwk : matching(jwkSet, KeyType.RSA, alg)) {
         verifiers.add(new RSASSAVerifier(jwk.toRSAKey()));
       }
       return verify(jwt, claimConstraints, verifiers.toArray(new JWSVerifier[0]));
     } else if (alg.equals(JWSAlgorithm.ES256) || alg.equals(JWSAlgorithm.ES256K) || alg.equals(JWSAlgorithm.ES384)
         || alg.equals(JWSAlgorithm.ES512)) {
-      for (JWK jwk : jwkSet) {
+      for (JWK jwk : matching(jwkSet, KeyType.EC, alg)) {
         verifiers.add(new ECDSAVerifier(jwk.toECKey()));
       }
       return verify(jwt, claimConstraints, verifiers.toArray(new JWSVerifier[0]));
     } else if (alg.equals(JWSAlgorithm.EdDSA) || alg.equals(JWSAlgorithm.Ed25519)) {
-      for (JWK jwk : jwkSet) {
+      for (JWK jwk : matching(jwkSet, KeyType.OKP, alg)) {
         verifiers.add(new Ed25519Verifier(jwk.toPublicJWK().toOctetKeyPair()));
       }
       return verify(jwt, claimConstraints, verifiers.toArray(new JWSVerifier[0]));
     } else {
       throw new IllegalArgumentException("Unsupported algorithm '" + alg + "'");
     }
+  }
+
+  /**
+   * Filters a JWK set down to the keys of a given key type.
+   * <p>
+   * The algorithm is taken from the JWT header and is therefore attacker controlled, while the key
+   * type is a property of the configured JWK set. Converting a key to the type implied by the
+   * algorithm without checking would throw a {@link ClassCastException}, so keys of a different
+   * type are skipped here and simply do not yield a verifier.
+   *
+   * @param jwkSet The JWK set.
+   * @param keyType The key type required by the JWT's algorithm.
+   * @param alg The JWT's algorithm, for logging only.
+   * @return The keys of the requested type.
+   */
+  private static List<JWK> matching(List<JWK> jwkSet, KeyType keyType, JWSAlgorithm alg) {
+    List<JWK> matching = new ArrayList<>();
+    for (JWK jwk : jwkSet) {
+      if (keyType.equals(jwk.getKeyType())) {
+        matching.add(jwk);
+      } else {
+        logger.debug("Skipping JWK '{}' of type '{}', algorithm '{}' requires a key of type '{}'",
+            jwk.getKeyID(), jwk.getKeyType(), alg, keyType);
+      }
+    }
+    if (matching.isEmpty()) {
+      logger.warn("The JWK set contains no key of type '{}' as required by the JWT's algorithm '{}'", keyType, alg);
+    }
+    return matching;
   }
 
   /**

--- a/modules/security-jwt/src/test/java/org/opencastproject/security/jwt/JWTGenerator.java
+++ b/modules/security-jwt/src/test/java/org/opencastproject/security/jwt/JWTGenerator.java
@@ -29,9 +29,15 @@ import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.KeyLengthException;
+import com.nimbusds.jose.crypto.ECDSASigner;
 import com.nimbusds.jose.crypto.MACSigner;
 import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.OctetKeyPair;
 import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jose.jwk.gen.OctetKeyPairGenerator;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
@@ -56,6 +62,8 @@ public final class JWTGenerator {
   // Asymmetric Algorithm
   private final int keySize = 2048;
   private final RSAKey rsaJWK;
+  private ECKey ecJWK;
+  private OctetKeyPair okpJWK;
 
   // Claims
   private final String issuer = "https://auth.example.org";
@@ -220,6 +228,34 @@ public final class JWTGenerator {
     return new RSAKeyGenerator(keySize)
         .keyID("ABC")
         .generate();
+  }
+
+  /**
+   * Generates a JWT signed with an EC key, i.e. using an algorithm whose key type does not match
+   * an RSA or OKP JWK set.
+   *
+   * @return The serialized JWT.
+   */
+  public String generateValidEcJWT() throws JOSEException {
+    return generateValidJWT(new ECDSASigner(getEcJWK()), JWSAlgorithm.ES256, name, email, roles, 60 * 60 * 1000);
+  }
+
+  public ECKey getEcJWK() throws JOSEException {
+    if (ecJWK == null) {
+      ecJWK = new ECKeyGenerator(Curve.P_256)
+          .keyID("EC")
+          .generate();
+    }
+    return ecJWK;
+  }
+
+  public OctetKeyPair getOkpJWK() throws JOSEException {
+    if (okpJWK == null) {
+      okpJWK = new OctetKeyPairGenerator(Curve.Ed25519)
+          .keyID("OKP")
+          .generate();
+    }
+    return okpJWK;
   }
 
   public String getSecret() {

--- a/modules/security-jwt/src/test/java/org/opencastproject/security/jwt/JWTVerifierTest.java
+++ b/modules/security-jwt/src/test/java/org/opencastproject/security/jwt/JWTVerifierTest.java
@@ -147,4 +147,51 @@ public class JWTVerifierTest {
     );
   }
 
+  /**
+   * A JWT whose algorithm implies a different key type than the one offered by the JWK set must be
+   * rejected as unverifiable rather than causing a {@link ClassCastException}.
+   */
+  @Test
+  public void testVerifyAlgorithmKeyTypeMismatch() throws Exception {
+    // EC-signed JWT against an OKP (Ed25519) JWK set, the combination reported in the issue
+    JWKSetProvider okpProvider = createMock(JWKSetProvider.class);
+    expect(okpProvider.getAll())
+        .andReturn(List.of(generator.getOkpJWK().toPublicJWK()))
+        .atLeastOnce();
+    replay(okpProvider);
+
+    assertThrows(
+        JOSEException.class,
+        () -> JWTVerifier.verify(
+            generator.generateValidEcJWT(),
+            okpProvider,
+            generator.generateValidClaimConstraints()
+        )
+    );
+
+    // EC-signed JWT against an RSA JWK set
+    assertThrows(
+        JOSEException.class,
+        () -> JWTVerifier.verify(
+            generator.generateValidEcJWT(),
+            validProvider,
+            generator.generateValidClaimConstraints()
+        )
+    );
+
+    // A JWK set mixing an unusable and a usable key must still verify via the usable one
+    JWKSetProvider mixedProvider = createMock(JWKSetProvider.class);
+    expect(mixedProvider.getAll())
+        .andReturn(List.of(generator.getOkpJWK().toPublicJWK(), generator.getEcJWK().toPublicJWK()))
+        .atLeastOnce();
+    replay(mixedProvider);
+
+    SignedJWT signedJWT = JWTVerifier.verify(
+        generator.generateValidEcJWT(),
+        mixedProvider,
+        generator.generateValidClaimConstraints()
+    );
+    assertEquals(generator.getUsername(), signedJWT.getJWTClaimsSet().getClaimAsString("username"));
+  }
+
 }


### PR DESCRIPTION
Fixes #7243.

A JWT's algorithm is read from its header and is therefore controlled by whoever sends the token, while the key type is a property of the configured JWK set. `JWTVerifier` converted every key in the set to the type implied by that algorithm — `toRSAKey()`, `toECKey()`, `toOctetKeyPair()` — without checking first. Those are unguarded casts, so an ES256-signed JWT against an Ed25519 JWKS threw

```
java.lang.ClassCastException: class com.nimbusds.jose.jwk.OctetKeyPair cannot be cast to class com.nimbusds.jose.jwk.ECKey
```

out of `JWK.toECKey()`.

That also explains the second half of the report, that nothing was logged. `ClassCastException` is unchecked, so it passed straight through the `catch (ParseException | JOSEException)` in `DynamicLoginHandler.handleToken()` — the `logger.debug` there never ran — and escaped to the container as an HTTP 500 instead of the token being rejected.

Keys whose type does not match the JWT's algorithm are now skipped. Verification then fails with a `JOSEException`, `handleToken()` returns `null`, and the request is treated as unauthenticated, which is the behaviour the issue asks for. A JWK set holding a mix of key types still verifies through the usable ones, so this does not narrow what a valid configuration can do.

### How to test this patch

`JWTVerifierTest.testVerifyAlgorithmKeyTypeMismatch` covers it: an EC-signed JWT against an Ed25519 JWK set (the combination in the issue), the same JWT against an RSA set, and a mixed set that must still verify successfully. The test was confirmed to fail against unpatched code with the exact `ClassCastException` from the report before the fix was applied.

Full module suite: 31 tests, 0 failures. Repo-wide `mvn checkstyle:check` reports 0 violations.

### AI Usage

Claude Opus (Anthropic), via Claude Code, was used to investigate the issue, write the fix and the accompanying test. A human reviewed the change and approved sending it.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
