### PR TITLE
Use a valid charset when building the force-remove query string

### DIFF
--- a/modules/workflow-service-remote/pom.xml
+++ b/modules/workflow-service-remote/pom.xml
@@ -48,6 +48,11 @@
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/modules/workflow-service-remote/src/main/java/org/opencastproject/workflow/remote/WorkflowServiceRemoteImpl.java
+++ b/modules/workflow-service-remote/src/main/java/org/opencastproject/workflow/remote/WorkflowServiceRemoteImpl.java
@@ -557,7 +557,7 @@ public class WorkflowServiceRemoteImpl extends RemoteBase implements WorkflowSer
     if (force) {
       List<NameValuePair> queryStringParams = new ArrayList<NameValuePair>();
       queryStringParams.add(new BasicNameValuePair("force", "true"));
-      deleteString = deleteString + "?" + URLEncodedUtils.format(queryStringParams, "UTF_8");
+      deleteString = deleteString + "?" + URLEncodedUtils.format(queryStringParams, StandardCharsets.UTF_8);
     }
 
     HttpDelete delete = new HttpDelete(deleteString);

--- a/modules/workflow-service-remote/src/test/java/org/opencastproject/workflow/remote/WorkflowServiceRemoteImplTest.java
+++ b/modules/workflow-service-remote/src/test/java/org/opencastproject/workflow/remote/WorkflowServiceRemoteImplTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.workflow.remote;
+
+import static org.apache.http.HttpStatus.SC_NO_CONTENT;
+import static org.junit.Assert.assertEquals;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.message.BasicHttpResponse;
+import org.junit.Test;
+
+public class WorkflowServiceRemoteImplTest {
+
+  /**
+   * Captures the request instead of sending it, so the URI built by the service under test can be inspected
+   * without a remote service registry or any HTTP traffic.
+   */
+  private static final class CapturingWorkflowServiceRemoteImpl extends WorkflowServiceRemoteImpl {
+    private String requestUri;
+
+    @Override
+    protected HttpResponse getResponse(HttpRequestBase httpRequest, Integer... expectedHttpStatus) {
+      requestUri = httpRequest.getURI().toString();
+      return new BasicHttpResponse(HttpVersion.HTTP_1_1, SC_NO_CONTENT, "No Content");
+    }
+
+    @Override
+    protected void closeConnection(HttpResponse response) {
+    }
+  }
+
+  @Test
+  public void testRemoveWithForceBuildsQueryString() throws Exception {
+    CapturingWorkflowServiceRemoteImpl service = new CapturingWorkflowServiceRemoteImpl();
+
+    service.remove(42, true);
+
+    assertEquals("/remove/42?force=true", service.requestUri);
+  }
+
+  @Test
+  public void testRemoveWithoutForceOmitsQueryString() throws Exception {
+    CapturingWorkflowServiceRemoteImpl service = new CapturingWorkflowServiceRemoteImpl();
+
+    service.remove(42, false);
+
+    assertEquals("/remove/42", service.requestUri);
+  }
+}


### PR DESCRIPTION
Fixes #7881.

`WorkflowServiceRemoteImpl.remove(long, boolean)` passes the string `"UTF_8"` to `URLEncodedUtils.format`. `"UTF_8"` is neither the canonical name nor a registered alias for UTF-8, so `Charset.forName("UTF_8")` throws `UnsupportedCharsetException` and force-removing a workflow through the remote proxy fails before any request is sent. Verified on JDK 21:

```
Charset.forName("UTF_8")         -> java.nio.charset.UnsupportedCharsetException: UTF_8
StandardCharsets.UTF_8.aliases() -> [unicode-1-1-utf-8, UTF8]
```

The name is syntactically legal — underscore is a permitted charset-name character — so this fails at lookup, at runtime, rather than being caught earlier. The branch is only reached when `force` is `true`, so plain removal is unaffected, and only deployments where `WorkflowService` resolves to `workflow-service-remote` are affected. Introduced by 7cb88de04 ("Add a force parameter to remove running workflows"), first released in 9.0.

Passing `StandardCharsets.UTF_8` to the `Charset`-typed overload rules out this class of typo rather than just correcting the spelling. `StandardCharsets` is already imported and used elsewhere in the file.

### How to test this patch

`WorkflowServiceRemoteImplTest` covers both paths:

- `testRemoveWithForceBuildsQueryString` — expects `/remove/42?force=true`
- `testRemoveWithoutForceOmitsQueryString` — expects `/remove/42`

The force test was confirmed to fail against unpatched code with `java.nio.charset.UnsupportedCharsetException: UTF_8` before the fix was applied, while the non-force test passed — which is what shows the defect is confined to the `force == true` branch.

The tests override the `protected` `getResponse` seam inherited from `RemoteBase` to capture the request URI and return a canned `204`, so they exercise the real method with no service registry and no HTTP traffic. That also means a clustered deployment is not needed to reproduce this.

The module had no test class, so one was added along with the `junit` test-scoped dependency; the bundle's runtime dependencies are unchanged.

Module suite: 2 tests, 0 failures. Repo-wide `mvnw checkstyle:check` reports 0 violations.

### AI Usage

This change was prepared with the assistance of Claude Code (model Claude Opus 5, provider Anthropic). The tool was used to verify the charset behaviour against the JDK, write the fix and its tests, and draft this description. A human reviewed the change and approved sending it.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)