### PR TITLE
Make check-availability configurable for auto-updates on series changes

### DIFF
--- a/docs/guides/admin/docs/releasenotes/check-availability-autoupdate.txt
+++ b/docs/guides/admin/docs/releasenotes/check-availability-autoupdate.txt
@@ -1,0 +1,1 @@
+When changing the series of an event (e.g. metadata or ACL), those changes are automatically republished to search. In org.opencastproject.event.handler.SearchUpdatedEventHandler.cfg you can now switch off checkAvailability after distributing the changed files, which might improve performance. Default behavior has not changed.

--- a/etc/org.opencastproject.event.handler.SearchUpdatedEventHandler.cfg
+++ b/etc/org.opencastproject.event.handler.SearchUpdatedEventHandler.cfg
@@ -1,0 +1,3 @@
+# Whether to check if distributed files are available after distribution
+# Default: true
+# distribution.check.availability=true

--- a/modules/conductor/src/main/java/org/opencastproject/event/handler/SearchUpdatedEventHandler.java
+++ b/modules/conductor/src/main/java/org/opencastproject/event/handler/SearchUpdatedEventHandler.java
@@ -84,8 +84,14 @@ public class SearchUpdatedEventHandler {
   /** The logger */
   protected static final Logger logger = LoggerFactory.getLogger(SearchUpdatedEventHandler.class);
 
+  // config keys
+  protected static final String DISTRIBUTION_CHECK_AVAILABILITY = "distribution.check.availability";
+
+  /** Whether to propagate episode meta data changes to OAI-PMH or not */
+  private boolean checkAvailability;
+
   /** The distribution service */
-  protected DistributionService distributionService = null;
+  protected DownloadDistributionService downloadDistributionService = null;
 
   /** The search service */
   protected SearchService searchService = null;
@@ -108,12 +114,20 @@ public class SearchUpdatedEventHandler {
   /**
    * OSGI callback for component activation.
    *
-   * @param bundleContext
-   *          the OSGI bundle context
+   * @param componentContext
+   *          the OSGI component context
    */
   @Activate
-  protected void activate(BundleContext bundleContext) {
-    this.systemAccount = bundleContext.getProperty("org.opencastproject.security.digest.user");
+  protected void activate(ComponentContext componentContext) {
+    this.systemAccount = componentContext.getBundleContext().getProperty("org.opencastproject.security.digest.user");
+    updated(componentContext);
+  }
+
+  @Modified
+  protected void updated(ComponentContext componentContext) {
+    checkAvailability = BooleanUtils.toBoolean(Objects.toString(componentContext.getProperties()
+            .get(DISTRIBUTION_CHECK_AVAILABILITY), "true"));
+    logger.info("Check-availability flag set to {}", checkAvailability);
   }
 
   /**
@@ -135,12 +149,12 @@ public class SearchUpdatedEventHandler {
   }
 
   /**
-   * @param distributionService
-   *          the distributionService to set
+   * @param downloadDistributionService
+   *          the downloadDstributionService to set
    */
   @Reference(target = "(distribution.channel=download)")
-  public void setDistributionService(DistributionService distributionService) {
-    this.distributionService = distributionService;
+  public void setDownloadDistributionService(DownloadDistributionService downloadDistributionService) {
+    this.downloadDistributionService = downloadDistributionService;
   }
 
   /**
@@ -194,7 +208,7 @@ public class SearchUpdatedEventHandler {
 
               MediaPackageElement[] distributedEpisodeAcls = mp.getElementsByFlavor(XACML_POLICY_EPISODE);
               for (MediaPackageElement distributedEpisodeAcl : distributedEpisodeAcls) {
-                distributionService.retractSync(CHANNEL_ID, mp, distributedEpisodeAcl.getIdentifier());
+                downloadDistributionService.retractSync(CHANNEL_ID, mp, distributedEpisodeAcl.getIdentifier());
                 authorizationService.removeAcl(mp, AclScope.Episode);
               }
             }
@@ -202,8 +216,8 @@ public class SearchUpdatedEventHandler {
             Attachment fileRepoCopy = authorizationService.setAcl(mp, AclScope.Series, seriesItem.getAcl()).getB();
 
             // Distribute the updated XACML file
-            List<MediaPackageElement> mpes = distributionService.distributeSync(CHANNEL_ID, mp,
-                fileRepoCopy.getIdentifier());
+            List<MediaPackageElement> mpes = downloadDistributionService.distributeSync(CHANNEL_ID, mp,
+                fileRepoCopy.getIdentifier(), checkAvailability);
             if (mpes != null && mpes.size() == 1) {
               mp.remove(fileRepoCopy);
               mp.add(mpes.getFirst());
@@ -235,7 +249,7 @@ public class SearchUpdatedEventHandler {
               c.setChecksum(null);
 
               // Distribute the updated series dc
-              List<MediaPackageElement> mpes = distributionService.distributeSync(CHANNEL_ID, mp, c.getIdentifier());
+              List<MediaPackageElement> mpes = downloadDistributionService.distributeSync(CHANNEL_ID, mp, c.getIdentifier(), checkAvailability);
               if (mpes != null && mpes.size() == 1) {
                 mp.remove(c);
                 mp.add(mpes.getFirst());
@@ -258,7 +272,7 @@ public class SearchUpdatedEventHandler {
 
             // retract the series catalog
             for (Catalog c : mp.getCatalogs(MediaPackageElements.SERIES)) {
-              distributionService.retractSync(CHANNEL_ID, mp, c.getIdentifier());
+              downloadDistributionService.retractSync(CHANNEL_ID, mp, c.getIdentifier());
               mp.remove(c);
             }
 
@@ -274,8 +288,8 @@ public class SearchUpdatedEventHandler {
               episodeCatalog.setChecksum(null);
 
               // Distribute the updated episode dublincore
-              List<MediaPackageElement> mpes = distributionService.distributeSync(CHANNEL_ID, mp,
-                  episodeCatalog.getIdentifier());
+              List<MediaPackageElement> mpes = downloadDistributionService.distributeSync(CHANNEL_ID, mp,
+                  episodeCatalog.getIdentifier(), checkAvailability);
 
               if (mpes != null && mpes.size() == 1) {
                 mp.remove(episodeCatalog);

--- a/modules/conductor/src/main/java/org/opencastproject/event/handler/SearchUpdatedEventHandler.java
+++ b/modules/conductor/src/main/java/org/opencastproject/event/handler/SearchUpdatedEventHandler.java
@@ -99,9 +99,6 @@ public class SearchUpdatedEventHandler {
   /** The authorization service */
   protected AuthorizationService authorizationService = null;
 
-  /** The organization directory */
-  protected OrganizationDirectoryService organizationDirectoryService = null;
-
   /** Dublin core catalog service */
   protected DublinCoreCatalogService dublinCoreService = null;
 
@@ -183,15 +180,6 @@ public class SearchUpdatedEventHandler {
   @Reference
   public void setAuthorizationService(AuthorizationService authorizationService) {
     this.authorizationService = authorizationService;
-  }
-
-  /**
-   * @param organizationDirectoryService
-   *          the organizationDirectoryService to set
-   */
-  @Reference
-  public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
-    this.organizationDirectoryService = organizationDirectoryService;
   }
 
   public void handleEvent(final SeriesItem seriesItem) {

--- a/modules/conductor/src/main/java/org/opencastproject/event/handler/SearchUpdatedEventHandler.java
+++ b/modules/conductor/src/main/java/org/opencastproject/event/handler/SearchUpdatedEventHandler.java
@@ -84,9 +84,6 @@ public class SearchUpdatedEventHandler {
   /** The logger */
   protected static final Logger logger = LoggerFactory.getLogger(SearchUpdatedEventHandler.class);
 
-  /** The service registry */
-  protected ServiceRegistry serviceRegistry = null;
-
   /** The distribution service */
   protected DistributionService distributionService = null;
 
@@ -117,15 +114,6 @@ public class SearchUpdatedEventHandler {
   @Activate
   protected void activate(BundleContext bundleContext) {
     this.systemAccount = bundleContext.getProperty("org.opencastproject.security.digest.user");
-  }
-
-  /**
-   * @param serviceRegistry
-   *          the serviceRegistry to set
-   */
-  @Reference
-  public void setServiceRegistry(ServiceRegistry serviceRegistry) {
-    this.serviceRegistry = serviceRegistry;
   }
 
   /**
@@ -201,135 +189,130 @@ public class SearchUpdatedEventHandler {
         // If the security policy has been updated, make sure to distribute that change
         // to the distribution channels as well
         if (SeriesItem.Type.UpdateAcl.equals(seriesItem.getType())) {
-          if (Boolean.TRUE.equals(seriesItem.getOverrideEpisodeAcl())) {
+          try {
+            if (Boolean.TRUE.equals(seriesItem.getOverrideEpisodeAcl())) {
 
-            MediaPackageElement[] distributedEpisodeAcls = mp.getElementsByFlavor(XACML_POLICY_EPISODE);
-            for (MediaPackageElement distributedEpisodeAcl : distributedEpisodeAcls) {
-              List<MediaPackageElement> mpes = distributionService.retractSync(CHANNEL_ID, mp,
-                      distributedEpisodeAcl.getIdentifier());
-              if (mpes == null) {
-                logger.error("Unable to retract episode XACML {}", distributedEpisodeAcl.getIdentifier());
-              } else {
+              MediaPackageElement[] distributedEpisodeAcls = mp.getElementsByFlavor(XACML_POLICY_EPISODE);
+              for (MediaPackageElement distributedEpisodeAcl : distributedEpisodeAcls) {
+                distributionService.retractSync(CHANNEL_ID, mp, distributedEpisodeAcl.getIdentifier());
                 authorizationService.removeAcl(mp, AclScope.Episode);
               }
             }
-          }
 
-          Attachment fileRepoCopy = authorizationService.setAcl(mp, AclScope.Series, seriesItem.getAcl()).getB();
+            Attachment fileRepoCopy = authorizationService.setAcl(mp, AclScope.Series, seriesItem.getAcl()).getB();
 
-          // Distribute the updated XACML file
-          List<MediaPackageElement> mpes = distributionService.distributeSync(CHANNEL_ID, mp,
-                  fileRepoCopy.getIdentifier());
-          if (mpes != null && mpes.size() == 1) {
-            mp.remove(fileRepoCopy);
-            mp.add(mpes.get(0));
-          } else {
-            logger.error("Unable to distribute series XACML {}", fileRepoCopy.getIdentifier());
+            // Distribute the updated XACML file
+            List<MediaPackageElement> mpes = distributionService.distributeSync(CHANNEL_ID, mp,
+                fileRepoCopy.getIdentifier());
+            if (mpes != null && mpes.size() == 1) {
+              mp.remove(fileRepoCopy);
+              mp.add(mpes.getFirst());
+            } else {
+              throw new DistributionException("Unable to distribute series XACML " + fileRepoCopy.getIdentifier());
+            }
+          } catch (DistributionException | MediaPackageException e) {
+            logger.error("Could not update series ACL in search for event {} of series {}", mp.getIdentifier(),
+                seriesId, e);
             continue;
           }
         }
 
         // Update the series dublin core
         if (SeriesItem.Type.UpdateCatalog.equals(seriesItem.getType())) {
-          DublinCoreCatalog seriesDublinCore = seriesItem.getMetadata();
-          mp.setSeriesTitle(seriesDublinCore.getFirst(DublinCore.PROPERTY_TITLE));
+          try {
+            DublinCoreCatalog seriesDublinCore = seriesItem.getMetadata();
+            mp.setSeriesTitle(seriesDublinCore.getFirst(DublinCore.PROPERTY_TITLE));
 
-          // Update the series dublin core
-          Catalog[] seriesCatalogs = mp.getCatalogs(MediaPackageElements.SERIES);
-          if (seriesCatalogs.length == 1) {
-            Catalog c = seriesCatalogs[0];
-            String filename = FilenameUtils.getName(c.getURI().toString());
-            URI uri = workspace.put(mp.getIdentifier().toString(), c.getIdentifier(), filename,
-                    dublinCoreService.serialize(seriesDublinCore));
-            c.setURI(uri);
-            // setting the URI to a new source so the checksum will most like be invalid
-            c.setChecksum(null);
+            // Update the series dublin core
+            Catalog[] seriesCatalogs = mp.getCatalogs(MediaPackageElements.SERIES);
+            if (seriesCatalogs.length == 1) {
+              Catalog c = seriesCatalogs[0];
+              String filename = FilenameUtils.getName(c.getURI().toString());
+              URI uri = workspace.put(mp.getIdentifier().toString(), c.getIdentifier(), filename,
+                  dublinCoreService.serialize(seriesDublinCore));
+              c.setURI(uri);
+              // setting the URI to a new source so the checksum will most like be invalid
+              c.setChecksum(null);
 
-            // Distribute the updated series dc
-            List<MediaPackageElement> mpes = distributionService.distributeSync(CHANNEL_ID, mp, c.getIdentifier());
-            if (mpes != null && mpes.size() == 1) {
-              mp.remove(c);
-              mp.add(mpes.get(0));
-            } else {
-              logger.error("Unable to distribute series catalog {}", c.getIdentifier());
-              continue;
+              // Distribute the updated series dc
+              List<MediaPackageElement> mpes = distributionService.distributeSync(CHANNEL_ID, mp, c.getIdentifier());
+              if (mpes != null && mpes.size() == 1) {
+                mp.remove(c);
+                mp.add(mpes.getFirst());
+              } else {
+                throw new DistributionException("Unable to distribute series catalog " + c.getIdentifier());
+              }
             }
+          } catch (DistributionException | IOException | MediaPackageException e) {
+            logger.error("Could not update series catalog in search for event {} of series {}", mp.getIdentifier(),
+                seriesId, e);
+            continue;
           }
         }
 
         // Remove the series catalog and isPartOf from episode catalog
         if (SeriesItem.Type.Delete.equals(seriesItem.getType())) {
-          mp.setSeries(null);
-          mp.setSeriesTitle(null);
+          try {
+            mp.setSeries(null);
+            mp.setSeriesTitle(null);
 
-          boolean retractSeriesCatalog = retractSeriesCatalog(mp);
-          boolean updateEpisodeCatalog = updateEpisodeCatalog(mp);
+            // retract the series catalog
+            for (Catalog c : mp.getCatalogs(MediaPackageElements.SERIES)) {
+              distributionService.retractSync(CHANNEL_ID, mp, c.getIdentifier());
+              mp.remove(c);
+            }
 
-          if (!retractSeriesCatalog || !updateEpisodeCatalog) {
+            // update episode catalog
+            for (Catalog episodeCatalog : mp.getCatalogs(MediaPackageElements.EPISODE)) {
+              DublinCoreCatalog episodeDublinCore = DublinCoreUtil.loadDublinCore(workspace, episodeCatalog);
+              episodeDublinCore.remove(DublinCore.PROPERTY_IS_PART_OF);
+              String filename = FilenameUtils.getName(episodeCatalog.getURI().toString());
+              URI uri = workspace.put(mp.getIdentifier().toString(), episodeCatalog.getIdentifier(), filename,
+                  dublinCoreService.serialize(episodeDublinCore));
+              episodeCatalog.setURI(uri);
+              // setting the URI to a new source so the checksum will most like be invalid
+              episodeCatalog.setChecksum(null);
+
+              // Distribute the updated episode dublincore
+              List<MediaPackageElement> mpes = distributionService.distributeSync(CHANNEL_ID, mp,
+                  episodeCatalog.getIdentifier());
+
+              if (mpes != null && mpes.size() == 1) {
+                mp.remove(episodeCatalog);
+                mp.add(mpes.getFirst());
+              } else {
+                throw new DistributionException(
+                    "Unable to distribute episode catalog " + episodeCatalog.getIdentifier());
+              }
+            }
+          } catch (DistributionException | IOException | MediaPackageException e) {
+            logger.error("Could remove series {} from search for event {}", seriesId, mp.getIdentifier(), e);
             continue;
           }
         }
 
         // Update the search index with the modified mediapackage
-        searchService.addSynchronously(mp);
+        try {
+          searchService.addSynchronously(mp);
+        } catch (SearchException e) {
+          logger.error("Unable to update media package {} in search for series {}", mp.getIdentifier(), seriesId, e);
+        }
       }
       //We remove the episode->series links above, which effectively orphaned the series in the index, now we remove it
       if (SeriesItem.Type.Delete.equals(seriesItem.getType())) {
-        searchService.deleteSeries(seriesId);
+        try {
+          searchService.deleteSeries(seriesId);
+        } catch (NotFoundException e) {
+          // that's fine
+        } catch (SearchException e) {
+          logger.error("Could not delete series {} from search", seriesId, e);
+        }
       }
-    } catch (SearchException e) {
-      logger.warn("Unable to find mediapackages for series {} in search: {}", seriesItem, e.getMessage());
-    } catch (UnauthorizedException | MediaPackageException | ServiceRegistryException
-             | NotFoundException | IOException | DistributionException e) {
-      logger.warn("Unable to update mediapackages for series {} for user {}: {} {}",
-                  seriesId, prevUser.getUsername(), e.getClass().getSimpleName(), e.getMessage());
+    } catch (UnauthorizedException e) {
+      logger.error("Unoauthorized for system user - this should never happen!");
     } finally {
       securityService.setOrganization(prevOrg);
       securityService.setUser(prevUser);
     }
-  }
-
-  private boolean retractSeriesCatalog(MediaPackage mp) throws DistributionException {
-    // Retract the series catalog
-    for (Catalog c : mp.getCatalogs(MediaPackageElements.SERIES)) {
-      Job retractJob = distributionService.retract(CHANNEL_ID, mp, c.getIdentifier());
-      JobBarrier barrier = new JobBarrier(null, serviceRegistry, retractJob);
-      Result jobResult = barrier.waitForJobs();
-      if (jobResult.getStatus().get(retractJob).equals(FINISHED)) {
-        mp.remove(c);
-      } else {
-        logger.error("Unable to retract series catalog {}", c.getIdentifier());
-        return false;
-      }
-    }
-    return true;
-  }
-
-  private boolean updateEpisodeCatalog(MediaPackage mp) throws DistributionException, MediaPackageException,
-          NotFoundException, ServiceRegistryException, IllegalArgumentException, IOException {
-    // Update the episode catalog
-    for (Catalog episodeCatalog : mp.getCatalogs(MediaPackageElements.EPISODE)) {
-      DublinCoreCatalog episodeDublinCore = DublinCoreUtil.loadDublinCore(workspace, episodeCatalog);
-      episodeDublinCore.remove(DublinCore.PROPERTY_IS_PART_OF);
-      String filename = FilenameUtils.getName(episodeCatalog.getURI().toString());
-      URI uri = workspace.put(mp.getIdentifier().toString(), episodeCatalog.getIdentifier(), filename,
-              dublinCoreService.serialize(episodeDublinCore));
-      episodeCatalog.setURI(uri);
-      // setting the URI to a new source so the checksum will most like be invalid
-      episodeCatalog.setChecksum(null);
-
-      // Distribute the updated episode dublincore
-      Job distributionJob = distributionService.distribute(CHANNEL_ID, mp, episodeCatalog.getIdentifier());
-      JobBarrier barrier = new JobBarrier(null, serviceRegistry, distributionJob);
-      Result jobResult = barrier.waitForJobs();
-      if (jobResult.getStatus().get(distributionJob).equals(FINISHED)) {
-        mp.remove(episodeCatalog);
-        mp.add(getFromXml(serviceRegistry.getJob(distributionJob.getId()).getPayload()));
-      } else {
-        logger.error("Unable to distribute episode catalog {}", episodeCatalog.getIdentifier());
-        return false;
-      }
-    }
-    return true;
   }
 }

--- a/modules/conductor/src/main/java/org/opencastproject/event/handler/SearchUpdatedEventHandler.java
+++ b/modules/conductor/src/main/java/org/opencastproject/event/handler/SearchUpdatedEventHandler.java
@@ -257,7 +257,7 @@ public class SearchUpdatedEventHandler {
                 throw new DistributionException("Unable to distribute series catalog " + c.getIdentifier());
               }
             }
-          } catch (DistributionException | IOException | MediaPackageException e) {
+          } catch (DistributionException | IOException e) {
             logger.error("Could not update series catalog in search for event {} of series {}", mp.getIdentifier(),
                 seriesId, e);
             continue;
@@ -299,7 +299,7 @@ public class SearchUpdatedEventHandler {
                     "Unable to distribute episode catalog " + episodeCatalog.getIdentifier());
               }
             }
-          } catch (DistributionException | IOException | MediaPackageException e) {
+          } catch (DistributionException | IOException e) {
             logger.error("Could remove series {} from search for event {}", seriesId, mp.getIdentifier(), e);
             continue;
           }

--- a/modules/conductor/src/main/java/org/opencastproject/event/handler/SearchUpdatedEventHandler.java
+++ b/modules/conductor/src/main/java/org/opencastproject/event/handler/SearchUpdatedEventHandler.java
@@ -21,19 +21,13 @@
 
 package org.opencastproject.event.handler;
 
-import static org.opencastproject.job.api.Job.Status.FINISHED;
-import static org.opencastproject.mediapackage.MediaPackageElementParser.getFromXml;
 import static org.opencastproject.mediapackage.MediaPackageElements.XACML_POLICY_EPISODE;
 import static org.opencastproject.workflow.handler.distribution.EngagePublicationChannel.CHANNEL_ID;
 
 import org.opencastproject.distribution.api.DistributionException;
-import org.opencastproject.distribution.api.DistributionService;
-import org.opencastproject.job.api.Job;
-import org.opencastproject.job.api.JobBarrier;
-import org.opencastproject.job.api.JobBarrier.Result;
+import org.opencastproject.distribution.api.DownloadDistributionService;
 import org.opencastproject.mediapackage.Attachment;
 import org.opencastproject.mediapackage.Catalog;
-import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElement;
 import org.opencastproject.mediapackage.MediaPackageElements;
 import org.opencastproject.mediapackage.MediaPackageException;
@@ -47,20 +41,19 @@ import org.opencastproject.search.api.SearchService;
 import org.opencastproject.security.api.AclScope;
 import org.opencastproject.security.api.AuthorizationService;
 import org.opencastproject.security.api.Organization;
-import org.opencastproject.security.api.OrganizationDirectoryService;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.security.api.User;
 import org.opencastproject.security.util.SecurityUtil;
-import org.opencastproject.serviceregistry.api.ServiceRegistry;
-import org.opencastproject.serviceregistry.api.ServiceRegistryException;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.workspace.api.Workspace;
 
 import org.apache.commons.io.FilenameUtils;
-import org.osgi.framework.BundleContext;
+import org.apache.commons.lang3.BooleanUtils;
+import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,6 +61,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
+import java.util.Objects;
 
 /** Responds to series events by re-distributing metadata and security policy files for published mediapackages. */
 @Component(
@@ -185,7 +179,7 @@ public class SearchUpdatedEventHandler {
   }
 
   public void handleEvent(final SeriesItem seriesItem) {
-    // A series or its ACL has been updated. Find any mediapackages with that series, and update them.
+    // A series or its ACL has been updated. Find any media packages with that series, and update them.
     logger.debug("Handling {}", seriesItem);
     String seriesId = seriesItem.getSeriesId();
 
@@ -249,7 +243,8 @@ public class SearchUpdatedEventHandler {
               c.setChecksum(null);
 
               // Distribute the updated series dc
-              List<MediaPackageElement> mpes = downloadDistributionService.distributeSync(CHANNEL_ID, mp, c.getIdentifier(), checkAvailability);
+              List<MediaPackageElement> mpes = downloadDistributionService.distributeSync(
+                  CHANNEL_ID, mp, c.getIdentifier(), checkAvailability);
               if (mpes != null && mpes.size() == 1) {
                 mp.remove(c);
                 mp.add(mpes.getFirst());

--- a/modules/distribution-service-api/src/main/java/org/opencastproject/distribution/api/DistributionService.java
+++ b/modules/distribution-service-api/src/main/java/org/opencastproject/distribution/api/DistributionService.java
@@ -24,7 +24,6 @@ package org.opencastproject.distribution.api;
 import org.opencastproject.job.api.Job;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElement;
-import org.opencastproject.mediapackage.MediaPackageException;
 
 import java.util.List;
 
@@ -51,11 +50,9 @@ public interface DistributionService {
    * @return The job
    * @throws DistributionException
    *           if there was a problem distributing the media
-   * @throws MediaPackageException
-   *           if there was a problem with the mediapackage element
    */
   Job distribute(String channelId, MediaPackage mediapackage, String elementId)
-          throws DistributionException, MediaPackageException;
+          throws DistributionException;
 
   /**
    * Distributes a media package element synchronously, bypassing the Opencast job system.
@@ -68,11 +65,9 @@ public interface DistributionService {
    * @return list of distributed media package elements
    * @throws DistributionException
    *           if there was a problem distributing the media
-   * @throws MediaPackageException
-   *           if there was a problem with the mediapackage element
    */
   List<MediaPackageElement> distributeSync(String channelId, MediaPackage mediapackage, String elementId)
-          throws DistributionException, MediaPackageException;
+          throws DistributionException;
 
   /**
    * Retract a media package element from the distribution channel.
@@ -98,7 +93,7 @@ public interface DistributionService {
    *           if there was a problem retracting the mediapackage
    */
   List<MediaPackageElement> retractSync(String channelId, MediaPackage mediaPackage, String elementId)
-          throws DistributionException, MediaPackageException;
+          throws DistributionException;
 
   /**
    * Returns the distribution type for this service.

--- a/modules/distribution-service-api/src/main/java/org/opencastproject/distribution/api/DownloadDistributionService.java
+++ b/modules/distribution-service-api/src/main/java/org/opencastproject/distribution/api/DownloadDistributionService.java
@@ -51,8 +51,7 @@ public interface DownloadDistributionService extends DistributionService {
           throws DistributionException;
 
   List<MediaPackageElement> distributeSync(String channelId, MediaPackage mediapackage, String elementId,
-      boolean checkAvailability)
-          throws DistributionException;
+      boolean checkAvailability) throws DistributionException;
 
   /**
    * Distributes the given elements synchronously. This should be used rarely since load balancing will be unavailable.

--- a/modules/distribution-service-api/src/main/java/org/opencastproject/distribution/api/DownloadDistributionService.java
+++ b/modules/distribution-service-api/src/main/java/org/opencastproject/distribution/api/DownloadDistributionService.java
@@ -24,7 +24,6 @@ package org.opencastproject.distribution.api;
 import org.opencastproject.job.api.Job;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElement;
-import org.opencastproject.mediapackage.MediaPackageException;
 
 import java.util.List;
 import java.util.Set;
@@ -35,10 +34,10 @@ import java.util.Set;
 public interface DownloadDistributionService extends DistributionService {
 
   Job distribute(String channelId, MediaPackage mediapackage, String elementId, boolean checkAvailability)
-          throws DistributionException, MediaPackageException;
+          throws DistributionException;
 
   Job distribute(String channelId, MediaPackage mediapackage, Set<String> elementIds, boolean checkAvailability)
-          throws DistributionException, MediaPackageException;
+          throws DistributionException;
 
   Job distribute(
       String pubChannelId,
@@ -46,14 +45,14 @@ public interface DownloadDistributionService extends DistributionService {
       Set<String> downloadIds,
       boolean checkAvailability,
       boolean preserveReference
-  ) throws DistributionException, MediaPackageException;
+  ) throws DistributionException;
 
   Job retract(String channelId, MediaPackage mediaPackage, Set<String> elementIds)
           throws DistributionException;
 
   List<MediaPackageElement> distributeSync(String channelId, MediaPackage mediapackage, String elementId,
       boolean checkAvailability)
-      throws DistributionException, MediaPackageException;
+          throws DistributionException;
 
   /**
    * Distributes the given elements synchronously. This should be used rarely since load balancing will be unavailable.
@@ -74,7 +73,7 @@ public interface DownloadDistributionService extends DistributionService {
       MediaPackage mediapackage,
       Set<String> elementIds,
       boolean checkAvailability
-  ) throws DistributionException, MediaPackageException;
+  ) throws DistributionException;
 
   /**
    * Retracts the given elements synchronously. This should be used rarely since load balancing will be unavailable.

--- a/modules/distribution-service-api/src/main/java/org/opencastproject/distribution/api/DownloadDistributionService.java
+++ b/modules/distribution-service-api/src/main/java/org/opencastproject/distribution/api/DownloadDistributionService.java
@@ -51,6 +51,10 @@ public interface DownloadDistributionService extends DistributionService {
   Job retract(String channelId, MediaPackage mediaPackage, Set<String> elementIds)
           throws DistributionException;
 
+  List<MediaPackageElement> distributeSync(String channelId, MediaPackage mediapackage, String elementId,
+      boolean checkAvailability)
+      throws DistributionException, MediaPackageException;
+
   /**
    * Distributes the given elements synchronously. This should be used rarely since load balancing will be unavailable.
    * However, since the dispatching logic is bypassed, synchronous execution is much faster. It is useful in interactive
@@ -70,7 +74,7 @@ public interface DownloadDistributionService extends DistributionService {
       MediaPackage mediapackage,
       Set<String> elementIds,
       boolean checkAvailability
-  ) throws DistributionException;
+  ) throws DistributionException, MediaPackageException;
 
   /**
    * Retracts the given elements synchronously. This should be used rarely since load balancing will be unavailable.

--- a/modules/distribution-service-api/src/main/java/org/opencastproject/distribution/api/StreamingDistributionService.java
+++ b/modules/distribution-service-api/src/main/java/org/opencastproject/distribution/api/StreamingDistributionService.java
@@ -24,7 +24,6 @@ package org.opencastproject.distribution.api;
 import org.opencastproject.job.api.Job;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElement;
-import org.opencastproject.mediapackage.MediaPackageException;
 
 import java.util.List;
 import java.util.Set;
@@ -42,7 +41,7 @@ public interface StreamingDistributionService extends DistributionService {
   boolean publishToStreaming();
 
   Job distribute(String channelId, MediaPackage mediapackage, Set<String> elementIds)
-          throws DistributionException, MediaPackageException;
+          throws DistributionException;
 
   Job retract(String channelId, MediaPackage mediaPackage, Set<String> elementIds)
           throws DistributionException;

--- a/modules/distribution-service-aws-s3-remote/src/main/java/org/opencastproject/distribution/aws/s3/remote/AwsS3DistributionServiceRemoteImpl.java
+++ b/modules/distribution-service-aws-s3-remote/src/main/java/org/opencastproject/distribution/aws/s3/remote/AwsS3DistributionServiceRemoteImpl.java
@@ -31,7 +31,6 @@ import org.opencastproject.distribution.aws.s3.api.AwsS3DistributionService;
 import org.opencastproject.job.api.Job;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElement;
-import org.opencastproject.mediapackage.MediaPackageException;
 import org.opencastproject.mediapackage.MediaPackageParser;
 import org.opencastproject.security.api.TrustedHttpClient;
 import org.opencastproject.serviceregistry.api.RemoteBase;
@@ -213,7 +212,7 @@ public class AwsS3DistributionServiceRemoteImpl extends RemoteBase implements Aw
 
   @Override
   public Job distribute(String pubChannelId, MediaPackage mediaPackage, Set<String> downloadIds,
-      boolean checkAvailability, boolean preserveReference) throws DistributionException, MediaPackageException {
+      boolean checkAvailability, boolean preserveReference) throws DistributionException {
     throw new UnsupportedOperationException("Not supported yet.");
   //stub function
   }

--- a/modules/distribution-service-aws-s3-remote/src/main/java/org/opencastproject/distribution/aws/s3/remote/AwsS3DistributionServiceRemoteImpl.java
+++ b/modules/distribution-service-aws-s3-remote/src/main/java/org/opencastproject/distribution/aws/s3/remote/AwsS3DistributionServiceRemoteImpl.java
@@ -154,6 +154,14 @@ public class AwsS3DistributionServiceRemoteImpl extends RemoteBase implements Aw
   }
 
   @Override
+  public List<MediaPackageElement> distributeSync(String channelId, MediaPackage mediapackage, String elementId,
+      boolean checkAvailability) throws DistributionException {
+    Set<String> elementIds = new HashSet<String>();
+    elementIds.add(elementId);
+    return distributeSync(channelId, mediapackage, elementIds, checkAvailability);
+  }
+
+  @Override
   public List<MediaPackageElement>  distributeSync(String channelId, MediaPackage mediaPackage, String elementId)
           throws DistributionException {
     Set<String> elementIds = new HashSet<String>();

--- a/modules/distribution-service-aws-s3/src/main/java/org/opencastproject/distribution/aws/s3/AwsS3DistributionServiceImpl.java
+++ b/modules/distribution-service-aws-s3/src/main/java/org/opencastproject/distribution/aws/s3/AwsS3DistributionServiceImpl.java
@@ -387,7 +387,7 @@ public class AwsS3DistributionServiceImpl extends AbstractDistributionService
 
   @Override
   public Job distribute(String pubChannelId, MediaPackage mediaPackage, Set<String> downloadIds,
-          boolean checkAvailability, boolean preserveReference) throws DistributionException, MediaPackageException {
+          boolean checkAvailability, boolean preserveReference) throws DistributionException {
     throw new UnsupportedOperationException("Not supported yet.");
     // stub function
   }
@@ -400,7 +400,7 @@ public class AwsS3DistributionServiceImpl extends AbstractDistributionService
    */
   @Override
   public Job distribute(String channelId, MediaPackage mediaPackage, Set<String> elementIds, boolean checkAvailability)
-          throws DistributionException, MediaPackageException {
+          throws DistributionException {
     notNull(mediaPackage, "mediapackage");
     notNull(elementIds, "elementIds");
     notNull(channelId, "channelId");
@@ -421,7 +421,7 @@ public class AwsS3DistributionServiceImpl extends AbstractDistributionService
    */
   @Override
   public Job distribute(String channelId, MediaPackage mediapackage, String elementId)
-          throws DistributionException, MediaPackageException {
+          throws DistributionException {
     return distribute(channelId, mediapackage, elementId, true);
   }
 
@@ -433,7 +433,7 @@ public class AwsS3DistributionServiceImpl extends AbstractDistributionService
    */
   @Override
   public Job distribute(String channelId, MediaPackage mediaPackage, String elementId, boolean checkAvailability)
-          throws DistributionException, MediaPackageException {
+          throws DistributionException {
     Set<String> elementIds = new HashSet<>();
     elementIds.add(elementId);
     return distribute(channelId, mediaPackage, elementIds, checkAvailability);
@@ -624,8 +624,16 @@ public class AwsS3DistributionServiceImpl extends AbstractDistributionService
   }
 
   @Override
+  public List<MediaPackageElement> distributeSync(String channelId, MediaPackage mediapackage, String elementId,
+      boolean checkAvailability) throws DistributionException {
+    Set<String> elementIds = new HashSet<String>();
+    elementIds.add(elementId);
+    return distributeSync(channelId, mediapackage, elementIds, checkAvailability);
+  }
+
+  @Override
   public List<MediaPackageElement> distributeSync(String channelId, MediaPackage mediapackage, String elementId)
-          throws DistributionException, MediaPackageException {
+          throws DistributionException {
     Set<String> elementIds = new HashSet<String>();
     elementIds.add(elementId);
     return distributeSync(channelId, mediapackage, elementIds, true);

--- a/modules/distribution-service-download-remote/src/main/java/org/opencastproject/distribution/download/remote/DownloadDistributionServiceRemoteImpl.java
+++ b/modules/distribution-service-download-remote/src/main/java/org/opencastproject/distribution/download/remote/DownloadDistributionServiceRemoteImpl.java
@@ -31,7 +31,6 @@ import org.opencastproject.distribution.api.DownloadDistributionService;
 import org.opencastproject.job.api.Job;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElement;
-import org.opencastproject.mediapackage.MediaPackageException;
 import org.opencastproject.mediapackage.MediaPackageParser;
 import org.opencastproject.security.api.TrustedHttpClient;
 import org.opencastproject.serviceregistry.api.RemoteBase;
@@ -167,7 +166,7 @@ public class DownloadDistributionServiceRemoteImpl extends RemoteBase
 
   @Override
   public List<MediaPackageElement> distributeSync(String channelId, MediaPackage mediapackage, String elementId)
-          throws DistributionException, MediaPackageException {
+          throws DistributionException {
     Set<String> elementIds = new HashSet<String>();
     elementIds.add(elementId);
     return distributeSync(channelId, mediapackage, elementIds, true);

--- a/modules/distribution-service-download-remote/src/main/java/org/opencastproject/distribution/download/remote/DownloadDistributionServiceRemoteImpl.java
+++ b/modules/distribution-service-download-remote/src/main/java/org/opencastproject/distribution/download/remote/DownloadDistributionServiceRemoteImpl.java
@@ -158,6 +158,14 @@ public class DownloadDistributionServiceRemoteImpl extends RemoteBase
   }
 
   @Override
+  public List<MediaPackageElement> distributeSync(String channelId, MediaPackage mediapackage, String elementId,
+      boolean checkAvailability) throws DistributionException {
+    Set<String> elementIds = new HashSet<String>();
+    elementIds.add(elementId);
+    return distributeSync(channelId, mediapackage, elementIds, checkAvailability);
+  }
+
+  @Override
   public List<MediaPackageElement> distributeSync(String channelId, MediaPackage mediapackage, String elementId)
           throws DistributionException, MediaPackageException {
     Set<String> elementIds = new HashSet<String>();

--- a/modules/distribution-service-download/src/main/java/org/opencastproject/distribution/download/DownloadDistributionServiceImpl.java
+++ b/modules/distribution-service-download/src/main/java/org/opencastproject/distribution/download/DownloadDistributionServiceImpl.java
@@ -545,43 +545,36 @@ public class DownloadDistributionServiceImpl extends AbstractDistributionService
     return distributeSync(channelId, mediapackage, elementIds, true, false);
   }
 
+  @Override
+  public List<MediaPackageElement> distributeSync(String channelId, MediaPackage mediapackage, String elementId,
+      boolean checkAvailability)
+      throws DistributionException, MediaPackageException {
+    Set<String> elementIds = new HashSet<String>();
+    elementIds.add(elementId);
+    return distributeSync(channelId, mediapackage, elementIds, checkAvailability, false);
+  }
+
+  @Override
+  public List<MediaPackageElement> distributeSync(String channelId, MediaPackage mediapackage, Set<String> elementIds,
+                                                  boolean checkAvailability)
+      throws DistributionException, MediaPackageException {
+    return distributeSync(channelId, mediapackage, elementIds, checkAvailability, false);
+  }
+
   public List<MediaPackageElement> distributeSync(
-          String channelId,
-          MediaPackage mediapackage,
-          Set<String> elementIds,
-          boolean checkAvailability,
-          boolean preserveReference
+      String channelId,
+      MediaPackage mediapackage,
+      Set<String> elementIds,
+      boolean checkAvailability,
+      boolean preserveReference
   ) throws DistributionException, MediaPackageException {
     notNull(mediapackage, "mediapackage");
     notNull(elementIds, "elementIds");
     notNull(channelId, "channelId");
 
     MediaPackageElement[] distributedElements = distributeElements(channelId, mediapackage, elementIds,
-            checkAvailability, preserveReference);
+        checkAvailability, preserveReference);
     return Arrays.asList(distributedElements);
-  }
-
-  @Override
-  public List<MediaPackageElement> distributeSync(String channelId, MediaPackage mediapackage, Set<String> elementIds,
-                                                  boolean checkAvailability) throws DistributionException {
-    Job job = null;
-    try {
-      job = serviceRegistry
-          .createJob(
-              JOB_TYPE, Operation.Distribute.toString(), null, null, false, distributeJobLoad);
-      job.setStatus(Job.Status.RUNNING);
-      job = serviceRegistry.updateJob(job);
-      final MediaPackageElement[] mediaPackageElements
-          = this.distributeElements(channelId, mediapackage, elementIds, checkAvailability);
-      job.setStatus(Job.Status.FINISHED);
-      return Arrays.asList(mediaPackageElements);
-    } catch (ServiceRegistryException e) {
-      throw new DistributionException(e);
-    } catch (NotFoundException e) {
-      throw new DistributionException("Unable to update distribution job", e);
-    } finally {
-      finallyUpdateJob(job);
-    }
   }
 
   @Override

--- a/modules/distribution-service-download/src/main/java/org/opencastproject/distribution/download/DownloadDistributionServiceImpl.java
+++ b/modules/distribution-service-download/src/main/java/org/opencastproject/distribution/download/DownloadDistributionServiceImpl.java
@@ -191,13 +191,13 @@ public class DownloadDistributionServiceImpl extends AbstractDistributionService
 
   @Override
   public Job distribute(String channelId, MediaPackage mediapackage, String elementId)
-          throws DistributionException, MediaPackageException {
+          throws DistributionException {
     return distribute(channelId, mediapackage, elementId, true);
   }
 
   @Override
   public Job distribute(String channelId, MediaPackage mediapackage, String elementId, boolean checkAvailability)
-          throws DistributionException, MediaPackageException {
+          throws DistributionException {
     Set<String> elementIds = new HashSet<String>();
     elementIds.add(elementId);
     return distribute(channelId, mediapackage, elementIds, checkAvailability, false);
@@ -205,7 +205,7 @@ public class DownloadDistributionServiceImpl extends AbstractDistributionService
 
   @Override
   public Job distribute(String channelId, MediaPackage mediapackage, Set<String> elementIds, boolean checkAvailability)
-          throws DistributionException, MediaPackageException {
+          throws DistributionException {
     return distribute(channelId, mediapackage, elementIds, checkAvailability, false);
   }
 
@@ -216,7 +216,7 @@ public class DownloadDistributionServiceImpl extends AbstractDistributionService
       Set<String> elementIds,
       boolean checkAvailability,
       boolean preserveReference
-  ) throws DistributionException, MediaPackageException {
+  ) throws DistributionException {
     notNull(mediapackage, "mediapackage");
     notNull(elementIds, "elementIds");
     notNull(channelId, "channelId");
@@ -539,7 +539,7 @@ public class DownloadDistributionServiceImpl extends AbstractDistributionService
 
   @Override
   public List<MediaPackageElement> distributeSync(String channelId, MediaPackage mediapackage, String elementId)
-          throws DistributionException, MediaPackageException {
+          throws DistributionException {
     Set<String> elementIds = new HashSet<String>();
     elementIds.add(elementId);
     return distributeSync(channelId, mediapackage, elementIds, true, false);
@@ -548,7 +548,7 @@ public class DownloadDistributionServiceImpl extends AbstractDistributionService
   @Override
   public List<MediaPackageElement> distributeSync(String channelId, MediaPackage mediapackage, String elementId,
       boolean checkAvailability)
-      throws DistributionException, MediaPackageException {
+          throws DistributionException {
     Set<String> elementIds = new HashSet<String>();
     elementIds.add(elementId);
     return distributeSync(channelId, mediapackage, elementIds, checkAvailability, false);
@@ -557,7 +557,7 @@ public class DownloadDistributionServiceImpl extends AbstractDistributionService
   @Override
   public List<MediaPackageElement> distributeSync(String channelId, MediaPackage mediapackage, Set<String> elementIds,
                                                   boolean checkAvailability)
-      throws DistributionException, MediaPackageException {
+          throws DistributionException {
     return distributeSync(channelId, mediapackage, elementIds, checkAvailability, false);
   }
 
@@ -567,7 +567,7 @@ public class DownloadDistributionServiceImpl extends AbstractDistributionService
       Set<String> elementIds,
       boolean checkAvailability,
       boolean preserveReference
-  ) throws DistributionException, MediaPackageException {
+  ) throws DistributionException {
     notNull(mediapackage, "mediapackage");
     notNull(elementIds, "elementIds");
     notNull(channelId, "channelId");
@@ -579,7 +579,7 @@ public class DownloadDistributionServiceImpl extends AbstractDistributionService
 
   @Override
   public List<MediaPackageElement> retractSync(String channelId, MediaPackage mediapackage, String elementId)
-          throws DistributionException, MediaPackageException {
+          throws DistributionException {
     Set<String> elementIds = new HashSet();
     elementIds.add(elementId);
     return retractSync(channelId, mediapackage, elementIds);

--- a/modules/distribution-service-download/src/main/java/org/opencastproject/distribution/download/DownloadDistributionServiceImpl.java
+++ b/modules/distribution-service-download/src/main/java/org/opencastproject/distribution/download/DownloadDistributionServiceImpl.java
@@ -612,7 +612,7 @@ public class DownloadDistributionServiceImpl extends AbstractDistributionService
    *          the mediapackage
    * @param elementIds
    *          the element identifiers
-   * @return the retracted element or <code>null</code> if the element was not retracted
+   * @return the retracted elements
    * @throws org.opencastproject.distribution.api.DistributionException
    *           in case of an error
    */
@@ -643,7 +643,7 @@ public class DownloadDistributionServiceImpl extends AbstractDistributionService
    *          the mediapackage
    * @param element
    *          the element
-   * @return the retracted element or <code>null</code> if the element was not retracted
+   * @return the retracted element
    * @throws org.opencastproject.distribution.api.DistributionException
    *           in case of an error
    */

--- a/modules/distribution-service-streaming-remote/src/main/java/org/opencastproject/distribution/streaming/remote/StreamingDistributionServiceRemoteImpl.java
+++ b/modules/distribution-service-streaming-remote/src/main/java/org/opencastproject/distribution/streaming/remote/StreamingDistributionServiceRemoteImpl.java
@@ -31,7 +31,6 @@ import org.opencastproject.distribution.api.StreamingDistributionService;
 import org.opencastproject.job.api.Job;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElement;
-import org.opencastproject.mediapackage.MediaPackageException;
 import org.opencastproject.mediapackage.MediaPackageParser;
 import org.opencastproject.security.api.TrustedHttpClient;
 import org.opencastproject.serviceregistry.api.RemoteBase;
@@ -102,7 +101,7 @@ public class StreamingDistributionServiceRemoteImpl extends RemoteBase implement
 
   @Override
   public Job distribute(String channelId, MediaPackage mediaPackage, String elementId)
-          throws DistributionException, MediaPackageException {
+          throws DistributionException {
     Set<String> elementIds = new HashSet<String>();
     elementIds.add(elementId);
     return distribute(channelId, mediaPackage, elementIds);
@@ -131,7 +130,7 @@ public class StreamingDistributionServiceRemoteImpl extends RemoteBase implement
 
   @Override
   public Job distribute(String channelId, final MediaPackage mediaPackage, Set<String> elementIds)
-          throws DistributionException,  MediaPackageException {
+          throws DistributionException {
     logger.info("Distributing {} elements to {}@{}", elementIds.size(), channelId, distributionChannel);
     final HttpPost req = post(param(PARAM_CHANNEL_ID, channelId),
                               param(PARAM_MEDIAPACKAGE, MediaPackageParser.getAsXml(mediaPackage)),

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/ConfigurablePublishWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/ConfigurablePublishWorkflowOperationHandler.java
@@ -396,7 +396,7 @@ public class ConfigurablePublishWorkflowOperationHandler extends ConfigurableWor
           job = downloadDistributionService.distribute(channelId, mediapackage, bulkElementIds, checkAvailability);
         }
         jobs.add(job);
-      } catch (DistributionException | MediaPackageException e) {
+      } catch (DistributionException e) {
         logger.error("Creating the distribution job for {} elements of media package '{}' failed",
                 bulkElementIds.size(), mediapackage, e);
         throw new WorkflowOperationException(e);
@@ -414,7 +414,7 @@ public class ConfigurablePublishWorkflowOperationHandler extends ConfigurableWor
             job = downloadDistributionService.distribute(channelId, mediapackage, elementId, checkAvailability);
           }
           jobs.add(job);
-        } catch (DistributionException | MediaPackageException e) {
+        } catch (DistributionException e) {
           logger.error("Creating the distribution job for element '{}' of media package '{}' failed", elementId,
                   mediapackage, e);
           throw new WorkflowOperationException(e);


### PR DESCRIPTION
When one changes the series belonging to an event (e.g. metadata or ACL), those changes are automatically republished to search. This PR makes it possible to turn off check-availability after distributing the changed files. This might improve performance. Related to the issue that also prompted #7670. Default behavior did not change. Includes release notes.

How to test: Create a series and an event for that series that is published to search, then change metadata or ACL of the series. 

**Attention**: This also somewhat  refactors the event handler that updates search in this case as well as parts of the DownloadDistributionServices for the following reasons:
- Insufficient error handling in event handler (list of retracted/distributed elements is never null and should thus not be used for checking for errors)
- Improve logged error messages
- Don't annotate exceptions we never actually throw
- Remove unused dependencies
- make all methods of distributeSync() behave the same way
- include another wrapper method for distributeSync to make things easier
- always use synced retract/distribute methods in event handler instead of sometimes using job barrier
- merge private methods in event handler with main method to improve readability