### PR TITLE
Log media package merging at debug level

### DIFF
--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java
@@ -718,27 +718,27 @@ public class PublishEngageWorkflowOperationHandler extends AbstractWorkflowOpera
     MediaPackage mergedMediaPackage = (MediaPackage) updatedMp.clone();
     for (MediaPackageElement element : publishedMp.elements()) {
       String type = element.getElementType().toString().toLowerCase();
-      boolean elementHasFlavorThatAlreadyExists = updatedMp.getElementsByFlavor(element.getFlavor()).length > 0;
+      MediaPackageElement[] existingElements = updatedMp.getElementsByFlavor(element.getFlavor());
+      boolean elementHasFlavorThatAlreadyExists = existingElements.length > 0;
       boolean elementHasForceMergeFlavor = mergeForceFlavors.stream().anyMatch((f) -> element.getFlavor().matches(f));
       boolean elementHasForceAddFlavor = addForceFlavors.stream().anyMatch((f) -> element.getFlavor().matches(f));
 
       if (elementHasForceAddFlavor) {
-        logger.info("Adding {} '{}' into the updated mediapackage", type, element.getIdentifier());
+        logger.debug("Adding {} '{}' into the updated mediapackage", type, element.getIdentifier());
         mergedMediaPackage.add((MediaPackageElement) element.clone());
         continue;
       }
       if (!elementHasFlavorThatAlreadyExists) {
         if (elementHasForceMergeFlavor) {
-          logger.info("Forcing removal of {} {} due to the absence of a new element with flavor {}",
+          logger.debug("Forcing removal of {} {} due to the absence of a new element with flavor {}",
                   type, element.getIdentifier(), element.getFlavor().toString());
           continue;
         }
-        logger.info("Merging {} '{}' into the updated mediapackage", type, element.getIdentifier());
+        logger.debug("Merging {} '{}' into the updated mediapackage", type, element.getIdentifier());
         mergedMediaPackage.add((MediaPackageElement) element.clone());
       } else {
-        logger.info("Overwriting existing {} '{}' with '{}' in the updated mediapackage",
-                type, element.getIdentifier(), updatedMp.getElementsByFlavor(element.getFlavor())[0].getIdentifier());
-
+        logger.debug("Overwriting existing {} '{}' with '{}' in the updated mediapackage",
+                type, element.getIdentifier(), existingElements[0].getIdentifier());
       }
     }
 


### PR DESCRIPTION
`PublishEngageWorkflowOperationHandler` logged one INFO line per media package element while merging an update into the currently published media package. On a busy system that is by far the loudest thing in the log: on our production admin node, those statements produced 1.2 million of 1.53 million INFO lines over five days – 83% of the log and about 200MB of a 270MB file – burying the errors and warnings an operator actually wants to see.

The messages describe which element replaced which, which is only of interest when debugging the publish handler itself, so log them at debug instead. This matches what the OAI-PMH publication service and `MediaPackageSupport.merge(…)` already do. The one INFO line per publish announcing that the media package goes to the search index stays.

Fixes #7923


### AI Usage

Log analysis, issue creation and patch done by Claude.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
