### PR TITLE
Stop logging stack traces for HTTP client errors

### DIFF
--- a/etc/org.ops4j.pax.logging.cfg
+++ b/etc/org.ops4j.pax.logging.cfg
@@ -37,6 +37,10 @@ log4j2.logger.felix.name = org.apache.felix
 log4j2.logger.felix.level = WARN
 log4j2.logger.cxf.name = org.apache.cxf
 log4j2.logger.cxf.level = WARN
+# CXF logs a full stack trace at WARN for every client error other than 404. Client errors are not
+# server faults and the traces carry no request details, so this only floods the log.
+log4j2.logger.cxf-wae-mapper.name = org.apache.cxf.jaxrs.impl.WebApplicationExceptionMapper
+log4j2.logger.cxf-wae-mapper.level = ERROR
 log4j2.logger.jetty.name = org.eclipse.jetty
 log4j2.logger.jetty.level = ERROR
 


### PR DESCRIPTION
CXF's WebApplicationExceptionMapper logs a full stack trace at WARN for every client error other than 404, and we ship the whole org.apache.cxf tree at WARN. On a public-facing presentation node that means every malformed or hostile request writes about 140 lines into opencast.log. On our presentation node 97% of the log consisted of such traces, nearly all of them from a single burst of HTTP 405s caused by a scanner.

The traces contain neither the request path, nor the method, nor the client address, so they are not actionable, and they let an unauthenticated client inflate the log by ~14KB per request.

Silence that mapper. Note that this also drops the trace for a WebApplicationException carrying a 5xx, but server faults are logged by the endpoints themselves anyway.

Fixes #7937

### AI Usage
Used Claude for log analysis and patch

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
