### PR TITLE
Handle metadata validation errors in the External API

### DIFF
--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -55,6 +55,7 @@ import org.opencastproject.index.service.api.IndexService;
 import org.opencastproject.index.service.catalog.adapter.DublinCoreMetadataUtil;
 import org.opencastproject.index.service.catalog.adapter.events.CommonEventCatalogUIAdapter;
 import org.opencastproject.index.service.exception.IndexServiceException;
+import org.opencastproject.index.service.exception.MetadataValidationException;
 import org.opencastproject.index.service.impl.util.EventHttpServletRequest;
 import org.opencastproject.index.service.impl.util.EventUtils;
 import org.opencastproject.index.service.util.RequestUtils;
@@ -149,6 +150,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.Dictionary;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
@@ -1745,11 +1747,14 @@ public class EventsEndpoint implements ManagedService {
       },
       responses = {
           @RestResponse(description = "The metadata of the given namespace has been updated.",
-              responseCode = HttpServletResponse.SC_OK),
+              responseCode = HttpServletResponse.SC_NO_CONTENT),
           @RestResponse(description = "The request is invalid or inconsistent.",
               responseCode = HttpServletResponse.SC_BAD_REQUEST),
           @RestResponse(description = "The specified event does not exist.",
-              responseCode = HttpServletResponse.SC_NOT_FOUND)
+              responseCode = HttpServletResponse.SC_NOT_FOUND),
+          @RestResponse(description = "The metadata stored for the specified event is incomplete or invalid and needs "
+              + "to be fixed before it can be updated.",
+              responseCode = HttpServletResponse.SC_INTERNAL_SERVER_ERROR)
       })
   public Response updateEventMetadataByType(@HeaderParam("Accept") String acceptHeader, @PathParam("eventId") String id,
           @QueryParam("type") String type, @FormParam("metadata") String metadataJSON) throws Exception {
@@ -1811,6 +1816,10 @@ public class EventsEndpoint implements ManagedService {
         return ApiResponseBuilder.notFound("Cannot find a catalog with type '%s' for event with id '%s'.", type, id);
       }
 
+      // Remember which fields the client actually modified. If storing the metadata fails later on, this tells us
+      // whether the offending field is one the client sent or one which was already invalid in the stored catalog.
+      Set<String> updatedFieldIds = new HashSet<>();
+
       for (String key : updatedFields.keySet()) {
         if ("subjects".equals(key)) {
           MetadataField field = collection.getOutputFields().get(DublinCore.PROPERTY_SUBJECT.getLocalName());
@@ -1818,8 +1827,17 @@ public class EventsEndpoint implements ManagedService {
           if (error.isPresent()) {
             return error.get();
           }
+          JSONArray subjectArray;
+          try {
+            subjectArray = (JSONArray) parser.parse(updatedFields.get(key));
+          } catch (ParseException | ClassCastException e) {
+            logger.debug("Unable to update event '{}' as the subjects '{}' are no json array",
+                    id, updatedFields.get(key), e);
+            return R.badRequest(
+                    String.format("Unable to parse subjects '%s' as a json array.", updatedFields.get(key)));
+          }
+          updatedFieldIds.add(field.getInputID());
           collection.removeField(field);
-          JSONArray subjectArray = (JSONArray) parser.parse(updatedFields.get(key));
           collection.addField(
                   MetadataJson.copyWithDifferentJsonValue(field, StringUtils.join(subjectArray.iterator(), ",")));
         } else if ("startDate".equals(key)) {
@@ -1834,15 +1852,11 @@ public class EventsEndpoint implements ManagedService {
             final String startDate = configuredMetadataFields.get("startDate").getPattern();
             apiPattern = startDate == null ? apiPattern : startDate;
           }
-          SimpleDateFormat apiSdf = MetadataField.getSimpleDateFormatter(apiPattern);
-          SimpleDateFormat sdf = MetadataField.getSimpleDateFormatter(field.getPattern());
-          DateTime oldStartDate = new DateTime(sdf.parse((String) field.getValue()), DateTimeZone.UTC);
-          DateTime newStartDate = new DateTime(apiSdf.parse(updatedFields.get(key)), DateTimeZone.UTC);
-          DateTime updatedStartDate = oldStartDate.withDate(newStartDate.year().get(), newStartDate.monthOfYear().get(),
-              newStartDate.dayOfMonth().get());
-          collection.removeField(field);
-          collection.addField(
-                  MetadataJson.copyWithDifferentJsonValue(field, sdf.format(updatedStartDate.toDate())));
+          updatedFieldIds.add(field.getInputID());
+          error = updateStartDate(collection, field, id, apiPattern, updatedFields.get(key), false);
+          if (error.isPresent()) {
+            return error.get();
+          }
         } else if ("startTime".equals(key)) {
           // Special handling for start time since in API v1 we expect start date and start time to be separate fields.
           MetadataField field = collection.getOutputFields().get("startDate");
@@ -1855,24 +1869,18 @@ public class EventsEndpoint implements ManagedService {
             final String startTime = configuredMetadataFields.get("startTime").getPattern();
             apiPattern = startTime == null ? apiPattern : startTime;
           }
-          SimpleDateFormat apiSdf = MetadataField.getSimpleDateFormatter(apiPattern);
-          SimpleDateFormat sdf = MetadataField.getSimpleDateFormatter(field.getPattern());
-          DateTime oldStartDate = new DateTime(sdf.parse((String) field.getValue()), DateTimeZone.UTC);
-          DateTime newStartDate = new DateTime(apiSdf.parse(updatedFields.get(key)), DateTimeZone.UTC);
-          DateTime updatedStartDate = oldStartDate.withTime(
-                  newStartDate.hourOfDay().get(),
-                  newStartDate.minuteOfHour().get(),
-                  newStartDate.secondOfMinute().get(),
-                  newStartDate.millisOfSecond().get());
-          collection.removeField(field);
-          collection.addField(
-                  MetadataJson.copyWithDifferentJsonValue(field, sdf.format(updatedStartDate.toDate())));
+          updatedFieldIds.add(field.getInputID());
+          error = updateStartDate(collection, field, id, apiPattern, updatedFields.get(key), true);
+          if (error.isPresent()) {
+            return error.get();
+          }
         } else {
           MetadataField field = collection.getOutputFields().get(key);
           Optional<Response> error = validateField(field, key, id, type, updatedFields);
           if (error.isPresent()) {
             return error.get();
           }
+          updatedFieldIds.add(field.getInputID());
           collection.removeField(field);
           collection.addField(
                   MetadataJson.copyWithDifferentJsonValue(field, updatedFields.get(key)));
@@ -1880,10 +1888,93 @@ public class EventsEndpoint implements ManagedService {
       }
 
       metadataList.add(adapter, collection);
-      indexService.updateEventMetadata(id, metadataList, elasticsearchIndex);
+      try {
+        indexService.updateEventMetadata(id, metadataList, elasticsearchIndex);
+      } catch (MetadataValidationException e) {
+        if (updatedFieldIds.contains(e.getFieldId())) {
+          logger.debug("Client sent an invalid value for field '{}' of event '{}'", e.getFieldId(), id, e);
+          return R.badRequest(e.getMessage());
+        }
+        // The client did not touch this field. Its value was already invalid in the stored catalog, so there is
+        // nothing the client can do about this.
+        logger.error("Cannot update metadata of event '{}' since the required field '{}' is empty in the stored "
+                + "catalog. The event needs to be fixed before its metadata can be updated.", id, e.getFieldId());
+        return ApiResponseBuilder.serverError(
+                "Cannot update metadata of event '%s' because its stored metadata is incomplete: %s",
+                id, e.getMessage());
+      } catch (IllegalArgumentException e) {
+        logger.error("Cannot update metadata of event '{}'", id, e);
+        return ApiResponseBuilder.serverError("Cannot update metadata of event '%s': %s", id, e.getMessage());
+      }
       return Response.noContent().build();
     }
     return ApiResponseBuilder.notFound("Cannot find an event with id '%s'.", id);
+  }
+
+  /**
+   * Update the start date field of a metadata collection with a new date or time.
+   * <p>
+   * In API v1 start date and start time are separate fields while the catalog holds a single date. Hence the new value
+   * is merged into the date which is already stored.
+   *
+   * @param collection
+   *          The metadata collection to update.
+   * @param field
+   *          The start date field of that collection.
+   * @param id
+   *          The identifier of the event, used for logging and error messages.
+   * @param apiPattern
+   *          The date pattern the client is expected to use.
+   * @param value
+   *          The new date or time as sent by the client.
+   * @param timeOnly
+   *          If only the time of day shall be updated instead of the date.
+   * @return An error response if either the stored or the new value could not be parsed, empty otherwise.
+   */
+  private Optional<Response> updateStartDate(DublinCoreMetadataCollection collection, MetadataField field, String id,
+          String apiPattern, String value, boolean timeOnly) {
+    final SimpleDateFormat sdf = MetadataField.getSimpleDateFormatter(field.getPattern());
+    final String storedValue = Objects.toString(field.getValue(), null);
+    final DateTime oldStartDate;
+    try {
+      if (storedValue == null) {
+        throw new java.text.ParseException("No start date stored", 0);
+      }
+      oldStartDate = new DateTime(sdf.parse(storedValue), DateTimeZone.UTC);
+    } catch (java.text.ParseException e) {
+      logger.error("Cannot update metadata of event '{}' since its stored start date '{}' does not match the "
+              + "pattern '{}'. The event needs to be fixed before its metadata can be updated.",
+              id, storedValue, field.getPattern());
+      return Optional.of(ApiResponseBuilder.serverError(
+              "Cannot update metadata of event '%s' because its stored start date '%s' cannot be parsed.",
+              id, storedValue));
+    }
+
+    final DateTime newStartDate;
+    try {
+      newStartDate = new DateTime(MetadataField.getSimpleDateFormatter(apiPattern).parse(value), DateTimeZone.UTC);
+    } catch (java.text.ParseException e) {
+      logger.debug("Unable to update event '{}' as '{}' does not match the pattern '{}'", id, value, apiPattern, e);
+      return Optional.of(R.badRequest(
+              String.format("Unable to parse '%s' as a date matching the pattern '%s'.", value, apiPattern)));
+    }
+
+    final DateTime updatedStartDate;
+    if (timeOnly) {
+      updatedStartDate = oldStartDate.withTime(
+              newStartDate.hourOfDay().get(),
+              newStartDate.minuteOfHour().get(),
+              newStartDate.secondOfMinute().get(),
+              newStartDate.millisOfSecond().get());
+    } else {
+      updatedStartDate = oldStartDate.withDate(
+              newStartDate.year().get(),
+              newStartDate.monthOfYear().get(),
+              newStartDate.dayOfMonth().get());
+    }
+    collection.removeField(field);
+    collection.addField(MetadataJson.copyWithDifferentJsonValue(field, sdf.format(updatedStartDate.toDate())));
+    return Optional.empty();
   }
 
   private Optional<Response> validateField(MetadataField field, String key, String id, String type,

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
@@ -50,6 +50,7 @@ import org.opencastproject.external.util.AclUtils;
 import org.opencastproject.external.util.ExternalMetadataUtils;
 import org.opencastproject.index.service.api.IndexService;
 import org.opencastproject.index.service.exception.IndexServiceException;
+import org.opencastproject.index.service.exception.MetadataValidationException;
 import org.opencastproject.index.service.util.RequestUtils;
 import org.opencastproject.index.service.util.RestUtils;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
@@ -102,11 +103,13 @@ import java.net.URI;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
@@ -738,7 +741,10 @@ public class SeriesEndpoint {
           @RestResponse(description = "The request is invalid or inconsistent.",
               responseCode = HttpServletResponse.SC_BAD_REQUEST),
           @RestResponse(description = "The specified series does not exist.",
-              responseCode = HttpServletResponse.SC_NOT_FOUND)
+              responseCode = HttpServletResponse.SC_NOT_FOUND),
+          @RestResponse(description = "The metadata stored for the specified series is incomplete or invalid and needs "
+              + "to be fixed before it can be updated.",
+              responseCode = HttpServletResponse.SC_INTERNAL_SERVER_ERROR)
       })
   public Response updateSeriesMetadata(@HeaderParam("Accept") String acceptHeader, @PathParam("seriesId") String id,
           @QueryParam("type") String type, @FormParam("metadata") String metadataJSON) throws Exception {
@@ -804,6 +810,10 @@ public class SeriesEndpoint {
 
     DublinCoreMetadataCollection collection = optCollection.get();
 
+    // Remember which fields the client actually modified. If storing the metadata fails later on, this tells us
+    // whether the offending field is one the client sent or one which was already invalid in the stored catalog.
+    Set<String> updatedFieldIds = new HashSet<>();
+
     for (String key : updatedFields.keySet()) {
       MetadataField field = collection.getOutputFields().get(key);
       if (field == null) {
@@ -815,12 +825,30 @@ public class SeriesEndpoint {
                 "The series metadata field with id '%s' and the metadata type '%s' is required and can not be empty!.",
                 key, type));
       }
+      updatedFieldIds.add(field.getInputID());
       collection.removeField(field);
       collection.addField(MetadataJson.copyWithDifferentJsonValue(field, updatedFields.get(key)));
     }
 
     metadataList.add(adapter, collection);
-    indexService.updateAllSeriesMetadata(id, metadataList, elasticsearchIndex);
+    try {
+      indexService.updateAllSeriesMetadata(id, metadataList, elasticsearchIndex);
+    } catch (MetadataValidationException e) {
+      if (updatedFieldIds.contains(e.getFieldId())) {
+        logger.debug("Client sent an invalid value for field '{}' of series '{}'", e.getFieldId(), id, e);
+        return R.badRequest(e.getMessage());
+      }
+      // The client did not touch this field. Its value was already invalid in the stored catalog, so there is
+      // nothing the client can do about this.
+      logger.error("Cannot update metadata of series '{}' since the required field '{}' is empty in the stored "
+              + "catalog. The series needs to be fixed before its metadata can be updated.", id, e.getFieldId());
+      return ApiResponseBuilder.serverError(
+              "Cannot update metadata of series '%s' because its stored metadata is incomplete: %s",
+              id, e.getMessage());
+    } catch (IllegalArgumentException e) {
+      logger.error("Cannot update metadata of series '{}'", id, e);
+      return ApiResponseBuilder.serverError("Cannot update metadata of series '%s': %s", id, e.getMessage());
+    }
     return ApiResponseBuilder.Json.ok(acceptHeader, "");
   }
 

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/EventsEndpointTest.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/EventsEndpointTest.java
@@ -22,6 +22,8 @@ package org.opencastproject.external.endpoint;
 
 import static io.restassured.RestAssured.given;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
 import static javax.servlet.http.HttpServletResponse.SC_NO_CONTENT;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -153,6 +155,44 @@ public class EventsEndpointTest {
     assertThat(MetadataJson.collectionToJson(
             actualMetadataList.getMetadataByFlavor("dublincore/episode"), true, true).toString(),
             SameJSONAs.sameJSONAs(expectedJson).allowingAnyArrayOrdering());
+  }
+
+  /**
+   * A value sent by the client which does not pass validation is the client's fault and has to result in a bad request.
+   */
+  @Test
+  public void testUpdateEventMetadataByTypeWithInvalidClientValue() throws IOException {
+    String jsonString = IOUtils.toString(getClass().getResource("/event-metadata-update.json"), UTF_8);
+    String eventId = TestEventsEndpoint.METADATA_VALIDATION_EVENT;
+    String result = given().formParam("metadata", jsonString).pathParam("event_id", eventId)
+            .queryParam("type", "dublincore/episode")
+            .expect().statusCode(SC_BAD_REQUEST).when().put(env.host("{event_id}/metadata")).asString();
+    assertTrue(result.contains("'title'"));
+  }
+
+  /**
+   * If a field the client did not touch is invalid in the stored catalog, there is nothing the client can do about it.
+   * That is a server side problem and must not be reported as a bad request.
+   */
+  @Test
+  public void testUpdateEventMetadataByTypeWithIncompleteStoredCatalog() throws IOException {
+    String jsonString = IOUtils.toString(getClass().getResource("/event-metadata-update-subject-only.json"), UTF_8);
+    String eventId = TestEventsEndpoint.METADATA_VALIDATION_EVENT;
+    given().formParam("metadata", jsonString).pathParam("event_id", eventId)
+            .queryParam("type", "dublincore/episode")
+            .expect().statusCode(SC_INTERNAL_SERVER_ERROR).when().put(env.host("{event_id}/metadata"));
+  }
+
+  /**
+   * A start date which does not match the expected pattern is a bad request instead of an unhandled exception.
+   */
+  @Test
+  public void testUpdateEventMetadataByTypeWithInvalidStartDate() throws IOException {
+    String jsonString = IOUtils.toString(getClass().getResource("/event-metadata-update-invalid-date.json"), UTF_8);
+    String eventId = TestEventsEndpoint.METADATA_UPDATE_EVENT;
+    given().formParam("metadata", jsonString).pathParam("event_id", eventId)
+            .queryParam("type", "dublincore/episode")
+            .expect().statusCode(SC_BAD_REQUEST).when().put(env.host("{event_id}/metadata"));
   }
 
   /**

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/TestEventsEndpoint.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/TestEventsEndpoint.java
@@ -35,6 +35,7 @@ import org.opencastproject.elasticsearch.index.objects.event.Event;
 import org.opencastproject.index.service.api.IndexService;
 import org.opencastproject.index.service.catalog.adapter.events.CommonEventCatalogUIAdapter;
 import org.opencastproject.index.service.exception.IndexServiceException;
+import org.opencastproject.index.service.exception.MetadataValidationException;
 import org.opencastproject.ingest.api.IngestService;
 import org.opencastproject.mediapackage.Catalog;
 import org.opencastproject.mediapackage.MediaPackage;
@@ -87,6 +88,7 @@ public class TestEventsEndpoint extends EventsEndpoint {
   public static final String UNAUTHORIZED_TYPE = "unauthorizedcatalog";
   public static final String UPDATE_EVENT = "updateevent";
   public static final String METADATA_UPDATE_EVENT = "metadataupdateevent";
+  public static final String METADATA_VALIDATION_EVENT = "metadatavalidationevent";
   public static final String METADATA_GET_EVENT = "metadatagetevent";
   public static final String SCHEDULING_GET_EVENT = "schedulinggetevent";
   public static final String SCHEDULING_UPDATE_EVENT = "schedulingupdateevent";
@@ -231,6 +233,21 @@ public class TestEventsEndpoint extends EventsEndpoint {
     EasyMock.expect(indexService.updateEventMetadata(eq(METADATA_UPDATE_EVENT), capture(capturedMetadataList2),
         eq(elasticsearchIndex))).andReturn(null).anyTimes();
     EasyMock.expect(indexService.getEventMediapackage(updateEventMetadata)).andReturn(null).anyTimes();
+
+    /**
+     * Update event metadata failing validation while storing the catalog. The offending field is 'title', so a request
+     * updating the title is the client's fault while any other request hits a title which was already empty in the
+     * stored catalog.
+     */
+    Event metadataValidationEvent = new Event(METADATA_VALIDATION_EVENT, defaultOrg.getId());
+    metadataValidationEvent.setRecordingStartDate("2017-08-29T00:05:00.000Z");
+    EasyMock.expect(indexService.getEvent(METADATA_VALIDATION_EVENT, elasticsearchIndex))
+        .andReturn(Optional.of(metadataValidationEvent)).anyTimes();
+    EasyMock.expect(indexService.updateEventMetadata(eq(METADATA_VALIDATION_EVENT),
+        EasyMock.anyObject(MetadataList.class), eq(elasticsearchIndex)))
+        .andThrow(new MetadataValidationException("title", "The event metadata field with id 'title' and the "
+            + "metadata type 'TEXT' is required and can not be empty!.")).anyTimes();
+    EasyMock.expect(indexService.getEventMediapackage(metadataValidationEvent)).andReturn(null).anyTimes();
 
     /**
      * Update event track data

--- a/modules/external-api/src/test/resources/event-metadata-update-invalid-date.json
+++ b/modules/external-api/src/test/resources/event-metadata-update-invalid-date.json
@@ -1,0 +1,6 @@
+[
+  {
+    "id": "startDate",
+    "value": "not a date"
+  }
+]

--- a/modules/external-api/src/test/resources/event-metadata-update-subject-only.json
+++ b/modules/external-api/src/test/resources/event-metadata-update-subject-only.json
@@ -1,0 +1,6 @@
+[
+  {
+    "id": "subject",
+    "value": "What this is about - edited"
+  }
+]

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/DublinCoreMetadataUtil.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/DublinCoreMetadataUtil.java
@@ -21,6 +21,7 @@
 
 package org.opencastproject.index.service.catalog.adapter;
 
+import org.opencastproject.index.service.exception.MetadataValidationException;
 import org.opencastproject.mediapackage.EName;
 import org.opencastproject.metadata.dublincore.DCMIPeriod;
 import org.opencastproject.metadata.dublincore.DublinCore;
@@ -88,14 +89,14 @@ public final class DublinCoreMetadataUtil {
           setIterableString(dc, field, ename);
         } else {
           if (field.isRequired() && StringUtils.isBlank(field.getValue().toString())) {
-            throw new IllegalArgumentException(String.format(
+            throw new MetadataValidationException(field.getInputID(), String.format(
                 "The event metadata field with id '%s' and the metadata type '%s' is required and can not be empty!.",
                 field.getInputID(), field.getType()));
           }
           dc.set(ename, field.getValue().toString());
         }
       } else if (field.getValue() == null && field.isRequired()) {
-        throw new IllegalArgumentException(String.format(
+        throw new MetadataValidationException(field.getInputID(), String.format(
                 "The event metadata field with id '%s' and the metadata type '%s' is required and can not be empty!.",
                 field.getInputID(), field.getType()));
       }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/exception/MetadataValidationException.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/exception/MetadataValidationException.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.index.service.exception;
+
+/**
+ * An exception indicating that a metadata field did not pass validation while storing a catalog.
+ * <p>
+ * In contrast to a plain {@link IllegalArgumentException}, this exception names the field which failed validation. That
+ * allows callers to distinguish a value sent by a client from a field which was already invalid in the stored catalog,
+ * and to pick an appropriate response for either case.
+ * <p>
+ * This extends {@link IllegalArgumentException} so that existing handlers keep working unchanged.
+ */
+public class MetadataValidationException extends IllegalArgumentException {
+
+  private static final long serialVersionUID = 6320734174319294928L;
+
+  private final String fieldId;
+
+  /**
+   * Create a new exception for the field which failed validation.
+   *
+   * @param fieldId
+   *          The input identifier of the metadata field which failed validation.
+   * @param message
+   *          The message describing the validation failure.
+   */
+  public MetadataValidationException(String fieldId, String message) {
+    super(message);
+    this.fieldId = fieldId;
+  }
+
+  /**
+   * Returns the input identifier of the metadata field which failed validation.
+   *
+   * @return The field identifier.
+   */
+  public String getFieldId() {
+    return fieldId;
+  }
+
+}


### PR DESCRIPTION
Updating event or series metadata via the External API could fail with an unhandled IllegalArgumentException thrown while storing the Dublin Core catalog. Nothing caught it, so CXF turned it into an HTTP 500 and logged two full stack traces per request: a WARN from PhaseInterceptorChain and an ERROR from AbstractFaultChainInitiatorObserver claiming an unexpected error occurred during error handling. The latter is particularly misleading since it suggests a defect in Opencast's error handling. On a production admin node a single misbehaving client caused 598 such log blocks within five days.

The exception has two rather different causes which deserve different responses:

- the client sent a value which ends up empty for a required field. The endpoint's own validation misses this if the value only becomes empty after being transformed, e.g. an empty list of subjects.
- a required field the client never touched is already empty in the stored catalog. Since all catalogs are loaded and stored again, such a pre-existing inconsistency aborts a completely unrelated update and there is nothing the client can do about it.

To tell those apart, DublinCoreMetadataUtil now throws a MetadataValidationException naming the field which failed validation. It extends IllegalArgumentException so that all existing handlers keep working. The endpoints remember which fields a request actually modified and answer with 400 for the client's own values or with 500, logging a single line naming the event and the field, if the stored catalog is at fault.

Additionally, invalid start dates and malformed subject lists sent by a client are answered with 400 instead of escaping as well, and the documented response codes have been updated.

Fixes #7919

### AI Usage
Used Claude for analysis and fix.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
