### PR TITLE
Stop logging and rethrowing snapshot failures

### DIFF
--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
@@ -498,8 +498,9 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
       Snapshot archived = addInternal(owner, MediaPackageSupport.copy(mp)).toSnapshot();
       return getHttpAssetProvider().prepareForDelivery(archived);
     } catch (Exception e) {
-      logger.error("An error occurred", e);
-      throw unwrapExceptionUntil(AssetManagerException.class, e).orElse(new AssetManagerException(e));
+      throw unwrapExceptionUntil(AssetManagerException.class, e)
+          .orElseGet(() -> new AssetManagerException(
+              format("Failed to take snapshot of media package %s", mp.getIdentifier()), e));
     }
   }
 
@@ -1412,29 +1413,23 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
     calcChecksumsForMediaPackageElements(pmp);
     // download and archive elements
     storeAssets(pmp, version);
-    // store mediapackage in db
-    final SnapshotDto snapshotDto;
-    try {
-      // rewrite URIs for archival
-      for (MediaPackageElement mpe : pmp.getElements()) {
-        String fileName = getFileName(mpe).orElse("unknown");
-        URI archiveUri = new URI(
-            "urn",
-            "matterhorn:" + mpId + ":" + version + ":" + mpe.getIdentifier() + ":" + fileName,
-            null
-        );
-        mpe.setURI(archiveUri);
-      }
-
-      String currentOrgId = securityService.getOrganization().getId();
-      snapshotDto = getDatabase().saveSnapshot(
-              currentOrgId, pmp, now, version,
-              Availability.ONLINE, getLocalAssetStore().getStoreType(), owner
+    // rewrite URIs for archival
+    for (MediaPackageElement mpe : pmp.getElements()) {
+      String fileName = getFileName(mpe).orElse("unknown");
+      URI archiveUri = new URI(
+          "urn",
+          "matterhorn:" + mpId + ":" + version + ":" + mpe.getIdentifier() + ":" + fileName,
+          null
       );
-    } catch (AssetManagerException e) {
-      logger.error("Could not take snapshot {}", mpId, e);
-      throw new AssetManagerException(e);
+      mpe.setURI(archiveUri);
     }
+
+    // store mediapackage in db
+    String currentOrgId = securityService.getOrganization().getId();
+    final SnapshotDto snapshotDto = getDatabase().saveSnapshot(
+            currentOrgId, pmp, now, version,
+            Availability.ONLINE, getLocalAssetStore().getStoreType(), owner
+    );
     // save manifest to element store
     // this is done at the end after the media package element ids have been rewritten to neutral URNs
     storeManifest(pmp, version);


### PR DESCRIPTION
`AssetManagerImpl.takeSnapshotInternal()` caught every exception, logged it at ERROR and then rethrew it. Since the callers – and ultimately CXF – report it again, a single failed snapshot logged the same ~150 frame stack trace several times. The additional message carried no context atall:

    ERROR (AssetManagerImpl:501) - An error occurred

`addInternal()` did the same one level down, additionally wrapping the exception in another `AssetManagerException` for no reason.

Drop both log statements and instead name the media package in the exception thrown by `takeSnapshotInternal()`, so the layer which actually handles the failure can report it with context. The try/catch in `addInternal()` is gone entirely; the method declares `throws Exception` anyway, hence the URI rewriting needs no catch of its own.

Fixes #7926

### AI Usage
Clause was used for log analysis and implementation.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
