### PR TITLE
Add logging to aid debugging of videosegmenter issues

### DIFF
--- a/modules/videosegmenter-ffmpeg/src/main/java/org/opencastproject/videosegmenter/ffmpeg/VideoSegmenterServiceImpl.java
+++ b/modules/videosegmenter-ffmpeg/src/main/java/org/opencastproject/videosegmenter/ffmpeg/VideoSegmenterServiceImpl.java
@@ -814,13 +814,18 @@ public class VideoSegmenterServiceImpl extends AbstractJobProducer implements
       // calculate errors for "normal" and filtered segmentation
       // and compare them to find better optimization.
       // "normal"
-      OptimizationStep currentStep = new OptimizationStep(changesThresholdLocal, segments.size(), prefNumberLocal,
-              mpeg7, segments);
+      OptimizationStep currentStep = new OptimizationStep(
+          changesThresholdLocal,
+          segments.size(),
+          prefNumberLocal,
+          mpeg7, segments);
       // filtered
       LinkedList<Segment> segmentsNew = new LinkedList<Segment>();
       OptimizationStep currentStepFiltered = new OptimizationStep(
-              changesThresholdLocal, 0,
-              prefNumberLocal, filterSegmentation(segments, track, segmentsNew, stabilityThreshold * 1000), segments);
+          changesThresholdLocal,
+          0,
+          prefNumberLocal,
+          filterSegmentation(segments, track, segmentsNew, stabilityThreshold * 1000), segments);
       currentStepFiltered.setSegmentNumAndRecalcErrors(segmentsNew.size());
 
       logger.info("Segmentation yields {} segments after filtering", segmentsNew.size());

--- a/modules/videosegmenter-ffmpeg/src/main/java/org/opencastproject/videosegmenter/ffmpeg/VideoSegmenterServiceImpl.java
+++ b/modules/videosegmenter-ffmpeg/src/main/java/org/opencastproject/videosegmenter/ffmpeg/VideoSegmenterServiceImpl.java
@@ -1066,7 +1066,8 @@ public class VideoSegmenterServiceImpl extends AbstractJobProducer implements
               .createSegment("segment-" + segmentcount);
           segment.setMediaTime(new MediaRelTimeImpl(starttime,
               endtime - starttime));
-          logger.debug("Created segment {} at start time {} with duration {}", segmentcount, starttime, endtime);
+          logger.debug("Created segment {} at start time {} with duration {}", segmentcount,
+              starttime, endtime - starttime);
           segments.add(segment);
           segmentcount++;
           starttime = endtime;

--- a/modules/videosegmenter-ffmpeg/src/main/java/org/opencastproject/videosegmenter/ffmpeg/VideoSegmenterServiceImpl.java
+++ b/modules/videosegmenter-ffmpeg/src/main/java/org/opencastproject/videosegmenter/ffmpeg/VideoSegmenterServiceImpl.java
@@ -974,8 +974,13 @@ public class VideoSegmenterServiceImpl extends AbstractJobProducer implements
 
     // if no reasonable segmentation could be found, instead return a uniform segmentation
     if (tmpSegments.size() < absoluteMinLocal || tmpSegments.size() > absoluteMaxLocal) {
-      mpeg7 = uniformSegmentation(track, tmpSegments, prefNumberLocal);
+      //NB: run these log lines first!  The uniformSegmentation below *overwrites* tmpSegments!
       logger.info("Since no reasonable segmentation could be found, a uniform segmentation was created");
+      logger.debug("{}, too few segments? {}, {} < {}",
+          track.getIdentifier(), tmpSegments.size() < absoluteMinLocal, tmpSegments.size(), absoluteMinLocal);
+      logger.debug("{} too many segments? {}, {} > {}",
+          track.getIdentifier(), tmpSegments.size() > absoluteMaxLocal, tmpSegments.size(), absoluteMaxLocal);
+      mpeg7 = uniformSegmentation(track, tmpSegments, prefNumberLocal);
     }
 
     return mpeg7;


### PR DESCRIPTION
During some debugging for a client, I ran into a few ugly bits in the video segmenter.  This PR specifically:
**
**Adds logging at debug about *why* no reasonable segmentation was found.**
**Logs the duration, rather than the end time, to match the log message.**

and fixes some formatting.  Developed against 19, but I'm not picky.

### How to test this patch

Make your video segmenter settings extremely agressive (hint: set the absolute minimum to be something huge), set the relevant debug stanza to debug and let it rip.

### AI Usage

N/A

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] ~include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)~
