### PR TITLE
Deduplicate roles before pagination in findRoles()

### DIFF
--- a/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/AclEndpoint.java
+++ b/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/AclEndpoint.java
@@ -80,11 +80,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import javax.ws.rs.DELETE;
 import javax.ws.rs.FormParam;
@@ -305,10 +303,9 @@ public class AclEndpoint {
     }
 
     List<Role> roles = roleDirectoryService.findRoles(roleQuery, roleTarget, offset, limit);
-    Set<Role> uniqueRoles = new LinkedHashSet<>(roles);
 
     JSONArray jsonRoles = new JSONArray();
-    for (Role role: uniqueRoles) {
+    for (Role role: roles) {
       JSONObject jsonRole = new JSONObject();
       jsonRole.put("name", role.getName());
       jsonRole.put("type", role.getType().toString());

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
@@ -63,6 +63,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -505,8 +506,9 @@ public class UserAndRoleDirectoryServiceImpl implements UserDirectoryService, Us
       throw new IllegalStateException("No organization is set");
     }
 
-    // Find all roles from the role providers
-    final List<Role> roles = new ArrayList<>();
+    // Multiple providers can return the same role (e.g.built-in system roles), so deduplicate them using a
+    // LinkedHashSet, before limit is applied.
+    final Set<Role> roles = new LinkedHashSet<>();
     for (RoleProvider roleProvider : roleProviders) {
       final String providerOrgId = roleProvider.getOrganization();
       if (ALL_ORGANIZATIONS.equals(providerOrgId) || org.getId().equals(providerOrgId)) {


### PR DESCRIPTION
UserAndRoleDirectoryServiceImpl.findRoles() can return the same role (e.g. ROLE_ADMIN) multiple times, due to calling different user providers. The admin ui endpoint was deduplicating them because the admin ui only cares about unique roles. However, this meant that dedup was applied after the pagination in findRoles(), so you could get less roles than the specified limit (e.g. 6 instead of 10), even though there were more roles available. Which implied that there were no more roles even though there really were.

This commit fixes this by moving the dedup into findRoles(), before limit is applied. This fixes the admin ui endpoint, but also technically changes behaviour for the UserDirectory endpoint and list provider. I am not sure why you would ever want these to return duplicated roles, but if there are reasons this would make for a breaking change.

### How to test this patch

Can be tested by calling the affected endpoints directly. Should not change admin ui behaviour, that is role dropdowns should still list the same roles.

### AI Usage

Claude Sonnet found this issue and suggested the fix.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
