### PR TITLE
Drop unused bundles from the ext-core feature

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -67,7 +67,6 @@
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.quartz/1.8.5_1</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.wsdl4j/1.6.3_1</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xerces/2.12.1_1</bundle>
-    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlschema/1.4.3_1</bundle>
     <bundle>mvn:org.codehaus.jettison/jettison/${jettison.version}</bundle>
     <bundle>mvn:org.opencastproject/android-mms/1.2</bundle>
     <bundle>wrap:mvn:com.googlecode.json-simple/json-simple/${json-simple.version}</bundle>

--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -57,9 +57,6 @@
          selects them as the JAXP TransformerFactory, DocumentBuilderFactory and SAXParserFactory,
          and etc/branding/coverimage.xsl uses Xalan's extension namespace. -->
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xalan/2.7.2_3</bundle>
-    <!-- cover-image-impl inlines Batik 1.17, but not batik-i18n, so its bundle still imports
-         org.apache.batik.i18n and this is the only exporter. -->
-    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.batik/1.7_3</bundle>
     <!-- cglib and wsdl4j have no Opencast users; both are optional imports of CXF
          (net.sf.cglib.proxy from cxf-core, javax.wsdl from cxf-rt-transports-http). -->
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.cglib/3.2.4_1</bundle>

--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -44,7 +44,8 @@
     <bundle>mvn:com.sun.mail/jakarta.mail/${jakarta.mail.version}</bundle>
     <bundle>mvn:commons-fileupload/commons-fileupload/${commons-fileupload.version}</bundle>
     <bundle>mvn:commons-io/commons-io/${commons-io.version}</bundle>
-    <!-- FIXME: commons-lang 2.6 only needed for org.springframework.ldap/1.3.1.RELEASE -->
+    <!-- FIXME: commons-lang 2.6 is not imported by any Opencast bundle; it is believed to be
+         needed only by the org.apache.servicemix.bundles.spring-ldap bundle installed below. -->
     <bundle>mvn:commons-lang/commons-lang/2.6</bundle>
     <bundle>mvn:joda-time/joda-time/${joda-time.version}</bundle>
     <bundle>mvn:org.aopalliance/com.springsource.org.aopalliance/1.0.0</bundle>
@@ -52,18 +53,20 @@
     <bundle>mvn:org.apache.commons/commons-compress/${commons-compress.version}</bundle>
     <bundle>mvn:org.apache.commons/commons-csv/${commons-csv.version}</bundle>
     <bundle>mvn:org.apache.commons/commons-lang3/${commons-lang3.version}</bundle>
-    <bundle>mvn:org.apache.commons/commons-text/${commons-text.version}</bundle>
+    <!-- Xalan and Xerces have no direct users, but assemblies/resources/system.properties.append
+         selects them as the JAXP TransformerFactory, DocumentBuilderFactory and SAXParserFactory,
+         and etc/branding/coverimage.xsl uses Xalan's extension namespace. -->
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xalan/2.7.2_3</bundle>
-    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.bcel/5.2_3</bundle>
+    <!-- cover-image-impl inlines Batik 1.17, but not batik-i18n, so its bundle still imports
+         org.apache.batik.i18n and this is the only exporter. -->
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.batik/1.7_3</bundle>
+    <!-- cglib and wsdl4j have no Opencast users; both are optional imports of CXF
+         (net.sf.cglib.proxy from cxf-core, javax.wsdl from cxf-rt-transports-http). -->
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.cglib/3.2.4_1</bundle>
-    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jakarta-regexp/1.4_1</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.javax-inject/1_2</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.quartz/1.8.5_1</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.wsdl4j/1.6.3_1</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xerces/2.12.1_1</bundle>
-    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlbeans/2.6.0_2</bundle>
-    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlresolver/1.2_1</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlschema/1.4.3_1</bundle>
     <bundle>mvn:org.codehaus.jettison/jettison/${jettison.version}</bundle>
     <bundle>mvn:org.opencastproject/android-mms/1.2</bundle>

--- a/modules/cover-image-impl/pom.xml
+++ b/modules/cover-image-impl/pom.xml
@@ -122,6 +122,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
+      <artifactId>batik-i18n</artifactId>
+      <version>${batik.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-parser</artifactId>
       <version>${batik.version}</version>
     </dependency>
@@ -262,6 +267,7 @@
               batik-dom;inline=true,
               batik-ext;inline=true,
               batik-gvt;inline=true,
+              batik-i18n;inline=true,
               batik-parser;inline=true,
               batik-rasterizer;inline=true,
               batik-svgrasterizer;inline=true,

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,6 @@
     <commons-fileupload.version>1.6.0</commons-fileupload.version>
     <commons-io.version>2.21.0</commons-io.version>
     <commons-lang3.version>3.18.0</commons-lang3.version>
-    <commons-text.version>1.14.0</commons-text.version>
     <cxf.version>3.6.4</cxf.version>
     <eclipselink.version>2.7.15</eclipselink.version>
     <eclipselink.asm.version>9.7.1</eclipselink.asm.version>
@@ -1205,11 +1204,6 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>${commons-lang3.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-text</artifactId>
-        <version>${commons-text.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
The `ext-core` feature in `assemblies/karaf-features/src/main/feature/feature.xml` installs a number of
bundles that nothing in the distribution uses. This removes the ones that could be shown to be
unnecessary, documents the ones that look unnecessary but are not, and fixes the one case where a
bundle was only needed because a module had not embedded everything it should.

Three commits, kept separate so a runtime regression can be bisected:

**1. Remove bundles with no importers** — `bcel`, `xmlbeans`, `xmlresolver`, `jakarta-regexp` and
`commons-text`. None is imported by any bundle in the distribution. `commons-text` additionally has no
module declaring it and no reference anywhere in the source tree, so its managed dependency and version
property go too.

Two of these are more interesting than "unused":

* **`bcel` is still present at runtime after this change.** The `cxf` feature installs it itself, at
  `5.2_4`. So the `ext-core` entry was not merely redundant, it held back the version to `5.2_3`.
* Comments were added recording why the *remaining* non-obvious entries are there, so the next person
  does not have to work it out again. **Xalan and Xerces** have no importers either, but they are
  selected as the JAXP `TransformerFactory`, `DocumentBuilderFactory` and `SAXParserFactory` in
  `assemblies/resources/system.properties.append`, and `etc/branding/coverimage.xsl` uses Xalan's
  extension namespace. **`cglib` and `wsdl4j`** have no Opencast users but are optional imports of CXF
  (`net.sf.cglib.proxy;resolution:=optional` in `cxf-core`, `javax.wsdl;resolution:=optional` in
  `cxf-rt-transports-http`); because those imports are optional, removing them would not break
  resolution, but it would silently take capability away from CXF, so they are left alone deliberately.
  Someone who knows whether Opencast wants CXF's CGLIB proxying may want to revisit that.

The stale `FIXME` on `commons-lang` 2.6 was also refreshed: it named Spring LDAP `1.3.1.RELEASE`, which
is not the version installed any more.

**2. Remove the XmlSchema 1.4.3 bundle** — its only consumer in the distribution is `cxf-core`, which
requires `org.apache.ws.commons.schema` in `[2.3,3)`, a range the ServiceMix XmlSchema `1.4.3` bundle
installed here cannot satisfy. CXF is served by the `xmlschema-core` 2.3.1 bundle that comes with the
`cxf` feature, so this entry has been dead weight rather than the version actually in use. Kept as its
own commit because, unlike the others, it depends on the `cxf` feature continuing to supply XmlSchema,
so it is the first thing to revert if bundle resolution ever regresses.

**3. Inline `batik-i18n` so only one Batik version remains.** Batik looks redundant, because
`cover-image-impl` embeds Batik 1.17 into its own bundle via `Embed-Dependency` — but that module does
not embed `batik-i18n`, so its bundle still imported `org.apache.batik.i18n`, and the ServiceMix
**Batik 1.7** bundle was the only thing exporting it. Cover image generation has therefore been running
Batik 1.17 with its internationalisation classes coming from 1.7. Not a crash, but a version mix nobody
chose, and the sole reason a second Batik had to stay in the runtime.

`batik-i18n` is already on the compile classpath as a transitive dependency of `batik-util`, so the fix
is small: declare it explicitly, like the module's other Batik artifacts, and add it to the
`Embed-Dependency` list. After that no bundle in the distribution imports any `org.apache.batik`
package, and the Batik 1.7 bundle can go as well. That is why the comment added in the first commit
explaining why Batik must stay is removed again in the third — the first two commits describe the
feature as it was, the third removes the reason.

Net effect: six bundles leave the runtime, one managed dependency and one version property go, and
Batik exists in exactly one version instead of two.

This is one of three independent branches that clean up dependency declarations. The other two are
"Clean up duplicate and dead dependency declarations" and "Remove Commons HttpClient 3.1". They are cut
separately from `develop` and can be merged in any order; this branch and the HttpClient one both touch
`feature.xml`, but in different hunks, so at most a trivial rebase is needed.

### How to test this patch

This is the branch of the three where a build alone proves the least: removing a bundle from an OSGi
feature fails at *runtime*, not at compile time. Please boot a distribution.

```
./mvnw clean install -Pdev -DskipTests
```

First confirm `cover-image-impl` no longer needs Batik from outside its own bundle:

```
unzip -p modules/cover-image-impl/target/opencast-cover-image-impl-*.jar META-INF/MANIFEST.MF \
  | tr -d '\r' | sed ':a;N;$!ba;s/\n //g' | tr ',' '\n' | grep batik
```

That should print nothing. Before this patch it printed `org.apache.batik.i18n`.

Then start the dependency container and a distribution:

```
cd docs/scripts/devel-dependency-containers
podman compose -f docker-compose-all-sql.yml down --timeout 0
podman compose -f docker-compose.yml up -d

cd ../../../build/opencast-dist-develop-*-SNAPSHOT
./bin/start-opencast
```

Check that nothing failed to resolve:

```
grep -E 'Unable to resolve|Unresolved constraint|ClassNotFoundException|NoClassDefFoundError' \
  data/log/opencast.log data/log/karaf.log

curl -u admin:opencast http://localhost:8080/sysinfo/bundles/check     # expect: true
curl -u admin:opencast http://localhost:8080/api/info/me               # expect: 200
```

`/api/` responding is the meaningful check for the XmlSchema removal, since it proves the JAX-RS/CXF
stack resolved. For Batik, generate a cover image with no Batik bundle present:

```
cat > /tmp/meta.xml <<'XML'
<?xml version="1.0" encoding="UTF-8"?><metadata><title>Batik Inline Test</title><date>2026-08-17</date><license>CC-BY</license></metadata>
XML

curl -u admin:opencast -X POST \
  --data-urlencode "xml@/tmp/meta.xml" \
  --data-urlencode "xsl@etc/branding/coverimage.xsl" \
  --data-urlencode 'width=1600' --data-urlencode 'height=900' \
  --data-urlencode 'targetflavor=image/cover' \
  http://localhost:8080/cover-image/generate
```

Poll the returned job until `FINISHED` and fetch the PNG from its payload — it should be a valid
1600x900 image with the title, date and licence rendered. Alternatively run any workflow including the
cover image operation, for example via `partial-theming-title-slide`.

What was tested before opening this:

* Full build with `-Pdev`: BUILD SUCCESS. `cover-image-impl`: 10 tests pass, Checkstyle clean.
* The rebuilt `cover-image-impl` bundle imports **no** `org.apache.batik` package, and the five
  `batik-i18n` classes are inlined into it.
* Distribution booted against the OpenSearch container: **no** Batik bundle present in the running
  system, no resolution or classloading errors in `opencast.log` or `karaf.log`, zero `ERROR` lines,
  `/sysinfo/bundles/check` returned `true`.
* All `/api/` endpoints tried returned 200, confirming CXF resolved without the XmlSchema entry, and
  `org.apache.ws.xmlschema.core 2.3.1` was confirmed present in the running system.
* `org.apache.servicemix.bundles.bcel 5.2.0.4` was confirmed present, supplied by the `cxf` feature.
* Cover image generation was run through `/cover-image/generate` with the shipped
  `etc/branding/coverimage.xsl`. The job reached `FINISHED` and produced a valid 1600x900 PNG which
  renders correctly: gradient background, title, formatted date and licence all present. The formatted
  date also exercises the Xalan extension namespace that stylesheet uses.
* An event was ingested via `ingest/addMediaPackage/fast` and the `fast` workflow ran to `SUCCEEDED`.

### AI Usage

This patch was produced with Claude Code, used to audit the feature file, make the
changes, and verify them.

The method matters here, because "is this bundle used?" is not answerable by grepping for imports in
Java source — an OSGi bundle can require a package that no `import` statement mentions. What was
actually done: the `Import-Package` header of all 232 built Opencast bundles was read (9148 imported
packages in total), plus the CXF, Spring, ServiceMix and Karaf bundles, and each removal candidate was
checked for having no importer anywhere.

That is what produced the findings above that source-level analysis had got wrong:

* Batik was initially removed outright, on the grounds that `cover-image-impl` inlines its own copy. The
  manifest scan showed the bundle still importing `org.apache.batik.i18n`, and that removal was
  reverted — it would have broken cover image generation. Embedding `batik-i18n` is what made the
  removal legitimate, and is the reason the third commit exists.
* `cglib` was initially assumed to be needed by Spring AOP. It is actually an optional import of
  `cxf-core`.

Every removal that survived was then checked on a booted distribution. Because the Batik change affects
what actually renders, it was not accepted on manifest evidence alone: a cover image was generated on a
running Opencast with the Batik bundle removed and the resulting PNG inspected, not merely checked for a
successful exit code. Findings that could not be verified — the `commons-lang` 2.6 dependency on Spring
LDAP — are marked as unverified in the comment rather than asserted.


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
