### PR TITLE
Remove Commons HttpClient 3.1

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -24,7 +24,6 @@
     <!-- httpclient needs to start before common so that it can get org.apache.commons.logging -->
     <bundle start-level="55">mvn:org.apache.httpcomponents/httpclient-osgi/${httpcomponents-httpclient.version}</bundle>
     <bundle start-level="55">mvn:org.apache.httpcomponents/httpcore-osgi/${httpcomponents-httpcore.version}</bundle>
-    <bundle start-level="55">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.commons-httpclient/3.1_7</bundle>
     <bundle start-level="55">mvn:commons-codec/commons-codec/${commons-codec.version}</bundle>
 
     <!-- JPA -->

--- a/modules/admin-service/pom.xml
+++ b/modules/admin-service/pom.xml
@@ -238,11 +238,6 @@
       <groupId>org.mnode.ical4j</groupId>
       <artifactId>ical4j</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.apache.servicemix.bundles</groupId>
-      <artifactId>org.apache.servicemix.bundles.commons-httpclient</artifactId>
-      <scope>test</scope>
-    </dependency>
     <!-- Testing -->
     <dependency>
       <groupId>junit</groupId>

--- a/modules/admin-service/src/test/java/org/opencastproject/adminui/endpoint/AclEndpointTest.java
+++ b/modules/admin-service/src/test/java/org/opencastproject/adminui/endpoint/AclEndpointTest.java
@@ -30,7 +30,7 @@ import org.opencastproject.adminui.util.ServiceEndpointTestsUtil;
 import org.opencastproject.test.rest.NotFoundExceptionMapper;
 import org.opencastproject.test.rest.RestServiceTestEnv;
 
-import org.apache.commons.httpclient.HttpStatus;
+import org.apache.http.HttpStatus;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;

--- a/modules/admin-service/src/test/java/org/opencastproject/adminui/endpoint/JobEndpointTest.java
+++ b/modules/admin-service/src/test/java/org/opencastproject/adminui/endpoint/JobEndpointTest.java
@@ -64,7 +64,7 @@ public class JobEndpointTest {
   @Test
   public void testSortCreator() {
     given().param("sort", "creator:ASC").expect()
-            .statusCode(org.apache.commons.httpclient.HttpStatus.SC_OK).contentType(ContentType.JSON)
+            .statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
             .body("count", equalTo(4)).body("total", equalTo(4))
             .body("results[0].creator", equalTo("testuser1"))
             .body("results[1].creator", equalTo("testuser1"))
@@ -73,7 +73,7 @@ public class JobEndpointTest {
             .when().get(rt.host("/jobs.json"));
 
     given().param("sort", "creator:DESC").expect()
-            .statusCode(org.apache.commons.httpclient.HttpStatus.SC_OK).contentType(ContentType.JSON)
+            .statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
             .body("count", equalTo(4)).body("total", equalTo(4))
             .body("results[0].creator", equalTo("testuser3"))
             .body("results[1].creator", equalTo("testuser2"))
@@ -85,7 +85,7 @@ public class JobEndpointTest {
   @Test
   public void testSortOperation() {
     given().param("sort", "operation:ASC").expect()
-            .statusCode(org.apache.commons.httpclient.HttpStatus.SC_OK).contentType(ContentType.JSON)
+            .statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
             .body("count", equalTo(4)).body("total", equalTo(4))
             .body("results[0].operation", equalTo("Encode"))
             .body("results[1].operation", equalTo("Inspect"))
@@ -94,7 +94,7 @@ public class JobEndpointTest {
             .when().get(rt.host("/jobs.json"));
 
     given().param("sort", "operation:DESC").expect()
-            .statusCode(org.apache.commons.httpclient.HttpStatus.SC_OK).contentType(ContentType.JSON)
+            .statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
             .body("count", equalTo(4)).body("total", equalTo(4))
             .body("results[0].operation", equalTo("test"))
             .body("results[1].operation", equalTo("RESUME"))
@@ -106,7 +106,7 @@ public class JobEndpointTest {
   @Test
   public void testSortProcessingHost() {
     given().param("sort", "processingHost:ASC").expect()
-            .statusCode(org.apache.commons.httpclient.HttpStatus.SC_OK).contentType(ContentType.JSON)
+            .statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
             .body("count", equalTo(4)).body("total", equalTo(4))
             .body("results[0].processingHost", equalTo("host1"))
             .body("results[1].processingHost", equalTo("host1"))
@@ -115,7 +115,7 @@ public class JobEndpointTest {
             .when().get(rt.host("/jobs.json"));
 
     given().param("sort", "processingHost:DESC").expect()
-            .statusCode(org.apache.commons.httpclient.HttpStatus.SC_OK).contentType(ContentType.JSON)
+            .statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
             .body("count", equalTo(4)).body("total", equalTo(4))
             .body("results[0].processingHost", equalTo("host3"))
             .body("results[1].processingHost", equalTo("host2"))
@@ -127,7 +127,7 @@ public class JobEndpointTest {
   @Test
   public void testSortStarted() {
     given().param("sort", "started:ASC").expect()
-            .statusCode(org.apache.commons.httpclient.HttpStatus.SC_OK).contentType(ContentType.JSON)
+            .statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
             .body("count", equalTo(4)).body("total", equalTo(4))
             .body("results[0].started", equalTo("2014-06-05T09:05:00Z"))
             .body("results[1].started", equalTo("2014-06-05T09:10:00Z"))
@@ -136,7 +136,7 @@ public class JobEndpointTest {
             .when().get(rt.host("/jobs.json"));
 
     given().param("sort", "started:DESC").expect()
-            .statusCode(org.apache.commons.httpclient.HttpStatus.SC_OK).contentType(ContentType.JSON)
+            .statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
             .body("count", equalTo(4)).body("total", equalTo(4))
             .body("results[0].started", equalTo("2014-06-05T09:16:00Z"))
             .body("results[1].started", equalTo("2014-06-05T09:11:11Z"))
@@ -148,7 +148,7 @@ public class JobEndpointTest {
   @Test
   public void testSortSubmitted() {
     given().param("sort", "submitted:ASC").expect()
-            .statusCode(org.apache.commons.httpclient.HttpStatus.SC_OK).contentType(ContentType.JSON)
+            .statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
             .body("count", equalTo(4)).body("total", equalTo(4))
             .body("results[0].submitted", equalTo("2014-06-05T09:05:00Z"))
             .body("results[1].submitted", equalTo("2014-06-05T09:10:00Z"))
@@ -157,7 +157,7 @@ public class JobEndpointTest {
             .when().get(rt.host("/jobs.json"));
 
     given().param("sort", "started:DESC").expect()
-            .statusCode(org.apache.commons.httpclient.HttpStatus.SC_OK).contentType(ContentType.JSON)
+            .statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
             .body("count", equalTo(4)).body("total", equalTo(4))
             .body("results[0].submitted", equalTo("2014-06-05T09:16:00Z"))
             .body("results[1].submitted", equalTo("2014-06-05T09:11:11Z"))
@@ -169,7 +169,7 @@ public class JobEndpointTest {
   @Test
   public void testSortType() {
     given().param("sort", "type:ASC").expect()
-            .statusCode(org.apache.commons.httpclient.HttpStatus.SC_OK).contentType(ContentType.JSON)
+            .statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
             .body("count", equalTo(4)).body("total", equalTo(4))
             .body("results[0].type", equalTo("org.opencastproject.composer"))
             .body("results[1].type", equalTo("org.opencastproject.composer"))
@@ -178,7 +178,7 @@ public class JobEndpointTest {
             .when().get(rt.host("/jobs.json"));
 
     given().param("sort", "type:DESC").expect()
-            .statusCode(org.apache.commons.httpclient.HttpStatus.SC_OK).contentType(ContentType.JSON)
+            .statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
             .body("count", equalTo(4)).body("total", equalTo(4))
             .body("results[0].type", equalTo("org.opencastproject.workflow"))
             .body("results[1].type", equalTo("org.opencastproject.inspection"))

--- a/modules/admin-service/src/test/java/org/opencastproject/adminui/endpoint/ServerEndpointTest.java
+++ b/modules/admin-service/src/test/java/org/opencastproject/adminui/endpoint/ServerEndpointTest.java
@@ -28,7 +28,7 @@ import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses
 import org.opencastproject.adminui.util.ServiceEndpointTestsUtil;
 import org.opencastproject.test.rest.RestServiceTestEnv;
 
-import org.apache.commons.httpclient.HttpStatus;
+import org.apache.http.HttpStatus;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;

--- a/modules/admin-service/src/test/java/org/opencastproject/adminui/endpoint/ServicesEndpointTest.java
+++ b/modules/admin-service/src/test/java/org/opencastproject/adminui/endpoint/ServicesEndpointTest.java
@@ -28,7 +28,7 @@ import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses
 import org.opencastproject.adminui.util.ServiceEndpointTestsUtil;
 import org.opencastproject.test.rest.RestServiceTestEnv;
 
-import org.apache.commons.httpclient.HttpStatus;
+import org.apache.http.HttpStatus;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;

--- a/modules/admin-service/src/test/java/org/opencastproject/adminui/endpoint/ThemesEndpointTest.java
+++ b/modules/admin-service/src/test/java/org/opencastproject/adminui/endpoint/ThemesEndpointTest.java
@@ -30,9 +30,9 @@ import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses
 import org.opencastproject.test.rest.NotFoundExceptionMapper;
 import org.opencastproject.test.rest.RestServiceTestEnv;
 
-import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpStatus;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;

--- a/modules/smil-api/pom.xml
+++ b/modules/smil-api/pom.xml
@@ -37,12 +37,13 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.servicemix.bundles</groupId>
-      <artifactId>org.apache.servicemix.bundles.commons-httpclient</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/modules/smil-api/src/main/java/org/opencastproject/smil/api/util/SmilUtil.java
+++ b/modules/smil-api/src/main/java/org/opencastproject/smil/api/util/SmilUtil.java
@@ -34,7 +34,6 @@ import org.opencastproject.workspace.api.Workspace;
 
 import com.android.mms.dom.smil.parser.SmilXmlParser;
 
-import org.apache.commons.httpclient.util.URIUtil;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -161,7 +160,7 @@ public final class SmilUtil {
     Element element = smilDocument.createElement(hasVideo ? "video" : "audio");
     element.setAttribute("begin", Long.toString(startTime) + "ms");
     element.setAttribute("dur", Long.toString(duration) + "ms");
-    element.setAttribute("src", URIUtil.getPath(uri.toString()));
+    element.setAttribute("src", uri.getRawPath());
     if (trackId != null) {
       element.setAttribute("xml:id", trackId);
     }

--- a/modules/smil-api/src/test/java/org/opencastproject/smil/api/util/SmilUtilTest.java
+++ b/modules/smil-api/src/test/java/org/opencastproject/smil/api/util/SmilUtilTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.opencastproject.smil.api.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import java.net.URI;
+
+public class SmilUtilTest {
+
+  /**
+   * The src attribute used to be built with Commons HttpClient 3.x
+   * URIUtil.getPath(). It is now taken from java.net.URI.getRawPath(). The two
+   * agree on every shape of track URI Opencast produces: the path is kept
+   * percent-encoded, and query and fragment are dropped. These cases pin that
+   * down so the old behaviour cannot regress unnoticed.
+   */
+  @Test
+  public void testAddTrackKeepsRawPathOnly() throws Exception {
+    assertSrc("/files/mediapackage/abc-123/def-456/track.mp4",
+        "http://localhost:8080/files/mediapackage/abc-123/def-456/track.mp4");
+    assertSrc("/files/mediapackage/mp/elem/presenter.webm",
+        "https://oc.example.org:8443/files/mediapackage/mp/elem/presenter.webm");
+    assertSrc("/var/lib/opencast/track.mp4", "file:///var/lib/opencast/track.mp4");
+
+    // query and fragment are not part of the path
+    assertSrc("/files/collection/c1/file.mp4",
+        "http://localhost:8080/files/collection/c1/file.mp4?foo=bar");
+    assertSrc("/files/collection/c1/file.mp4",
+        "http://localhost:8080/files/collection/c1/file.mp4#frag");
+
+    // percent escapes are preserved rather than decoded
+    assertSrc("/files/my%20video.mp4", "http://localhost:8080/files/my%20video.mp4");
+    assertSrc("/files/%C3%BCmlaut.mp4", "http://localhost:8080/files/%C3%BCmlaut.mp4");
+    assertSrc("/files/a+b.mp4", "http://localhost:8080/files/a+b.mp4");
+  }
+
+  private void assertSrc(String expectedSrc, String trackUri) throws Exception {
+    Document smil = SmilUtil.createSmil();
+    smil = SmilUtil.addTrack(smil, SmilUtil.TrackType.PRESENTER, true, 0L, 1000L,
+        new URI(trackUri), "track-1");
+    Element track = (Element) smil.getElementsByTagName("video").item(0);
+    assertEquals(expectedSrc, track.getAttribute("src"));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1122,11 +1122,6 @@
       </dependency>
       <dependency>
         <groupId>org.apache.servicemix.bundles</groupId>
-        <artifactId>org.apache.servicemix.bundles.commons-httpclient</artifactId>
-        <version>3.1_7</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.servicemix.bundles</groupId>
         <artifactId>org.apache.servicemix.bundles.xerces</artifactId>
         <version>2.12.2_1</version>
       </dependency>


### PR DESCRIPTION
Commons HttpClient 3.x has been end of life since 2011. It was still installed into the OSGi runtime
and still managed in the root pom, surviving on exactly two usages, neither of which needed it:

* **`SmilUtil` built the `src` attribute of a SMIL track** with
  `URIUtil.getPath(uri.toString())`. `java.net.URI.getRawPath()` returns the same string for every
  shape of track URI Opencast produces: the path stays percent-encoded, and query and fragment are
  dropped. The two were compared directly against the old library over the realistic cases, and they
  agree on all of them. They differ only for a URI with no path component at all (`http://host:8080`),
  where the old method returned `/` and the new one returns the empty string — that cannot identify a
  track, so it does not arise here.

  A test was added covering the shapes that matter, including percent-escapes, non-ASCII, `+`, and
  URIs carrying a query or fragment, so the old behaviour cannot regress unnoticed. `smil-api` had no
  tests before, so this also adds the test scaffolding to that module.

* **The `admin-service` tests used it for the `HttpStatus.SC_*` constants.** `httpcore` is already a
  direct dependency of that module and provides the same constants as `org.apache.http.HttpStatus`.
  `JobEndpointTest` was in fact already importing that class while fully qualifying the old one
  alongside it.

With both call sites gone, the bundle leaves the Karaf feature and the managed dependency is dropped.

This is one of three independent branches that clean up dependency declarations. The other two are
"Clean up duplicate and dead dependency declarations" and "Drop unused bundles from the ext-core
feature". They are cut separately from `develop` and can be merged in any order; this branch and the
ext-core one both touch `feature.xml`, but in different hunks, so at most a trivial rebase is needed.

### How to test this patch

No special configuration is needed.

```
./mvnw clean install -Pdev -DskipTests
./mvnw -pl modules/smil-api,modules/admin-service test
```

The behavioural change is in the SMIL `src` attribute, so the meaningful test is a partial ingest,
which is the path that calls `SmilUtil.addTrack`. Start a distribution and the OpenSearch dependency
container, then:

```
# create a media package
curl -u admin:opencast http://localhost:8080/ingest/createMediaPackage -o mp0.xml

# add two partial tracks at different start times
curl -u admin:opencast --data-urlencode "mediaPackage@mp0.xml" \
  --data-urlencode 'flavor=presenter/source' --data-urlencode 'startTime=0' \
  --data-urlencode 'url=https://radosgw.public.os.wwu.de/opencast-test-media/goat.mp4' \
  http://localhost:8080/ingest/addPartialTrack -o mp1.xml

curl -u admin:opencast --data-urlencode "mediaPackage@mp1.xml" \
  --data-urlencode 'flavor=presentation/source' --data-urlencode 'startTime=3000' \
  --data-urlencode 'url=https://radosgw.public.os.wwu.de/opencast-test-media/goat.mp4' \
  http://localhost:8080/ingest/addPartialTrack -o mp2.xml

# ingest with the partial-ingest workflow
curl -u admin:opencast --data-urlencode "mediaPackage@mp2.xml" \
  --data-urlencode 'workflowDefinitionId=partial-ingest' \
  http://localhost:8080/ingest/ingest
```

Then fetch the generated `source_partial.smil` from the resulting media package and check the `src`
attributes. They should be absolute paths with no scheme or host, for example
`/files/mediapackage/<mp-id>/<element-id>/goat.mp4`.

What was tested before opening this:

* Full build with `-Pdev`: BUILD SUCCESS.
* `smil-api`: new test passes, Checkstyle clean. `admin-service`: all 117 tests pass.
* A distribution was booted against the OpenSearch container: no `Unable to resolve`,
  `Unresolved constraint`, `ClassNotFoundException` or `NoClassDefFoundError`, zero `ERROR` lines, and
  `/sysinfo/bundles/check` returned `true`. Commons HttpClient 3.1 is gone from the running system;
  only `org.apache.httpcomponents.httpclient` (4.x) remains.
* The partial ingest above was run end to end. The workflow reached `SUCCEEDED` and the generated SMIL
  contained exactly the values the old code produced:

  ```xml
  <video begin="0ms"    dur="4160ms" src="/files/mediapackage/<mp>/<elem>/goat.mp4" xml:id="…"/>
  <video begin="3000ms" dur="4160ms" src="/files/mediapackage/<mp>/<elem>/goat.mp4" xml:id="…"/>
  ```

### AI Usage

This patch was produced with Claude Code, used to find the remaining usages, make the
change, and verify it.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
