### PR TITLE
Log exception on storage cleanup failure

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/cleanup/RecursiveDirectoryCleaner.java
+++ b/modules/common/src/main/java/org/opencastproject/cleanup/RecursiveDirectoryCleaner.java
@@ -122,7 +122,7 @@ public final class RecursiveDirectoryCleaner implements FileVisitor<Path> {
       Files.walkFileTree(startingDir, fileFilter);
       return true;
     } catch (IOException e) {
-      logger.error("Cleanup of directory {} failed", startingDir);
+      logger.error("Cleanup of directory {} failed", startingDir, e);
       return false;
     }
   }

--- a/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryCleaner.java
+++ b/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryCleaner.java
@@ -141,13 +141,13 @@ public class WorkingFileRepositoryCleaner {
       try {
         workingFileRepository.cleanupOldFilesFromCollection(collectionId, maxAge);
       } catch (IOException e) {
-        logger.error("Cleaning of collection with id:{} failed", collectionId);
+        logger.error("Cleaning of collection with id:{} failed", collectionId, e);
       }
     }
     try {
       workingFileRepository.cleanupOldFilesFromMediaPackage(maxAge);
     } catch (IOException e) {
-      logger.error("Cleaning of mediapackages failed");
+      logger.error("Cleaning of mediapackages failed", e);
     }
   }
 


### PR DESCRIPTION
When a directory cleanup failed, we logged an ERROR stating only that the cleanup failed and then discarded the IOException that caused it. The resulting log line has no cause and no stack trace, so there is no way to tell whether the storage is unreachable, a permission changed or a single file was locked. Since the caller in WorkspaceImpl discards the boolean return value, that log line is the only signal such a failure produces.

Pass the caught exception to the logger, like the symlink resolution branch a few lines above already does. The two identical cases in WorkingFileRepositoryCleaner are fixed as well.

Fixes #7922

### AI Usage
Used Claude for the initial log analysis and for generating issue and patch.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
