### PR TITLE
Limit queries to RoleProviders a bit in findRoles()

### DIFF
--- a/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/impl/CaptureAgentAdminRoleProviderImpl.java
+++ b/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/impl/CaptureAgentAdminRoleProviderImpl.java
@@ -34,6 +34,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -117,6 +118,7 @@ public class CaptureAgentAdminRoleProviderImpl implements RoleProvider {
 
     Stream<Role> roleStream = getRolesStream()
             .filter(e -> like(e.getName(), query) || like(e.getDescription(), query))
+            .sorted(Comparator.comparing(Role::getName))  // Sort for consistent returns on limit+offset
             .skip(offset);
     if (limit != 0) {
       roleStream = roleStream.limit(limit);

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaGroupRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaGroupRoleProvider.java
@@ -54,6 +54,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -235,18 +236,11 @@ public class JpaGroupRoleProvider implements AAIRoleProvider, GroupProvider, Gro
       }
     }
 
-    Set<Role> result = new HashSet<>();
-    int i = 0;
-    for (Role entry : roles) {
-      if (limit != 0 && result.size() >= limit) {
-        break;
-      }
-      if (i >= offset) {
-        result.add(entry);
-      }
-      i++;
-    }
-    return result.iterator();
+    return roles.stream()
+        .sorted(Comparator.comparing(Role::getName))  // Sort for consistent returns on limit+offset
+        .skip(offset)
+        .limit(limit > 0 ? limit : Long.MAX_VALUE)
+        .iterator();
   }
 
   /**

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/OrganizationRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/OrganizationRoleProvider.java
@@ -37,6 +37,7 @@ import org.osgi.service.component.annotations.Reference;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -112,7 +113,7 @@ public class OrganizationRoleProvider implements RoleProvider {
       throw new IllegalArgumentException("Query must be set");
     }
     Organization organization = securityService.getOrganization();
-    HashSet<Role> foundRoles = new HashSet<Role>();
+    HashSet<Role> foundRoles = new HashSet<>();
     for (Iterator<Role> it = getRoles(); it.hasNext();) {
       Role role = it.next();
       // Anonymous roles are not relevant for adding to users or groups
@@ -123,22 +124,12 @@ public class OrganizationRoleProvider implements RoleProvider {
         foundRoles.add(role);
       }
     }
-    return offsetLimitCollection(offset, limit, foundRoles).iterator();
-  }
 
-  private <T> HashSet<T> offsetLimitCollection(int offset, int limit, HashSet<T> entries) {
-    HashSet<T> result = new HashSet<T>();
-    int i = 0;
-    for (T entry : entries) {
-      if (limit != 0 && result.size() >= limit) {
-        break;
-      }
-      if (i >= offset) {
-        result.add(entry);
-      }
-      i++;
-    }
-    return result;
+    return foundRoles.stream()
+        .sorted(Comparator.comparing(Role::getName))  // Sort for consistent returns on limit+offset
+        .skip(offset)
+        .limit(limit > 0 ? limit : Long.MAX_VALUE)
+        .iterator();
   }
 
   private boolean like(String string, final String query) {

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
@@ -513,13 +513,17 @@ public class UserAndRoleDirectoryServiceImpl implements UserDirectoryService, Us
       throw new IllegalStateException("No organization is set");
     }
 
+    // Instead of getting all roles from all providers, limit the providers by "limit" and "offset" if possible.
+    // Intended to reduce computing time for low offset + limit requests.
+    final int providerLimit = limit > 0 ? (int) Math.min((long) offset + limit, Integer.MAX_VALUE) : 0;
+
     // Multiple providers can return the same role (e.g.built-in system roles), so deduplicate them using a
     // LinkedHashSet, before limit is applied.
     final Set<Role> roles = new LinkedHashSet<>();
     for (RoleProvider roleProvider : roleProviders) {
       final String providerOrgId = roleProvider.getOrganization();
       if (ALL_ORGANIZATIONS.equals(providerOrgId) || org.getId().equals(providerOrgId)) {
-        roleProvider.findRoles(query, target, 0, 0).forEachRemaining(roles::add);
+        roleProvider.findRoles(query, target, 0, providerLimit).forEachRemaining(roles::add);
       }
     }
     Stream<Role> stream = roles.stream().sorted(Comparator.comparing(Role::getName)).skip(offset);

--- a/modules/userdirectory/src/test/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImplTest.java
+++ b/modules/userdirectory/src/test/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImplTest.java
@@ -115,7 +115,8 @@ public class UserAndRoleDirectoryServiceImplTest {
     EasyMock.expect(roleProvider1.getRolesForUser((String) EasyMock.anyObject())).andReturn(rolesForUser1).anyTimes();
     EasyMock.expect(roleProvider1.findRoles("%", Role.Target.ALL, 0, 0)).andReturn(roles1.iterator()).anyTimes();
     EasyMock.expect(roleProvider1.findRoles("%2012%", Role.Target.ALL, 0, 0)).andReturn(findRoles1.iterator()).once();
-    EasyMock.expect(roleProvider1.findRoles("%2012%", Role.Target.ALL, 0, 0)).andReturn(findRoles1.iterator()).once();
+    // offset=1, limit=1 in the test call below becomes providerLimit = offset + limit = 2 per provider
+    EasyMock.expect(roleProvider1.findRoles("%2012%", Role.Target.ALL, 0, 2)).andReturn(findRoles1.iterator()).once();
 
     List<Role> roles2 = new ArrayList<Role>();
     roles2.add(new JaxbRole("ROLE_MATH_2011", org));
@@ -132,7 +133,8 @@ public class UserAndRoleDirectoryServiceImplTest {
     EasyMock.expect(roleProvider2.getRolesForUser((String) EasyMock.anyObject())).andReturn(rolesForUser2).anyTimes();
     EasyMock.expect(roleProvider2.findRoles("%", Role.Target.ALL, 0, 0)).andReturn(roles2.iterator()).anyTimes();
     EasyMock.expect(roleProvider2.findRoles("%2012%", Role.Target.ALL, 0, 0)).andReturn(findRoles2.iterator()).once();
-    EasyMock.expect(roleProvider2.findRoles("%2012%", Role.Target.ALL, 0, 0)).andReturn(findRoles2.iterator()).once();
+    // offset=1, limit=1 in the test call below becomes providerLimit = offset + limit = 2 per provider
+    EasyMock.expect(roleProvider2.findRoles("%2012%", Role.Target.ALL, 0, 2)).andReturn(findRoles2.iterator()).once();
 
     RoleProvider otherOrgRoleProvider = EasyMock.createNiceMock(RoleProvider.class);
     EasyMock.expect(otherOrgRoleProvider.getOrganization()).andReturn("otherOrg").anyTimes();


### PR DESCRIPTION
UserAndRoleDirectoryServiceImpl.findRoles() always queried every RoleProvider for its complete, unbounded result set (offset=0, limit=0) regardless of what the caller actually requested, and only applied the requested offset/limit as an in-memory skip()/limit() over the full union afterwards. For systems with many roles, this makes every query expensive, no matter how small of a range band limit+offset might query.

This commit attempts to improve the situation by limiting the query to each role provider by the maximum amount of roles we could need from them, based on the given limit+offset combination. This does nothing to help with very large offsets (or limits), but should improve the situation for smaller ones, which make up the most common paginated requests anyway.

Also enforces sorting for three RoleProviders to make sure we get consistent results when using limit+offset.

### How to test this patch

Can be tested using the relevant endpoints, e.g. /admin-ng/acl/roles.json.

### AI Usage

Claude Sonnet was used to analyze the code and suggest the fix.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
