### PR TITLE
Clean up duplicate and dead dependency declarations

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -84,7 +84,7 @@
     <feature version="[5.7.12,5.8)">spring-security</feature>
 
     <!-- Spring Security 5: LDAP has NOT been tested -->
-    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-security-ldap/${spring-security-ldap.version}</bundle>
+    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-security-ldap/${spring-security-ldap-servicemix.version}</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-ldap/2.4.1_1</bundle>
 
     <bundle>mvn:com.nimbusds/nimbus-jose-jwt/10.4.2</bundle>

--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -112,7 +112,7 @@
               <library>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.saaj-api-1.4/1.4_2;type:=endorsed;export:=true</library>
               <library>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.activation-api-1.1/2.8.0;type:=endorsed;export:=true</library>
               <library>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.stax-api-1.2/2.8.0;type:=endorsed;export:=true</library>
-              <library>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xerces/2.12.0_1;type:=boot;export:=true</library>
+              <library>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xerces/2.12.1_1;type:=boot;export:=true</library>
             </libraries>
             <archiveZip>false</archiveZip>
             <archiveTarGz>false</archiveTarGz>
@@ -122,14 +122,12 @@
               <feature>opencast-plugin-crop_allinone</feature>
               <feature>opencast-plugin-crop_admin</feature>
               <feature>opencast-plugin-crop_worker</feature>
-              <feature>opencast-plugin-legacy-annotation</feature>
               <feature>opencast-plugin-transcription-services</feature>
               <feature>opencast-plugin-userdirectory-brightspace</feature>
               <feature>opencast-plugin-userdirectory-canvas</feature>
               <feature>opencast-plugin-userdirectory-moodle</feature>
               <feature>opencast-plugin-userdirectory-sakai</feature>
               <feature>opencast-plugin-userdirectory-studip</feature>
-              <feature>opencast-plugin-userdirectory-brightspace</feature>
               <feature>opencast-plugin-usertracking</feature>
               <feature>opencast-plugin-graphql</feature>
             </installedFeatures>

--- a/pom.xml
+++ b/pom.xml
@@ -29,14 +29,13 @@
     <eclipselink.version>2.7.15</eclipselink.version>
     <eclipselink.asm.version>9.7.1</eclipselink.asm.version>
     <elasticsearch.version>7.10.2</elasticsearch.version>
-    <failureaccess.version>1.0.1</failureaccess.version>
+    <failureaccess.version>1.0.2</failureaccess.version>
     <freemarker.version>2.3.32</freemarker.version>
     <graphql.version>21.5</graphql.version>
     <graphql-annotations.version>21.5</graphql-annotations.version>
     <graphql-java-extended-scalars.version>21.0</graphql-java-extended-scalars.version>
     <gson.version>2.13.2</gson.version>
     <guava.version>33.3.1-jre</guava.version>
-    <failureaccess.version>1.0.2</failureaccess.version>
     <httpcomponents-httpclient.version>4.5.14</httpcomponents-httpclient.version>
     <httpcomponents-httpcore.version>4.4.16</httpcomponents-httpcore.version>
     <jackson.version>2.17.2</jackson.version>
@@ -68,7 +67,10 @@
     <spring.version>5.3.39</spring.version>
     <spring-security.version>5.7.12</spring-security.version>
     <spring-security-cas.version>5.7.12_4</spring-security-cas.version>
-    <spring-security-ldap.version>5.8.6_1</spring-security-ldap.version>
+    <!-- Compile-time artifact and the ServiceMix OSGi repackage installed by feature.xml must stay in
+         sync; the suffixed version is the ServiceMix rebuild of the same upstream release. -->
+    <spring-security-ldap.version>5.8.6</spring-security-ldap.version>
+    <spring-security-ldap-servicemix.version>5.8.6_1</spring-security-ldap-servicemix.version>
     <xmlsec.version>2.2.6</xmlsec.version>
   </properties>
   <modules>
@@ -1103,7 +1105,7 @@
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-ldap</artifactId>
-        <version>${spring-security.version}</version>
+        <version>${spring-security-ldap.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.santuario</groupId>
@@ -1144,12 +1146,6 @@
         <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
         <version>5.5.0</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.easymock</groupId>
-        <artifactId>easymockclassextension</artifactId>
-        <version>3.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -1272,6 +1268,8 @@
         <artifactId>hamcrest</artifactId>
         <version>3.0</version>
       </dependency>
+      <!-- Not declared by any module, but junit pulls it in transitively at 1.3.
+           Managing it keeps that in step with the hamcrest version above. -->
       <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-core</artifactId>
@@ -1281,12 +1279,6 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>4.13.2</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter</artifactId>
-        <version>${junit5.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -1474,7 +1466,7 @@
         <!-- use this to generate a code coverage report: -->
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.2</version>
+        <version>0.8.12</version>
         <configuration>
           <skip>${maven.test.skip}</skip>
           <output>file</output>


### PR DESCRIPTION
A number of long-standing inconsistencies had accumulated in the build files. None of them change what
is built, but each is a trap for the next person to touch these files:

* **`failureaccess.version` was declared twice** in the root pom, as `1.0.1` and `1.0.2`. Maven
  silently uses the last one, so the first was dead. Kept the effective value and put it back at the
  alphabetically correct position.

* **`spring-security-ldap` had a compile-vs-runtime version skew.** It was compiled against `5.7.12`,
  inherited from `spring-security.version`, while `feature.xml` installs the ServiceMix repackage of
  `5.8.6` at runtime. The compile-time artifact now follows what actually runs. Because the two use
  different version formats (`5.8.6` vs `5.8.6_1`), the ServiceMix bundle got its own clearly named
  property instead of sharing one.

* **Dropped two managed dependencies** that no module declares, no source imports and nothing pulls in
  transitively: `easymockclassextension` (obsolete since the class extension was folded into EasyMock
  3.x) and the `junit-jupiter` aggregate (only `junit-jupiter-api` is used, by `engage-ui`, `graphql`
  and `runtime-info-ui`).

  Note `hamcrest-core` looks equally unused but is **not**: junit depends on it, and the managed entry
  is what keeps it in step with `hamcrest` 3.0. Removing it would silently downgrade every module's
  test classpath from 3.0 to 1.3. That is now recorded in a comment so it does not look like an
  oversight next time.

* **`assemblies/pom.xml` installed a feature that does not exist**, `opencast-plugin-legacy-annotation`,
  and listed `opencast-plugin-userdirectory-brightspace` twice.

* **Aligned the ServiceMix Xerces version** on the Karaf boot classpath (`2.12.0_1`) with the one
  `feature.xml` installs (`2.12.1_1`).

* **The `<reporting>` section still pinned jacoco 0.8.2** while the build section uses 0.8.12.

This is the first of three independent branches that clean up dependency declarations. The other two
are "Remove Commons HttpClient 3.1" and "Drop unused bundles from the ext-core feature". They touch
mostly different places, are cut separately from `develop` and can be merged in any order.

### How to test this patch

No configuration or set-up beyond a normal development build is needed.

```
./mvnw clean install -Pdev -DskipTests
```

The interesting change is the `spring-security-ldap` version, so the modules to look at are `kernel`,
`security-ldap` and `userdirectory-ldap`:

```
./mvnw -pl modules/kernel,modules/security-ldap,modules/userdirectory-ldap test
```

To confirm the runtime side, start a distribution and check that the LDAP bundles come up and that the
version actually installed is the one now compiled against:

```
cd build/opencast-dist-develop-*-SNAPSHOT
./bin/start-opencast
grep spring-security-ldap data/log/opencast.log
```

That should report `org.apache.servicemix.bundles.spring-security-ldap … version 5.8.6.1`, and

```
curl -u admin:opencast http://localhost:8080/sysinfo/bundles/check
```

should return `true`.

What was tested before opening this:

* Full build with `-Pdev`: BUILD SUCCESS.
* `kernel`, `security-ldap` and `userdirectory-ldap` build and test green against `spring-security-ldap`
  5.8.6.
* A distribution was booted against the OpenSearch dependency container: no `Unable to resolve`,
  `Unresolved constraint`, `ClassNotFoundException` or `NoClassDefFoundError` in `opencast.log` or
  `karaf.log`, zero `ERROR` lines, `/sysinfo/bundles/check` returned `true`, and both
  `opencast-security-ldap` and `opencast-userdirectory-ldap` were active.
* An event was ingested via `ingest/addMediaPackage/fast` and the `fast` workflow ran to `SUCCEEDED`.

LDAP itself was not tested against a real directory server; the check above only confirms the bundles
resolve and start with the aligned version.

### AI Usage

This patch was produced with Claude Code, used for the whole cycle: auditing the
dependency declarations, writing the changes, and verifying them.

Worth knowing for reviewers, because it says something about where to look hardest:

* The audit was done by grepping for imports and cross-referencing the poms. That method produced
  several **false positives**, all caught before they were committed: it flagged `c3p0` in
  `admin-service` and `commons-logging` in `security-shibboleth` as unused, when both are genuinely
  needed (the first at test runtime via `DBTestEnv`, the second because
  `ShibbolethRequestHeaderAuthenticationFilter` calls `logger.info()` on an *inherited* commons-logging
  field, so there is no `import` line to find). Neither was removed.
* The `hamcrest-core` entry described above was initially removed on the same faulty reasoning and
  restored once a build showed junit resolving it transitively.
* Every claim that survived was checked by building and by booting a distribution, rather than by
  reading code alone.


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)

