### PR TITLE
Resolve wildcard timeline previews target flavor per track

### DIFF
--- a/modules/timelinepreviews-workflowoperation/src/main/java/org/opencastproject/workflow/handler/timelinepreviews/TimelinePreviewsWorkflowOperationHandler.java
+++ b/modules/timelinepreviews-workflowoperation/src/main/java/org/opencastproject/workflow/handler/timelinepreviews/TimelinePreviewsWorkflowOperationHandler.java
@@ -233,15 +233,18 @@ public class TimelinePreviewsWorkflowOperationHandler extends AbstractWorkflowOp
           }
 
           // set the timeline previews attachment flavor and add it to the mediapackage
-          if ("*".equals(targetFlavor.getType())) {
-            targetFlavor = new MediaPackageElementFlavor(
-                timelinePreviewsMpe.getFlavor().getType(), targetFlavor.getSubtype());
+          // Resolve wildcards against this element only. The configured target flavor must stay
+          // untouched, otherwise the first track's flavor would be reused for all later ones.
+          MediaPackageElementFlavor elementTargetFlavor = targetFlavor;
+          if ("*".equals(elementTargetFlavor.getType())) {
+            elementTargetFlavor = new MediaPackageElementFlavor(
+                timelinePreviewsMpe.getFlavor().getType(), elementTargetFlavor.getSubtype());
           }
-          if ("*".equals(targetFlavor.getSubtype())) {
-            targetFlavor = new MediaPackageElementFlavor(
-                targetFlavor.getType(), timelinePreviewsMpe.getFlavor().getSubtype());
+          if ("*".equals(elementTargetFlavor.getSubtype())) {
+            elementTargetFlavor = new MediaPackageElementFlavor(
+                elementTargetFlavor.getType(), timelinePreviewsMpe.getFlavor().getSubtype());
           }
-          timelinePreviewsMpe.setFlavor(targetFlavor);
+          timelinePreviewsMpe.setFlavor(elementTargetFlavor);
           applyTargetTagsToElement(targetTagsProperty, timelinePreviewsMpe);
 
           mediaPackage.add(timelinePreviewsMpe);


### PR DESCRIPTION
Fixes #6927.

`TimelinePreviewsWorkflowOperationHandler` reads `target-flavor` once, before the loop that adds the finished attachments to the media package. The wildcard resolution then assigned its result **back to that same variable**, so the first attachment replaced `*` with a concrete type and every later attachment reused it.

With the configuration shipped in `partial-publish.yaml` — `source-flavor: '*/trimmed'`, `target-flavor: '*/timeline+preview'` — an event with a presenter and a presentation track produced two attachments both flavored `presenter/timeline+preview`. The presentation timeline previews were effectively lost, which is what the issue reports.

The wildcards are now resolved into a per-element flavor, leaving the configured target flavor untouched. An explicit (non-wildcard) target flavor keeps being applied to every track exactly as before.

This also unblocks the concern raised in [opencast/roadmap#22](https://github.com/opencast/roadmap/issues/22), where the chapter thumbnail could not be taken from the presentation track for the same reason.

### How to test this patch

Verified end-to-end on a running Opencast, not only by unit test. The same two-track media package (`presenter/source` + `presentation/source`) was ingested through a workflow using `source-flavor: '*/source'` and `target-flavor: '*/timeline+preview'`, on two builds that differed only in this patch:

| Build | Resulting attachment flavors |
|---|---|
| Stock `develop` | `presenter/timeline+preview`, `presenter/timeline+preview` |
| With this patch | `presenter/timeline+preview`, `presentation/timeline+preview` |

Reproducing it needs a media package with **two or more source tracks** — with a single track the bug is invisible, since there is no second attachment to inherit the first one's resolved flavor.

An earlier revision of this PR added a `TimelinePreviewsWorkflowOperationHandlerTest`. **It was removed at @Arnei's request** — 175 test lines and three new test-scoped dependencies for a 10-line fix, most of it mock scaffolding, was disproportionate for the module. A holistic test class for this handler is better done as its own PR. This PR is now the fix alone: one file, +10/-7, and `pom.xml` is untouched.

Repo-wide `mvn checkstyle:check` reports 0 violations.

### AI Usage

Claude Opus (Anthropic), via Claude Code, was used to investigate the issue, write the fix, run the live verification described above, and apply the review feedback. A human reviewed the change and approved sending it.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)

