### PR TITLE
Read the response body when checking for active workflows

### DIFF
--- a/modules/workflow-service-remote/pom.xml
+++ b/modules/workflow-service-remote/pom.xml
@@ -48,6 +48,11 @@
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/modules/workflow-service-remote/src/main/java/org/opencastproject/workflow/remote/WorkflowServiceRemoteImpl.java
+++ b/modules/workflow-service-remote/src/main/java/org/opencastproject/workflow/remote/WorkflowServiceRemoteImpl.java
@@ -213,7 +213,7 @@ public class WorkflowServiceRemoteImpl extends RemoteBase implements WorkflowSer
     HttpResponse response = getResponse(get);
     try {
       if (response != null) {
-        return Boolean.parseBoolean(response.getEntity().getContent().toString());
+        return Boolean.parseBoolean(EntityUtils.toString(response.getEntity()).trim());
       }
     } catch (Exception e) {
       throw new WorkflowDatabaseException(e);
@@ -229,7 +229,7 @@ public class WorkflowServiceRemoteImpl extends RemoteBase implements WorkflowSer
     HttpResponse response = getResponse(get);
     try {
       if (response != null) {
-        return Boolean.parseBoolean(response.getEntity().getContent().toString());
+        return Boolean.parseBoolean(EntityUtils.toString(response.getEntity()).trim());
       }
     } catch (Exception e) {
       throw new WorkflowDatabaseException(e);

--- a/modules/workflow-service-remote/src/test/java/org/opencastproject/workflow/remote/WorkflowServiceRemoteImplHasActiveWorkflowsTest.java
+++ b/modules/workflow-service-remote/src/test/java/org/opencastproject/workflow/remote/WorkflowServiceRemoteImplHasActiveWorkflowsTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.workflow.remote;
+
+import static org.apache.http.HttpStatus.SC_OK;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.message.BasicHttpResponse;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+public class WorkflowServiceRemoteImplHasActiveWorkflowsTest {
+
+  /**
+   * Answers every request with a fixed body, the way the workflow service endpoint does, so the response
+   * handling of the service under test can be inspected without a remote service registry or any HTTP traffic.
+   */
+  private static final class StubWorkflowServiceRemoteImpl extends WorkflowServiceRemoteImpl {
+    private final String responseBody;
+    private String requestUri;
+
+    StubWorkflowServiceRemoteImpl(String responseBody) {
+      this.responseBody = responseBody;
+    }
+
+    @Override
+    protected HttpResponse getResponse(HttpRequestBase httpRequest, Integer... expectedHttpStatus) {
+      requestUri = httpRequest.getURI().toString();
+      HttpResponse response = new BasicHttpResponse(HttpVersion.HTTP_1_1, SC_OK, "OK");
+      response.setEntity(new StringEntity(responseBody, StandardCharsets.UTF_8));
+      return response;
+    }
+
+    @Override
+    protected void closeConnection(HttpResponse response) {
+    }
+  }
+
+  @Test
+  public void testMediaPackageHasActiveWorkflowsReadsTrueFromResponseBody() throws Exception {
+    StubWorkflowServiceRemoteImpl service = new StubWorkflowServiceRemoteImpl("true");
+
+    assertTrue(service.mediaPackageHasActiveWorkflows("mp-1"));
+    assertEquals("/mediaPackage/mp-1/hasActiveWorkflows", service.requestUri);
+  }
+
+  @Test
+  public void testMediaPackageHasActiveWorkflowsReadsFalseFromResponseBody() throws Exception {
+    StubWorkflowServiceRemoteImpl service = new StubWorkflowServiceRemoteImpl("false");
+
+    assertFalse(service.mediaPackageHasActiveWorkflows("mp-1"));
+  }
+
+  @Test
+  public void testUserHasActiveWorkflowsReadsTrueFromResponseBody() throws Exception {
+    StubWorkflowServiceRemoteImpl service = new StubWorkflowServiceRemoteImpl("true");
+
+    assertTrue(service.userHasActiveWorkflows("alice"));
+    assertEquals("/user/alice/hasActiveWorkflows", service.requestUri);
+  }
+
+  @Test
+  public void testUserHasActiveWorkflowsReadsFalseFromResponseBody() throws Exception {
+    StubWorkflowServiceRemoteImpl service = new StubWorkflowServiceRemoteImpl("false");
+
+    assertFalse(service.userHasActiveWorkflows("alice"));
+  }
+}


### PR DESCRIPTION
Fixes #7879.

`WorkflowServiceRemoteImpl.mediaPackageHasActiveWorkflows` and `userHasActiveWorkflows` call `Boolean.parseBoolean` on the `toString()` of the entity's `InputStream` instead of on the response body:

```java
return Boolean.parseBoolean(response.getEntity().getContent().toString());
```

`getContent()` returns an `InputStream`, which does not override `Object.toString()`, so `parseBoolean` is handed something like `org.apache.http.conn.EofSensorInputStream@6d06d69c` and returns `false` for every response. The body is never read, so the entity is also not consumed and the connection is not released.

The server side is already correct — `WorkflowRestService` returns `Response.ok(Boolean.toString(...))` for both endpoints, which is exactly what `parseBoolean` expects. Only the client is wrong.

### Why this matters

**No shipped assembly reaches this code** — thanks to @Arnei for catching that my original description overstated the impact. `assemblies/karaf-features/src/main/feature/feature.xml` puts the remote bundle and its callers on disjoint node types:

| feature | `workflow-service-remote` | `workflow-service-impl` | `admin-service` | `external-api` |
|---|---|---|---|---|
| allinone / admin / adminpresentation | – | yes | yes | yes |
| worker / presentation / ingest | yes | – | – | – |

The only two callers in the tree are `EventsEndpoint.java:2532` and `UsersEndpoint.java:575` (`grep -rn HasActiveWorkflows --include='*.java' modules/` finds no others). They ship only on the admin-side features, which resolve `WorkflowService` to the local `workflow-service-impl` — the correct path. The nodes that load this broken client have no caller for it.

So this is a **latent defect on a public `WorkflowService` API method**, not an observed failure. A custom assembly, or any future caller added on a worker or presentation node, would get a silently wrong `false` from it, and the unconsumed entity also leaks the connection back to the pool unreleased.

`EntityUtils.toString` reads the body and consumes the entity, which also releases the connection. `EntityUtils` is already imported in the file, so the fix adds no imports. The `trim()` guards against trailing whitespace in the body. Per @Arnei's review the explicit `StandardCharsets.UTF_8` was dropped — the body is only `true` or `false`, which is pure ASCII and decodes identically either way, and the no-charset form matches the existing `EntityUtils.toString` call at line 373 of the same file.

### How to test this patch

Honest answer: **you cannot usefully exercise this by hand.** Per the table above, no shipped assembly puts a caller and this client on the same node, so there is no deployment where the broken path runs. The quickest review is to read the two-line diff against `WorkflowRestService`, which already returns `Response.ok(Boolean.toString(...))` — exactly what `parseBoolean` expects.

If you want it exercised in code, `WorkflowServiceRemoteImplHasActiveWorkflowsTest` covers both methods against both answers. It overrides the `protected` `getResponse` / `closeConnection` seams from `RemoteBase` to return a canned `200` with a `StringEntity`, so no service registry and no HTTP traffic are involved. Against unpatched code the two `true` cases fail while the two `false` cases pass, which is what demonstrates the methods were stuck on `false`; the `true` cases also assert the request URI so a wrong path cannot make them pass for the wrong reason. After the fix: 4 tests, 0 failures.

The `junit` test-scoped dependency was added to the module; the bundle's runtime dependencies are unchanged. Repo-wide `mvnw checkstyle:check` reports 0 violations.

### AI Usage

This change was prepared with the assistance of Claude Code (model Claude Opus 5, provider Anthropic). The tool was used to verify the reported behaviour against the source and the JDK, identify the affected releases, write the fix and its tests, and draft this description. A human reviewed the change and approved sending it.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)

