### PR TITLE
Enforce dependency analysis during the build

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -67,7 +67,6 @@
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.quartz/1.8.5_1</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.wsdl4j/1.6.3_1</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xerces/2.12.1_1</bundle>
-    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlschema/1.4.3_1</bundle>
     <bundle>mvn:org.codehaus.jettison/jettison/${jettison.version}</bundle>
     <bundle>mvn:org.opencastproject/android-mms/1.2</bundle>
     <bundle>wrap:mvn:com.googlecode.json-simple/json-simple/${json-simple.version}</bundle>

--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -57,9 +57,6 @@
          selects them as the JAXP TransformerFactory, DocumentBuilderFactory and SAXParserFactory,
          and etc/branding/coverimage.xsl uses Xalan's extension namespace. -->
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xalan/2.7.2_3</bundle>
-    <!-- cover-image-impl inlines Batik 1.17, but not batik-i18n, so its bundle still imports
-         org.apache.batik.i18n and this is the only exporter. -->
-    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.batik/1.7_3</bundle>
     <!-- cglib and wsdl4j have no Opencast users; both are optional imports of CXF
          (net.sf.cglib.proxy from cxf-core, javax.wsdl from cxf-rt-transports-http). -->
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.cglib/3.2.4_1</bundle>

--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -44,7 +44,8 @@
     <bundle>mvn:com.sun.mail/jakarta.mail/${jakarta.mail.version}</bundle>
     <bundle>mvn:commons-fileupload/commons-fileupload/${commons-fileupload.version}</bundle>
     <bundle>mvn:commons-io/commons-io/${commons-io.version}</bundle>
-    <!-- FIXME: commons-lang 2.6 only needed for org.springframework.ldap/1.3.1.RELEASE -->
+    <!-- FIXME: commons-lang 2.6 is not imported by any Opencast bundle; it is believed to be
+         needed only by the org.apache.servicemix.bundles.spring-ldap bundle installed below. -->
     <bundle>mvn:commons-lang/commons-lang/2.6</bundle>
     <bundle>mvn:joda-time/joda-time/${joda-time.version}</bundle>
     <bundle>mvn:org.aopalliance/com.springsource.org.aopalliance/1.0.0</bundle>
@@ -52,18 +53,20 @@
     <bundle>mvn:org.apache.commons/commons-compress/${commons-compress.version}</bundle>
     <bundle>mvn:org.apache.commons/commons-csv/${commons-csv.version}</bundle>
     <bundle>mvn:org.apache.commons/commons-lang3/${commons-lang3.version}</bundle>
-    <bundle>mvn:org.apache.commons/commons-text/${commons-text.version}</bundle>
+    <!-- Xalan and Xerces have no direct users, but assemblies/resources/system.properties.append
+         selects them as the JAXP TransformerFactory, DocumentBuilderFactory and SAXParserFactory,
+         and etc/branding/coverimage.xsl uses Xalan's extension namespace. -->
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xalan/2.7.2_3</bundle>
-    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.bcel/5.2_3</bundle>
+    <!-- cover-image-impl inlines Batik 1.17, but not batik-i18n, so its bundle still imports
+         org.apache.batik.i18n and this is the only exporter. -->
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.batik/1.7_3</bundle>
+    <!-- cglib and wsdl4j have no Opencast users; both are optional imports of CXF
+         (net.sf.cglib.proxy from cxf-core, javax.wsdl from cxf-rt-transports-http). -->
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.cglib/3.2.4_1</bundle>
-    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jakarta-regexp/1.4_1</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.javax-inject/1_2</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.quartz/1.8.5_1</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.wsdl4j/1.6.3_1</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xerces/2.12.1_1</bundle>
-    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlbeans/2.6.0_2</bundle>
-    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlresolver/1.2_1</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlschema/1.4.3_1</bundle>
     <bundle>mvn:org.codehaus.jettison/jettison/${jettison.version}</bundle>
     <bundle>mvn:org.opencastproject/android-mms/1.2</bundle>

--- a/modules/admin-service/pom.xml
+++ b/modules/admin-service/pom.xml
@@ -152,6 +152,12 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-message-broker-api</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-common-jpa-impl</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/modules/authorization-manager/pom.xml
+++ b/modules/authorization-manager/pom.xml
@@ -46,6 +46,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-list-providers-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>osgi.core</artifactId>
     </dependency>

--- a/modules/cover-image-impl/pom.xml
+++ b/modules/cover-image-impl/pom.xml
@@ -223,6 +223,7 @@
             <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-dom</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-ext</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-gvt</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-i18n</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-js</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-parser</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-script</ignoredUnusedDeclaredDependency>

--- a/modules/cover-image-impl/pom.xml
+++ b/modules/cover-image-impl/pom.xml
@@ -122,6 +122,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
+      <artifactId>batik-i18n</artifactId>
+      <version>${batik.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-parser</artifactId>
       <version>${batik.version}</version>
     </dependency>
@@ -262,6 +267,7 @@
               batik-dom;inline=true,
               batik-ext;inline=true,
               batik-gvt;inline=true,
+              batik-i18n;inline=true,
               batik-parser;inline=true,
               batik-rasterizer;inline=true,
               batik-svgrasterizer;inline=true,

--- a/modules/email-template-service-impl/pom.xml
+++ b/modules/email-template-service-impl/pom.xml
@@ -83,12 +83,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-list-providers-api</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/modules/event-comment/pom.xml
+++ b/modules/event-comment/pom.xml
@@ -35,6 +35,16 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-list-providers-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>osgi.core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>

--- a/modules/graphql/pom.xml
+++ b/modules/graphql/pom.xml
@@ -188,6 +188,9 @@
         <configuration>
           <ignoredUnusedDeclaredDependencies>
             <ignoredUnusedDeclaredDependency>org.osgi:org.osgi.service.cm</ignoredUnusedDeclaredDependency>
+            <!-- only used for the compile time constant EventListQuery.FILTER_STATUS_NAME, which
+                 javac inlines, so the reference is not visible in the bytecode -->
+            <ignoredUnusedDeclaredDependency>org.opencastproject:opencast-list-providers-common</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>

--- a/modules/index-service/pom.xml
+++ b/modules/index-service/pom.xml
@@ -133,12 +133,6 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-userdirectory</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-distribution-workflowoperation</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
@@ -146,12 +140,6 @@
     <dependency>
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-elasticsearch-index</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-themes</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>

--- a/modules/ingest-service-impl/pom.xml
+++ b/modules/ingest-service-impl/pom.xml
@@ -135,10 +135,6 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
     </dependency>

--- a/modules/list-providers-api/pom.xml
+++ b/modules/list-providers-api/pom.xml
@@ -22,10 +22,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
@@ -33,16 +29,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymock</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.service.component.annotations</artifactId>
-      <scope>compile</scope>
     </dependency>
   </dependencies>
   <build>

--- a/modules/list-providers-common/pom.xml
+++ b/modules/list-providers-common/pom.xml
@@ -22,10 +22,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.felix</groupId>
-      <artifactId>org.apache.felix.fileinstall</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -58,6 +54,17 @@
       <artifactId>opencast-list-providers-api</artifactId>
       <version>${project.version}</version>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-workflow-service-api</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>osgi.core</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>

--- a/modules/list-providers-impl/pom.xml
+++ b/modules/list-providers-impl/pom.xml
@@ -49,12 +49,6 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-elasticsearch-index</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-list-providers-api</artifactId>
       <version>${project.version}</version>
       <scope>compile</scope>

--- a/modules/matrix-notification-workflowoperation/pom.xml
+++ b/modules/matrix-notification-workflowoperation/pom.xml
@@ -26,6 +26,10 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient-osgi</artifactId>
     </dependency>

--- a/modules/scheduler-impl/pom.xml
+++ b/modules/scheduler-impl/pom.xml
@@ -26,11 +26,6 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-list-providers-api</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-capture-admin-service-api</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/modules/serviceregistry/pom.xml
+++ b/modules/serviceregistry/pom.xml
@@ -75,10 +75,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
-      <artifactId>commons-collections4</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>

--- a/modules/smil-workflowoperation/pom.xml
+++ b/modules/smil-workflowoperation/pom.xml
@@ -39,10 +39,6 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/modules/static-file-service-impl/pom.xml
+++ b/modules/static-file-service-impl/pom.xml
@@ -23,10 +23,6 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/modules/statistics-provider-matomo/pom.xml
+++ b/modules/statistics-provider-matomo/pom.xml
@@ -27,15 +27,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.service.component</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.component.annotations</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/userdirectory/pom.xml
+++ b/modules/userdirectory/pom.xml
@@ -34,10 +34,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.googlecode.json-simple</groupId>
-      <artifactId>json-simple</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
     </dependency>

--- a/modules/workflow-workflowoperation/pom.xml
+++ b/modules/workflow-workflowoperation/pom.xml
@@ -151,6 +151,9 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
           <ignoredUnusedDeclaredDependencies>
+            <!-- no compile time reference, but the tests mock SeriesCatalogUIAdapter, and creating
+                 that proxy loads every type in its method signatures, including ResourceListQuery -->
+            <ignoredUnusedDeclaredDependency>org.opencastproject:opencast-list-providers-api</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,6 @@
     <commons-fileupload.version>1.6.0</commons-fileupload.version>
     <commons-io.version>2.21.0</commons-io.version>
     <commons-lang3.version>3.18.0</commons-lang3.version>
-    <commons-text.version>1.14.0</commons-text.version>
     <cxf.version>3.6.4</cxf.version>
     <eclipselink.version>2.7.15</eclipselink.version>
     <eclipselink.asm.version>9.7.1</eclipselink.asm.version>
@@ -1205,11 +1204,6 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>${commons-lang3.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-text</artifactId>
-        <version>${commons-text.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -749,7 +749,7 @@
           <artifactId>exec-maven-plugin</artifactId>
           <version>3.6.2</version>
         </plugin>
-        <!--<plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
           <version>3.8.1</version>
@@ -764,7 +764,7 @@
               </configuration>
             </execution>
           </executions>
-        </plugin>-->
+        </plugin>
         <plugin>
           <groupId>org.apache.karaf.tooling</groupId>
           <artifactId>karaf-services-maven-plugin</artifactId>


### PR DESCRIPTION
> [!NOTE]
> This patch is based on pull request https://github.com/opencast/opencast/pull/7948

**Depends on "Drop unused bundles from the ext-core feature"** (branch `trim-ext-core-bundles`) and is
branched from it, because one of the ignore entries added here covers the `batik-i18n` dependency that
patch introduces. Please merge that one first.

Nothing in the build checks dependency declarations today. `maven-dependency-plugin` was configured in
the root `pluginManagement` with an `analyze-only` execution and `failOnWarning=true` — but the whole
block was **commented out**, so it never ran. It was disabled in `d9b20c8e42`, a commit about adding
`modules/jacoco-reports` whose message does not mention dependency analysis at all, so the change looks
incidental rather than deliberate.

Everything else was already in place: **227 of the 230 modules** declare the plugin in their
`<build><plugins>`, and **104** already carry ignore lists totalling 237 entries. Only the execution
was missing.

This turns it back on and fixes everything it finds.

## What it found

26 findings across 20 modules, in two very different categories.

**Seven "used but undeclared" — the ones that matter.** These modules compile against a dependency they
never declare, getting it by accident through another module's transitive dependencies. A version bump
in an unrelated module can break them with no change of their own:

| Module | Missing dependency |
|---|---|
| `authorization-manager` | `opencast-list-providers-api` |
| `event-comment` | `opencast-list-providers-api`, `osgi.core` |
| `list-providers-common` | `opencast-workflow-service-api`, `osgi.core` |
| `admin-service` | `opencast-message-broker-api` (test) |
| `matrix-notification-workflowoperation` | `commons-lang3` |

**Seventeen "declared but unused"**, removed: dead `slf4j-api`, `easymock` and OSGi annotation
declarations in `list-providers-api`; `json-simple` in `userdirectory`; `felix.fileinstall` in
`list-providers-common`; `joda-time` in `ingest-service-impl` and `static-file-service-impl`;
`commons-collections4` in `serviceregistry`; `commons-lang3` in `smil-workflowoperation`; two OSGi
service artifacts in `statistics-provider-matomo`; and six inter-module declarations that nothing
references.

**Three false positives**, which get an ignore entry with a comment explaining why, rather than being
deleted. The analysis reads bytecode, and none of these are visible there:

* `cover-image-impl` **embeds** `batik-i18n` into its bundle rather than referencing it.
* `graphql` uses `list-providers-common` only for the compile-time constant
  `EventListQuery.FILTER_STATUS_NAME` — javac inlines the literal, so the class reference disappears.
* `workflow-workflowoperation` has no compile-time reference to `list-providers-api`, but its tests mock
  `SeriesCatalogUIAdapter`, and building that proxy loads every type in the interface's method
  signatures, one of which comes from that module.

That last one was **not** found by the analysis. It was found by running the test suite after removing
the dependency, which failed with `NoClassDefFoundError: org/opencastproject/list/api/ResourceListQuery`.
Worth knowing for anyone reviewing this class of change: "the analyzer says unused" is not sufficient
grounds to delete a dependency, and this patch is not a licence to do so mechanically in future.

## Notes for reviewers

* `modules/jacoco-reports` needed no special handling — `analyze-only` skips `pom`-packaging projects
  automatically, which is what that module is.
* Restoring the managed plugin entry also fixes a reproducibility hole: those 227 modules declare
  `maven-dependency-plugin` with **no version**, and with `pluginManagement` commented out Maven
  resolved whatever was newest. It is now pinned to 3.8.1 for all of them.
* CI needs no change. `.github/workflows/test-opencast-build.yml` already runs `./mvnw clean install`,
  and `analyze-only` binds to `verify` by default, so the check runs inside the existing build.
* The plugin was enabled at `failOnWarning=true` directly rather than being phased in behind a
  report-only period, because the finding count turned out small enough to fix in one go.

### How to test this patch

```
./mvnw clean install -Pdev
```

This is the whole point of the patch: the build now fails if any module declares a dependency it does
not use, or uses one it does not declare. It should pass.

To confirm the check is actually active rather than silently passing, add an unused dependency to any
module and rebuild it — for example add `org.apache.commons:commons-csv` to
`modules/list-providers-api/pom.xml`, then:

```
./mvnw -f modules/list-providers-api/pom.xml clean install
```

That must fail with `Unused declared dependencies found: org.apache.commons:commons-csv`. Remember to
revert it.

Because this removes 17 dependencies, it is also worth booting a distribution — a dependency that is
unnecessary at compile time can still matter at runtime:

```
cd docs/scripts/devel-dependency-containers
podman compose -f docker-compose.yml up -d
cd ../../../build/opencast-dist-develop-*-SNAPSHOT
./bin/start-opencast

grep -E 'Unable to resolve|Unresolved constraint|ClassNotFoundException|NoClassDefFoundError' \
  data/log/opencast.log data/log/karaf.log
curl -u admin:opencast http://localhost:8080/sysinfo/bundles/check    # expect: true
```

What was tested before opening this:

* `./mvnw clean install -Pdev -DskipTests` with the gate enabled: BUILD SUCCESS, zero analysis
  warnings across all 230 analysed modules.
* Full build **with tests**, `--fail-at-end`: BUILD SUCCESS, 478 test result lines, zero failures or
  errors.
* The gate was confirmed to bite: injecting an unused `commons-csv` dependency into
  `list-providers-api` produced `[ERROR] Unused declared dependencies found` and BUILD FAILURE. Reverted.
* A distribution was booted against the OpenSearch container: no resolution or classloading errors in
  `opencast.log` or `karaf.log`, zero `ERROR` lines, `/sysinfo/bundles/check` returned `true`, and
  `/api/info/me`, `/api/events` and `/api/series` all returned 200.
* An event was ingested via `ingest/addMediaPackage/fast` and the `fast` workflow ran to `SUCCEEDED`,
  which exercises `ingest-service-impl` — one of the modules that lost a declaration.

### AI Usage

This patch was produced with Claude Code, used to run the analysis, triage every
finding, apply the changes and verify them.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [x] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)


