### PR TITLE
Fix NullPointerException when deleting assets

### DIFF
--- a/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/AbstractFileSystemAssetStore.java
+++ b/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/AbstractFileSystemAssetStore.java
@@ -146,8 +146,10 @@ public abstract class AbstractFileSystemAssetStore implements AssetStore {
 
   @Override
   public boolean delete(DeletionSelector sel) throws AssetStoreException {
-    File dir = getDeletionSelectorDir(sel);
-    if (dir == null) {
+    // Resolve the root directory once, before anything is deleted. Deleting the directory below may remove the very
+    // directory a second lookup would search for, so the result must not be resolved again afterwards.
+    final String rootPath = getRootDirectory(sel.getOrganizationId(), sel.getMediaPackageId());
+    if (rootPath == null) {
       // MediaPackage could not be found locally. This could mean
       //   - all snapshots live in a remote asset store
       //   - mount failed and files are temporary not available
@@ -156,34 +158,31 @@ public abstract class AbstractFileSystemAssetStore implements AssetStore {
       // In any case, we cannot continue and return "false" to indicate that the files could not be found.
       return false;
     }
+    final File dir = getDeletionSelectorDir(rootPath, sel);
     try {
       FileUtils.deleteDirectory(dir);
       // also delete the media package directory if all versions have been deleted
-      boolean mpDirDeleted = FileSupport.deleteHierarchyIfEmpty(file(path(
-              getRootDirectory(sel.getOrganizationId(), sel.getMediaPackageId()), sel.getOrganizationId())),
-              dir.getParentFile());
+      boolean mpDirDeleted = FileSupport.deleteHierarchyIfEmpty(
+              file(path(rootPath, sel.getOrganizationId())), dir.getParentFile());
       if (mpDirDeleted) {
         onDeleteMediaPackage(sel.getOrganizationId(), sel.getMediaPackageId());
       }
       return true;
     } catch (IOException e) {
-      logger.error("Error deleting directory from archive {}", dir);
-      throw new AssetStoreException(e);
+      throw new AssetStoreException("Error deleting directory from archive " + dir, e);
     }
   }
 
   /**
    * Returns the directory file from a deletion selector
    *
+   * @param rootPath
+   *          the root directory of the media package the selector refers to
    * @param sel
    *          the deletion selector
-   * @return the directory file or null if it does not exist (e.g. MediaPackage does not exist locally)
+   * @return the directory file
    */
-  private File getDeletionSelectorDir(DeletionSelector sel) {
-    final String rootPath = getRootDirectory(sel.getOrganizationId(), sel.getMediaPackageId());
-    if (rootPath == null) {
-      return null;
-    }
+  private File getDeletionSelectorDir(String rootPath, DeletionSelector sel) {
     final String basePath = path(rootPath, sel.getOrganizationId(), sel.getMediaPackageId());
     if (sel.getVersion().isPresent()) {
       return file(basePath, sel.getVersion().get().toString());

--- a/modules/asset-manager-storage-fs/src/test/java/org/opencastproject/assetmanager/storage/impl/fs/AbstractFileSystemAssetStoreTest.java
+++ b/modules/asset-manager-storage-fs/src/test/java/org/opencastproject/assetmanager/storage/impl/fs/AbstractFileSystemAssetStoreTest.java
@@ -227,6 +227,38 @@ public class AbstractFileSystemAssetStoreTest {
     assertFalse(file.exists());
   }
 
+  /**
+   * The root directory has to be resolved before the deletion, not after. Deleting the media package directory removes
+   * exactly what a repeated lookup would search for, so that lookup may legitimately return null and must not be used
+   * unchecked.
+   */
+  @Test
+  public void testDeleteNoneVersionWithStaleRootDirectoryCache() throws Exception {
+    final OsgiFileSystemAssetStore store = new OsgiFileSystemAssetStore() {
+      @Override protected Workspace getWorkspace() {
+        return null;
+      }
+
+      @Override protected String getRootDirectory(String orgId, String mpId) {
+        final String rootDirectory = super.getRootDirectory(orgId, mpId);
+        // drop the cached entry so that every further lookup is resolved from disk again, just like it would be
+        // after the cache entry expired
+        onDeleteMediaPackage(orgId, mpId);
+        return rootDirectory;
+      }
+    };
+    Field rootDirectories = OsgiFileSystemAssetStore.class.getDeclaredField("rootDirectories");
+    rootDirectories.setAccessible(true);
+    rootDirectories.set(store, new ArrayList(Arrays.asList(tmpRoot.getAbsolutePath(), tmpRoot2.getAbsolutePath())));
+    store.setupCache();
+
+    assertTrue(store.delete(DeletionSelector.deleteAll(ORG_ID, MP_ID)));
+    assertFalse(sampleElemDir.exists());
+
+    File file = new File(PathSupport.concat(new String[] { tmpRoot.toString(), ORG_ID, MP_ID }));
+    assertFalse(file.exists());
+  }
+
   @Test
   public void testDeleteWrongVersion() throws Exception {
     DeletionSelector versionSelector = DeletionSelector.delete(ORG_ID, MP_ID, VERSION_1);

--- a/modules/common/src/main/java/org/opencastproject/util/PathSupport.java
+++ b/modules/common/src/main/java/org/opencastproject/util/PathSupport.java
@@ -91,6 +91,11 @@ public final class PathSupport {
     if (parts.length == 0) {
       throw new IllegalArgumentException("Array parts is empty");
     }
+    for (int i = 0; i < parts.length; i++) {
+      if (parts[i] == null) {
+        throw new IllegalArgumentException("Element " + i + " of argument parts is null");
+      }
+    }
     String path = removeDoubleSeparator(adjustSeparator(parts[0]));
     for (int i = 1; i < parts.length; i++) {
       path = concat(path, removeDoubleSeparator(adjustSeparator(parts[i])));


### PR DESCRIPTION
AbstractFileSystemAssetStore.delete() resolved the root directory of a media package twice, but checked the result for null only the first time. The second lookup happens directly after the directory has been deleted and, for a deletion selector without a version, that directory is exactly the one the lookup searches for. If the cached lookup result had expired in the meantime, the reload found nothing, returned null and the null was passed straight into PathSupport.path(), throwing a NullPointerException out of the asset store:

```
  java.lang.NullPointerException: Cannot invoke "String.replaceAll(String, String)" because "path" is null
    at org.opencastproject.util.PathSupport.adjustSeparator(PathSupport.java:114)
    …
    at org.opencastproject.assetmanager.storage.impl.fs.AbstractFileSystemAssetStore.delete(…:162)
    at org.opencastproject.scheduler.impl.SchedulerServiceImpl.removeEvent(…:876)
```

That aborted the removal of the event and left orphaned data behind.

The root directory is now resolved once, before anything is deleted, and that value is reused afterwards. Simply skipping the cleanup on a null result would have avoided the exception as well, but it would also skip deleting the now empty media package directory and invalidating the cache in precisely the case where both are needed.

Additionally, PathSupport.concat() now rejects null elements right away instead of failing deep inside adjustSeparator(), which made this kind of problem needlessly hard to trace.

Fixes #7921

### AI Usage
Used Claude for initial log analysis and patch

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
