### PR TITLE
Clean up JSON dependency declarations

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -700,7 +700,6 @@
 
     <!-- graphql transitive dependencies -->
     <bundle dependency="true">mvn:org.antlr/antlr4-runtime/4.7.2</bundle>
-    <bundle dependency="true">mvn:com.fasterxml.jackson.datatype/jackson-datatype-jdk8/${jackson.version}</bundle>
     <bundle dependency="true">mvn:com.fasterxml.jackson.datatype/jackson-datatype-jsr310/${jackson.version}</bundle>
     <bundle dependency="true">mvn:org.reactivestreams/reactive-streams/1.0.4</bundle>
     <bundle dependency="true">mvn:commons-beanutils/commons-beanutils/1.9.4</bundle>

--- a/modules/admin-service/pom.xml
+++ b/modules/admin-service/pom.xml
@@ -264,7 +264,6 @@
     <dependency>
       <groupId>uk.co.datumedge</groupId>
       <artifactId>hamcrest-json</artifactId>
-      <version>0.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/modules/elasticsearch-index/pom.xml
+++ b/modules/elasticsearch-index/pom.xml
@@ -105,7 +105,6 @@
     <dependency>
       <groupId>uk.co.datumedge</groupId>
       <artifactId>hamcrest-json</artifactId>
-      <version>0.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/modules/external-api/pom.xml
+++ b/modules/external-api/pom.xml
@@ -211,7 +211,6 @@
     <dependency>
       <groupId>uk.co.datumedge</groupId>
       <artifactId>hamcrest-json</artifactId>
-      <version>0.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/modules/external-api/pom.xml
+++ b/modules/external-api/pom.xml
@@ -191,7 +191,6 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>${gson.version}</version>
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>

--- a/modules/index-service/pom.xml
+++ b/modules/index-service/pom.xml
@@ -213,7 +213,6 @@
     <dependency>
       <groupId>uk.co.datumedge</groupId>
       <artifactId>hamcrest-json</artifactId>
-      <version>0.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/modules/playlists/pom.xml
+++ b/modules/playlists/pom.xml
@@ -54,12 +54,10 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -68,7 +66,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-xml</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>

--- a/modules/termination-state-impl/pom.xml
+++ b/modules/termination-state-impl/pom.xml
@@ -28,7 +28,6 @@
     <dependency>
       <groupId>com.googlecode.json-simple</groupId>
       <artifactId>json-simple</artifactId>
-      <version>${json-simple.version}</version>
     </dependency>
 
     <!-- Other build dependencies-->

--- a/modules/workflow-service-api/pom.xml
+++ b/modules/workflow-service-api/pom.xml
@@ -60,22 +60,18 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
     <gson.version>2.13.2</gson.version>
     <guava.version>33.3.1-jre</guava.version>
     <failureaccess.version>1.0.2</failureaccess.version>
+    <hamcrest-json.version>0.2</hamcrest-json.version>
     <httpcomponents-httpclient.version>4.5.14</httpcomponents-httpclient.version>
     <httpcomponents-httpcore.version>4.4.16</httpcomponents-httpcore.version>
     <jackson.version>2.17.2</jackson.version>
@@ -1249,6 +1250,12 @@
         <groupId>io.rest-assured</groupId>
         <artifactId>rest-assured</artifactId>
         <version>${rest-assured.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>uk.co.datumedge</groupId>
+        <artifactId>hamcrest-json</artifactId>
+        <version>${hamcrest-json.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1325,9 +1325,26 @@
         <artifactId>jackson-databind</artifactId>
         <version>${jackson.version}</version>
       </dependency>
+      <!--
+        Managed although no module declares it: the Elasticsearch client (elasticsearch-x-content)
+        pulls this in transitively at 2.10.4. Managing it here lifts that to ${jackson.version} so it
+        matches the bundle installed by assemblies/karaf-features/src/main/feature/feature.xml.
+        Do not remove; the version would silently fall back to the Elasticsearch one.
+      -->
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-cbor</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <!-- Same as cbor above: also supplied transitively at 2.10.4 by elasticsearch-x-content. -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-yaml</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-xml</artifactId>
         <version>${jackson.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
While auditing which JSON libraries Opencast actually uses, a few problems turned up in how the
dependencies are declared. This fixes those. It changes no Java code and no JSON output format.

Four commits, smallest blast radius first:

**Manage `jackson-dataformat-yaml` and `-xml` centrally.** Neither artifact was listed in the root
`dependencyManagement`, so their versions had to be pinned at each use site. That hid a real version
skew: `elasticsearch-x-content` supplies `jackson-dataformat-yaml` transitively at **2.10.4**, while
the Karaf feature installs the bundle at `${jackson.version}` (2.17.2). Five modules —
`adopter-registration-impl`, `elasticsearch-impl`, `live-schedule-impl`, `search-service-api` and
`search-service-impl` — therefore compiled against 2.10.4 but ran against 2.17.2. This is the only
commit that changes dependency resolution, kept separate so it can be reverted on its own.

It also adds a comment explaining why `jackson-dataformat-cbor` is managed even though no module
declares it. That entry looks removable but is not: it pins the same Elasticsearch-supplied 2.10.4
transitive up to the version we actually ship.

**Drop redundant `<version>` tags.** Eight declarations in four modules repeated a version the root
`dependencyManagement` already provides, which just adds a second place to update and lets the two
drift apart.

**Manage the `hamcrest-json` version centrally.** It was hardcoded as `0.2` in each of the four
modules using it, with no managed entry keeping them in step. Now a property plus a
`dependencyManagement` entry, matching the neighbouring rest-assured test dependencies.

**Drop the unused `jackson-datatype-jdk8` bundle.** Listed in the Karaf feature as a GraphQL
transitive dependency, but nothing needs it: no bundle in the distribution imports
`com.fasterxml.jackson.datatype.jdk8`, neither `graphql-java` nor `graphql-java-annotations`
declares a Jackson dependency at all, and `GraphQLObjectMapper` registers its modules explicitly
rather than discovering them, so `Jdk8Module` was never loaded reflectively either. It was also the
only Jackson artifact backed by no pom whatsoever, so its version came solely from the property
expanded into the feature descriptor.

Two related things deliberately left alone: `jackson-dataformat-smile` is also on 2.10.4 in eleven
modules, but nothing installs or imports it, so managing it would only imply it matters. And
`jackson-jaxrs-json-provider` resolves to 2.16.2 in `kernel` — it comes from CXF and is `provided`
scope, so it seemed better not to override it as a drive-by.

### How to test this patch

The important check is that dependency resolution moves in exactly one place and nowhere else:

```
./mvnw dependency:tree -Dincludes='com.fasterxml.jackson.core:*,com.fasterxml.jackson.dataformat:*,com.fasterxml.jackson.datatype:*,com.fasterxml.jackson.module:*,com.google.code.gson:*,com.googlecode.json-simple:*,org.codehaus.jettison:*,uk.co.datumedge:*'
```

Run it before and after the branch and diff. The only difference should be
`jackson-dataformat-yaml` going 2.10.4 → 2.17.2 in the five modules named above. Anything else
moving would mean a `<version>` was removed that was not actually redundant.

Then a normal build, plus tests for the modules whose dependencies changed:

```
./mvnw clean install -Pdev -DskipTests -Dcheckstyle.skip=true
./mvnw test -pl modules/admin-service,modules/elasticsearch-index,modules/external-api,modules/index-service,modules/playlists,modules/search-service-impl,modules/live-schedule-impl,modules/workflow-service-impl
```

Note `workflow-service-api` owns `YamlWorkflowParser`, the main consumer of the yaml dataformat, but
has no tests of its own — the parser is only covered indirectly from `workflow-service-impl`, which
is why that module is in the list instead.

For the removed jdk8 bundle, a running instance is needed, and GraphQL is **off by default** — with
the plugin disabled the feature is never installed and a clean startup log proves nothing. Enable it
first:

```
opencast-plugin-graphql = on     # etc/org.opencastproject.plugin.impl.PluginManagerImpl.cfg
```

Then confirm the feature installs and every bundle resolves, and that queries answer:

```
curl -u admin:opencast -X POST http://127.0.0.1:8080/graphql \
  -H 'Content-Type: application/json' \
  -d '{"query":"{ currentUser { username name } }"}'

curl -u admin:opencast -X POST http://127.0.0.1:8080/graphql \
  -H 'Content-Type: application/json' \
  -d '{"query":"query q($l: Int) { allSeries(limit: $l) { totalCount nodes { id title created } } }","variables":{"l":2}}'
```

`data/log/opencast.log` should contain no `ERROR`, no unresolved-bundle and no
`ClassNotFoundException` entries.

### AI Usage

AI was used significantly here. I asked Claude to audit which JSON libraries the codebase actually
uses, and this pull request is the cleanup half of what that audit turned up; it wrote the pom
changes and this description.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
