### PR TITLE
Do not warn about missing XACML files in workspace

### DIFF
--- a/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
+++ b/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
@@ -56,6 +56,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -285,8 +286,11 @@ public class XACMLAuthorizationService implements AuthorizationService {
       attachment = (Attachment) a.clone();
       try {
         workspace.delete(a.getURI());
+      } catch (NotFoundException | FileNotFoundException e) {
+        // The file is not in the local workspace. That is the desired end state anyway, so there is nothing to do.
+        logger.debug("XACML file {} was not in the workspace, nothing to delete", a.getURI());
       } catch (Exception e) {
-        logger.warn("Unable to delete XACML file:", e);
+        logger.warn("Unable to delete XACML file {}", a.getURI(), e);
       }
       mp.remove(a);
     }


### PR DESCRIPTION
Before writing a new XACML attachment, XACMLAuthorizationService deletes the previous one from the workspace. On a multi-node cluster the node serving the request has usually never fetched that file, so the delete fails. That is the expected case and the desired end state anyway, but it was logged at warn level with a full stack trace, looking like a storage failure.

Log the missing file at debug level instead and keep the warning for actual delete failures. The warning now also contains the file URI which so far only showed up in the stack trace.

Fixes #7925

### AI Usage
Used Claude for the initial log analysis and for generating the issue and patch.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
