### PR TITLE
Match capture device keys by prefix, not substring

### DIFF
--- a/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/impl/AgentImpl.java
+++ b/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/impl/AgentImpl.java
@@ -314,9 +314,8 @@ public class AgentImpl implements Agent {
         if (key.startsWith(check)) {
           String property = configuration.getProperty(key);
           if (property == null) {
-            log.error("Unable to expand variable in value for key {}, returning null!", key);
-            capabilitiesProperties = null;
-            return;
+            log.warn("Capture agent '{}': ignoring capability key '{}' because its value is null", this.name, key);
+            continue;
           }
           capabilitiesProperties.setProperty(key, property);
           propertyCounts.put(name, propertyCounts.get(name) + 1);

--- a/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/impl/AgentImpl.java
+++ b/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/impl/AgentImpl.java
@@ -311,7 +311,7 @@ public class AgentImpl implements Agent {
       for (String name : friendlyNames) {
         String check = CaptureParameters.CAPTURE_DEVICE_PREFIX + name;
         // If the key looks like a device prefix + the name, copy it
-        if (key.contains(check)) {
+        if (key.startsWith(check)) {
           String property = configuration.getProperty(key);
           if (property == null) {
             log.error("Unable to expand variable in value for key {}, returning null!", key);

--- a/modules/capture-admin-service-impl/src/test/java/org/opencastproject/capture/admin/impl/AgentTest.java
+++ b/modules/capture-admin-service-impl/src/test/java/org/opencastproject/capture/admin/impl/AgentTest.java
@@ -24,6 +24,7 @@ package org.opencastproject.capture.admin.impl;
 import static org.opencastproject.capture.admin.api.AgentState.CAPTURING;
 import static org.opencastproject.capture.admin.api.AgentState.IDLE;
 
+import org.opencastproject.capture.CaptureParameters;
 import org.opencastproject.capture.admin.api.Agent;
 import org.opencastproject.security.api.DefaultOrganization;
 
@@ -31,6 +32,8 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Properties;
 
 public class AgentTest {
   private Agent agent = null;
@@ -71,5 +74,22 @@ public class AgentTest {
     if (agent.getLastHeardFrom() <= time || agent.getLastHeardFrom() > System.currentTimeMillis()) {
       Assert.fail("Invalid checkin time");
     }
+  }
+
+  @Test
+  public void onlyKeysStartingWithTheDevicePrefixBecomeCapabilities() {
+    Properties configuration = new Properties();
+    configuration.setProperty(CaptureParameters.CAPTURE_DEVICE_NAMES, "CAMERA");
+    configuration.setProperty(CaptureParameters.CAPTURE_DEVICE_PREFIX + "CAMERA.src", "/dev/video0");
+    configuration.setProperty("legacy." + CaptureParameters.CAPTURE_DEVICE_PREFIX + "CAMERA.src", "/dev/video9");
+
+    agent.setConfiguration(configuration);
+
+    Properties capabilities = agent.getCapabilities();
+    Assert.assertEquals("CAMERA", capabilities.getProperty(CaptureParameters.CAPTURE_DEVICE_NAMES));
+    Assert.assertEquals("/dev/video0",
+        capabilities.getProperty(CaptureParameters.CAPTURE_DEVICE_PREFIX + "CAMERA.src"));
+    Assert.assertFalse("A key merely containing the device prefix must not become a capability",
+        capabilities.containsKey("legacy." + CaptureParameters.CAPTURE_DEVICE_PREFIX + "CAMERA.src"));
   }
 }


### PR DESCRIPTION
# Match capture device keys by prefix, not substring

Fixes the first defect in #7889, and adjusts the second as suggested in that thread.

`AgentImpl.setConfiguration()` derives an agent's advertised capabilities from the configuration it pushes to `POST /capture-admin/agents/{name}/configuration`.

**Defect 1 — `contains` where `startsWith` is meant.** The key test was `key.contains("capture.device." + name)`, so any key that merely mentions a device anywhere was promoted into that device's capabilities — `legacy.capture.device.CAMERA.src` was treated as a property of `CAMERA`. Capabilities are what the admin interface offers operators as selectable inputs (`AbstractEventEndpoint`, `CaptureAgentsEndpoint`), so the spurious entries surfaced in the scheduling UI. The surrounding comment already says "If the key looks like a device prefix + the name", which describes `startsWith`.

**Defect 2 — one null value discarded everything.** On a null value the method set `capabilitiesProperties = null` and returned, throwing away every capability collected so far *and* the `capture.device.names` entry set before the loop, leaving `getCapabilities()` null for callers that dereference it. Per @gregorydlogan's comment on the issue this now skips the unusable key and keeps the rest. The `log.error` text was inherited from an earlier implementation — it referred to variable expansion this method does not perform — so it is replaced with a message describing what actually happened.

On the config key mentioned in the issue: `propertyCounts` is left as is. Removing it is unrelated to either defect and would widen this change beyond what is needed to fix them.

## Reachability of defect 2

Worth recording, since the issue asked about it. The null branch appears to be **unreachable** in practice. The loop iterates `configuration.stringPropertyNames()`, which by contract only returns keys whose values are strings, so `getProperty()` cannot return null for a key it yields. The issue suggested the Gson path (`gson.fromJson(configuration, Properties.class)`) might produce such entries; testing each case against Gson 2.11.0:

- a JSON `null` throws `NullPointerException` inside `Properties.put` during deserialisation
- a nested object throws `JsonSyntaxException` ("Expected a string but was BEGIN_OBJECT")
- a JSON number is coerced to its `String` form, never null
- a non-`String` value inserted directly is omitted by `stringPropertyNames()`, and separately makes `configuration.store()` throw `ClassCastException` at the top of this method, before the loop

So the change to defect 2 is hardening rather than a fix for an observed failure. Defect 1 is unconditional and is the substantive fix here.

## Testing

Added `AgentTest.onlyKeysStartingWithTheDevicePrefixBecomeCapabilities`, which fails on the unpatched code (`legacy.capture.device.CAMERA.src` appears in the capabilities) and passes with the fix. Full module suite: 22 tests, 0 failures. Repo-wide `mvnw checkstyle:check`: 0 violations.

Defect 2 has no test, because no input reaching this method can produce the null it guards against — see above.

Targets `r/19.x` as requested in the issue.

## AI Usage

This change was prepared with the assistance of Claude Code (model Claude Opus 5, provider Anthropic). The tool was used to analyse the reported defects, verify the reachability of the null branch against Gson, write the fix and its test, and draft this description. A human reviewed the change and approved sending it.
