### PR TITLE
Fix short-circuit skipping AssetManager cleanup on engage retraction

### DIFF
--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/RetractEngageWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/RetractEngageWorkflowOperationHandler.java
@@ -162,7 +162,9 @@ public class RetractEngageWorkflowOperationHandler extends AbstractWorkflowOpera
           throws WorkflowOperationException {
     MediaPackage mediaPackage = workflowInstance.getMediaPackage();
     try {
-      if (removeFromEngage(mediaPackage.getIdentifier().toString()) || removeFromArchive(mediaPackage)) {
+      boolean removedFromEngage = removeFromEngage(mediaPackage.getIdentifier().toString());
+      boolean removedFromArchive = removeFromArchive(mediaPackage);
+      if (removedFromEngage || removedFromArchive) {
         return createResult(mediaPackage, Action.CONTINUE);
       }
       return createResult(mediaPackage, Action.SKIP);

--- a/modules/distribution-workflowoperation/src/test/java/org/opencastproject/workflow/handler/distribution/RetractEngageWorkflowOperationHandlerTest.java
+++ b/modules/distribution-workflowoperation/src/test/java/org/opencastproject/workflow/handler/distribution/RetractEngageWorkflowOperationHandlerTest.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.workflow.handler.distribution;
+
+import static org.junit.Assert.assertEquals;
+
+import org.opencastproject.distribution.api.DownloadDistributionService;
+import org.opencastproject.job.api.Job;
+import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.mediapackage.MediaPackageBuilder;
+import org.opencastproject.mediapackage.MediaPackageBuilderFactory;
+import org.opencastproject.mediapackage.Publication;
+import org.opencastproject.mediapackage.PublicationImpl;
+import org.opencastproject.mediapackage.identifier.IdImpl;
+import org.opencastproject.search.api.SearchService;
+import org.opencastproject.serviceregistry.api.ServiceRegistry;
+import org.opencastproject.util.MimeTypes;
+import org.opencastproject.util.NotFoundException;
+import org.opencastproject.workflow.api.WorkflowInstance;
+import org.opencastproject.workflow.api.WorkflowInstance.WorkflowState;
+import org.opencastproject.workflow.api.WorkflowOperationInstance;
+import org.opencastproject.workflow.api.WorkflowOperationResult;
+
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+public class RetractEngageWorkflowOperationHandlerTest {
+
+  private static final String MP_ID = "mp-id";
+  private static final long DELETE_FROM_SEARCH_JOB_ID = 1L;
+
+  private RetractEngageWorkflowOperationHandler handler;
+  private WorkflowInstance workflowInstance;
+  private MediaPackage mediaPackage;
+  private SearchService searchService;
+  private ServiceRegistry serviceRegistry;
+
+  @Before
+  public void setUp() throws Exception {
+    MediaPackageBuilder builder = MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder();
+    mediaPackage = builder.createNew(new IdImpl(MP_ID));
+    Publication publication = PublicationImpl.publication("pub-id", EngagePublicationChannel.CHANNEL_ID,
+            new URI("http://engage.org/play/" + MP_ID), MimeTypes.parseMimeType("text/html"));
+    mediaPackage.add(publication);
+
+    Job deleteFromSearchJob = mockJob(DELETE_FROM_SEARCH_JOB_ID);
+    serviceRegistry = EasyMock.createNiceMock(ServiceRegistry.class);
+    EasyMock.expect(serviceRegistry.getJob(DELETE_FROM_SEARCH_JOB_ID)).andReturn(deleteFromSearchJob).anyTimes();
+    EasyMock.replay(serviceRegistry);
+
+    searchService = EasyMock.createNiceMock(SearchService.class);
+    EasyMock.expect(searchService.delete(MP_ID)).andReturn(deleteFromSearchJob);
+
+    DownloadDistributionService downloadDistributionService =
+            EasyMock.createNiceMock(DownloadDistributionService.class);
+    EasyMock.replay(downloadDistributionService);
+
+    handler = new RetractEngageWorkflowOperationHandler();
+    handler.setJobBarrierPollingInterval(1L);
+    handler.setServiceRegistry(serviceRegistry);
+    handler.setSearchService(searchService);
+    handler.setDownloadDistributionService(downloadDistributionService);
+
+    workflowInstance = new WorkflowInstance();
+    workflowInstance.setId(1);
+    workflowInstance.setMediaPackage(mediaPackage);
+    workflowInstance.setState(WorkflowState.RUNNING);
+
+    WorkflowOperationInstance operation =
+            new WorkflowOperationInstance("retract-engage", WorkflowOperationInstance.OperationState.RUNNING);
+    List<WorkflowOperationInstance> operationsList = new ArrayList<>();
+    operationsList.add(operation);
+    workflowInstance.setOperations(operationsList);
+  }
+
+  private Job mockJob(Long jobId) {
+    Job job = EasyMock.createNiceMock(Job.class);
+    EasyMock.expect(job.getId()).andReturn(jobId).anyTimes();
+    EasyMock.expect(job.getStatus()).andReturn(Job.Status.FINISHED).anyTimes();
+    EasyMock.expect(job.getDateCreated()).andReturn(new Date()).anyTimes();
+    EasyMock.expect(job.getDateStarted()).andReturn(new Date()).anyTimes();
+    EasyMock.expect(job.getQueueTime()).andReturn(0L).anyTimes();
+    EasyMock.replay(job);
+    return job;
+  }
+
+  /**
+   * Regression test for OPENCAST-7911: engage retraction must remove the publication element from the
+   * media package even though it also succeeded in retracting/removing the media package from search.
+   */
+  @Test
+  public void testStartRemovesPublicationEvenWhenEngageRetractionSucceeds() throws Exception {
+    MediaPackage searchMediaPackage = MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder()
+            .createNew(new IdImpl(MP_ID));
+    EasyMock.expect(searchService.get(MP_ID)).andReturn(searchMediaPackage);
+    EasyMock.replay(searchService);
+
+    WorkflowOperationResult result = handler.start(workflowInstance, null);
+
+    assertEquals(WorkflowOperationResult.Action.CONTINUE, result.getAction());
+    assertEquals(0, result.getMediaPackage().getPublications().length);
+  }
+
+  @Test
+  public void testStartRemovesPublicationWhenAlreadyGoneFromSearch() throws Exception {
+    EasyMock.expect(searchService.get(MP_ID)).andThrow(new NotFoundException("Not found"));
+    EasyMock.replay(searchService);
+
+    WorkflowOperationResult result = handler.start(workflowInstance, null);
+
+    assertEquals(WorkflowOperationResult.Action.CONTINUE, result.getAction());
+    assertEquals(0, result.getMediaPackage().getPublications().length);
+  }
+
+  @Test
+  public void testStartSkipsWhenNothingToRetract() throws Exception {
+    mediaPackage.remove(mediaPackage.getPublications()[0]);
+    EasyMock.expect(searchService.get(MP_ID)).andThrow(new NotFoundException("Not found"));
+    EasyMock.replay(searchService);
+
+    WorkflowOperationResult result = handler.start(workflowInstance, null);
+
+    assertEquals(WorkflowOperationResult.Action.SKIP, result.getAction());
+  }
+}


### PR DESCRIPTION
Fixes a short-circuiting `||` in `RetractEngageWorkflowOperationHandler.start()` that let a successful `removeFromEngage()` call skip `removeFromArchive()` entirely, so the `engage-player` publication was never stripped from the media package during `retract-for-deletion`. `RetractionListener` then refused to complete the deletion, leaving the event gone from search but permanently stuck in the Asset Manager.

To reproduce: publish an event to Engage, then delete it via the External API (`DELETE /api/events/{id}`). The retraction workflow completes, but the event stays behind indefinitely with its `engage-player` publication still attached.

The fix evaluates both cleanup calls unconditionally instead of short-circuiting, matching the original intent of a468a0bfe9 ("Always remove publication from AM on retraction").

### How to test this patch

1. Ingest and process an event so it publishes to Engage.
2. Confirm `processing_state` is `SUCCEEDED` via `GET /api/events/{id}`.
3. `DELETE /api/events/{id}` and wait for the `retract-for-deletion` workflow to finish.
4. `GET /api/events/{id}` should now return `404`. Before this fix, it kept returning `200` with `publication_status: ["engage-player"]`.

Unit tests are included: `RetractEngageWorkflowOperationHandlerTest` covers the successful-retraction case (the regression), the already-gone-from-search case, and the nothing-to-retract `SKIP` case.

### AI Usage

Used Claude Code to investigate the issue, apply the fix, add regression tests, and verify the build/tests in the project's `compose.build.yaml` container.

### Your pull request should…

* [x] have a concise title
* [x] close an accompanying issue - Closes #7911
* [x] be against the correct branch - `develop` (bug introduced there, not present on release branches)
* [ ] include migration scripts and documentation, if appropriate - n/a
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] have proper commit messages (title and body) for all commits
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch - n/a, not targeting legacy
* [ ] include a release note - n/a, bug fix only
