### PR TITLE
Add "hasUser" to UserAndRoleDirectoryServiceImpl.findRoles([...])

### DIFF
--- a/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/AclEndpoint.java
+++ b/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/AclEndpoint.java
@@ -272,7 +272,8 @@ public class AclEndpoint {
       returnDescription = "Returns a JSON representation of the roles with the given parameters under the "
           + "current user's organization.",
       restParameters = {
-          @RestParameter(name = "query", isRequired = false, description = "The query.", type = STRING),
+          @RestParameter(name = "query", isRequired = false,
+              description = "Only return roles whose name contains this string (case-insensitive).", type = STRING),
           @RestParameter(name = "target", isRequired = false, description = "The target of the roles.",
               type = STRING),
           @RestParameter(name = "limit", defaultValue = "100",
@@ -293,7 +294,7 @@ public class AclEndpoint {
 
     String roleQuery = "%";
     if (StringUtils.isNotBlank(query)) {
-      roleQuery = query.trim() + "%";
+      roleQuery = "%" + query.trim() + "%";
     }
 
     Role.Target roleTarget = Role.Target.ALL;

--- a/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/AclEndpoint.java
+++ b/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/AclEndpoint.java
@@ -279,13 +279,17 @@ public class AclEndpoint {
               description = "The maximum number of items to return per page.", isRequired = false,
               type = RestParameter.Type.STRING),
           @RestParameter(name = "offset", defaultValue = "0", description = "The page number.", isRequired = false,
-              type = RestParameter.Type.STRING)
+              type = RestParameter.Type.STRING),
+          @RestParameter(name = "hasUser", isRequired = false,
+              description = "If set, only returns roles that do (true) or do not (false) correspond to an actual "
+                  + "user account. If omitted, roles are not filtered by this criterion.",
+              type = RestParameter.Type.BOOLEAN)
       },
       responses = {
           @RestResponse(responseCode = SC_OK, description = "The list of roles.")
       })
   public Response getRoles(@QueryParam("query") String query, @QueryParam("target") String target,
-      @QueryParam("offset") int offset, @QueryParam("limit") int limit) {
+      @QueryParam("offset") int offset, @QueryParam("limit") int limit, @QueryParam("hasUser") Boolean hasUser) {
 
     String roleQuery = "%";
     if (StringUtils.isNotBlank(query)) {
@@ -302,7 +306,7 @@ public class AclEndpoint {
       }
     }
 
-    List<Role> roles = roleDirectoryService.findRoles(roleQuery, roleTarget, offset, limit);
+    List<Role> roles = roleDirectoryService.findRoles(roleQuery, roleTarget, offset, limit, hasUser);
 
     JSONArray jsonRoles = new JSONArray();
     for (Role role: roles) {
@@ -312,7 +316,10 @@ public class AclEndpoint {
       jsonRole.put("description", role.getDescription());
       jsonRole.put("organization", role.getOrganizationId());
       jsonRole.put("isSanitize", isSanitize());
-      if (!isSanitize()) {
+      // If the caller already asked findRoles() to only return roles without a user (hasUser=false), every role
+      // here is guaranteed to have none -- skip the redundant loadUser() lookup, which findRoles() already paid
+      // for once per role, and which is never cache-backed for misses (see UserAndRoleDirectoryServiceImpl#loadUser).
+      if (!isSanitize() && !Boolean.FALSE.equals(hasUser)) {
         User user = userDirectoryService.loadUser(role.getName().replaceFirst(getUserRolePrefix(), ""));
         if (user != null) {
           jsonRole.put("user", generateJsonUser(user));

--- a/modules/admin-service/src/test/java/org/opencastproject/adminui/endpoint/TestAclEndpoint.java
+++ b/modules/admin-service/src/test/java/org/opencastproject/adminui/endpoint/TestAclEndpoint.java
@@ -93,9 +93,9 @@ public class TestAclEndpoint extends AclEndpoint {
 
     RoleDirectoryService roleDirectoryService = EasyMock.createNiceMock(RoleDirectoryService.class);
     EasyMock.expect(roleDirectoryService.findRoles(EasyMock.eq("%"), EasyMock.anyObject(), EasyMock.eq(1),
-      EasyMock.eq(2))).andReturn(rolesSubset).anyTimes();
+      EasyMock.eq(2), EasyMock.anyObject())).andReturn(rolesSubset).anyTimes();
     EasyMock.expect(roleDirectoryService.findRoles(EasyMock.anyString(), EasyMock.anyObject(), EasyMock.anyInt(),
-      EasyMock.anyInt())).andReturn(roles).anyTimes();
+      EasyMock.anyInt(), EasyMock.anyObject())).andReturn(roles).anyTimes();
     EasyMock.replay(roleDirectoryService);
 
     this.setAclServiceFactory(aclServiceFactory);

--- a/modules/common/src/main/java/org/opencastproject/security/api/RoleDirectoryService.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/RoleDirectoryService.java
@@ -42,5 +42,28 @@ public interface RoleDirectoryService {
    * @throws IllegalArgumentException
    *           if the query is <code>null</code>
    */
-  List<Role> findRoles(String query, Role.Target target, int offset, int limit);
+  default List<Role> findRoles(String query, Role.Target target, int offset, int limit) {
+    return findRoles(query, target, offset, limit, null);
+  }
+
+  /**
+   * Return the found roles as a list, optionally filtered by whether or not each role corresponds to an actual
+   * user account.
+   *
+   * @param query
+   *          the query. Use the wildcards "_" to match any single character and "%" to match an arbitrary number of
+   *          characters (including zero characters).
+   * @param offset
+   *          the offset.
+   * @param limit
+   *          the limit. 0 means no limit
+   * @param hasUser
+   *          if <code>null</code>, roles are not filtered by this criterion. If <code>true</code>, only roles that
+   *          resolve to an actual user account are returned. If <code>false</code>, only roles that do not resolve
+   *          to a user account are returned. The filter, if any, is applied before the offset/limit are applied.
+   * @return a list of roles
+   * @throws IllegalArgumentException
+   *           if the query is <code>null</code>
+   */
+  List<Role> findRoles(String query, Role.Target target, int offset, int limit, Boolean hasUser);
 }

--- a/modules/common/src/main/java/org/opencastproject/security/api/RoleProvider.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/RoleProvider.java
@@ -61,4 +61,29 @@ public interface RoleProvider {
    */
   Iterator<Role> findRoles(String query, Role.Target target, int offset, int limit);
 
+  /**
+   * Return the found roles as an iterator, optionally filtered by whether or not each role corresponds to an
+   * actual user account.
+   *
+   * @param query
+   *          the query. Use the wildcards "_" to match any single character and "%" to match an arbitrary number of
+   *          characters (including zero characters).
+   * @param offset
+   *          the offset
+   * @param limit
+   *          the limit. 0 means no limit
+   * @param hasUser
+   *          if <code>null</code>, roles are not filtered by this criterion. If <code>true</code>, only roles
+   *          that resolve to an actual user account should be returned. If <code>false</code>, only roles that
+   *          do not resolve to a user account should be returned. Providers that can never produce a role
+   *          resolving to a user account may use this to skip expensive work when <code>hasUser</code> is
+   *          <code>true</code>, and vice versa.
+   * @return an iterator of role's
+   * @throws IllegalArgumentException
+   *           if the query is <code>null</code>
+   */
+  default Iterator<Role> findRoles(String query, Role.Target target, int offset, int limit, Boolean hasUser) {
+    return findRoles(query, target, offset, limit);
+  }
+
 }

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
@@ -515,7 +515,11 @@ public class UserAndRoleDirectoryServiceImpl implements UserDirectoryService, Us
 
     // Instead of getting all roles from all providers, limit the providers by "limit" and "offset" if possible.
     // Intended to reduce computing time for low offset + limit requests.
-    final int providerLimit = limit > 0 ? (int) Math.min((long) offset + limit, Integer.MAX_VALUE) : 0;
+    // This optimization cannot be applied when filtering by "hasUser", since that filter is applied after fetching
+    // from the providers: trimming the provider results to offset+limit beforehand could discard roles that would have
+    // passed the filter, leaving fewer than "limit" results even though more were available.
+    final int providerLimit = limit > 0 && hasUser == null
+        ? (int) Math.min((long) offset + limit, Integer.MAX_VALUE) : 0;
 
     // Multiple providers can return the same role (e.g.built-in system roles), so deduplicate them using a
     // LinkedHashSet, before limit is applied.
@@ -523,7 +527,7 @@ public class UserAndRoleDirectoryServiceImpl implements UserDirectoryService, Us
     for (RoleProvider roleProvider : roleProviders) {
       final String providerOrgId = roleProvider.getOrganization();
       if (ALL_ORGANIZATIONS.equals(providerOrgId) || org.getId().equals(providerOrgId)) {
-        roleProvider.findRoles(query, target, 0, providerLimit).forEachRemaining(roles::add);
+        roleProvider.findRoles(query, target, 0, providerLimit, hasUser).forEachRemaining(roles::add);
       }
     }
     Stream<Role> stream = roles.stream().sorted(Comparator.comparing(Role::getName));

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
@@ -504,7 +504,7 @@ public class UserAndRoleDirectoryServiceImpl implements UserDirectoryService, Us
   }
 
   @Override
-  public List<Role> findRoles(String query, Role.Target target, int offset, int limit) {
+  public List<Role> findRoles(String query, Role.Target target, int offset, int limit, Boolean hasUser) {
     if (query == null) {
       throw new IllegalArgumentException("Query must be set");
     }
@@ -526,11 +526,30 @@ public class UserAndRoleDirectoryServiceImpl implements UserDirectoryService, Us
         roleProvider.findRoles(query, target, 0, providerLimit).forEachRemaining(roles::add);
       }
     }
-    Stream<Role> stream = roles.stream().sorted(Comparator.comparing(Role::getName)).skip(offset);
+    Stream<Role> stream = roles.stream().sorted(Comparator.comparing(Role::getName));
+    // Filter by whether or not the role resolves to an actual user account, before offset/limit are applied, so
+    // that a page of `limit` results is not silently shortened by roles excluded after the fact.
+    if (hasUser != null) {
+      stream = stream.filter(role -> hasUser.equals(roleHasUser(role)));
+    }
+    stream = stream.skip(offset);
     if (limit > 0) {
       return stream.limit(limit).collect(Collectors.toList());
     }
     return stream.collect(Collectors.toList());
+  }
+
+  /**
+   * Determines whether the given role corresponds to an actual user account, i.e. whether
+   * {@link #loadUser(String)} returns a non-null user for the role's name with the configured user role prefix
+   * stripped off.
+   *
+   * @param role
+   *          the role to check
+   * @return <code>true</code> if the role resolves to a user account, <code>false</code> otherwise
+   */
+  private boolean roleHasUser(Role role) {
+    return loadUser(role.getName().replaceFirst(UserIdRoleProvider.getUserRolePrefix(), "")) != null;
   }
 
   @Override

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserIdRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserIdRoleProvider.java
@@ -157,6 +157,14 @@ public class UserIdRoleProvider implements RoleProvider, ManagedService {
    */
   @Override
   public Iterator<Role> findRoles(String query, Role.Target target, int offset, int limit) {
+    return findRoles(query, target, offset, limit, null);
+  }
+
+  /**
+   * @see org.opencastproject.security.api.RoleProvider#findRoles(String, Role.Target, int, int, Boolean)
+   */
+  @Override
+  public Iterator<Role> findRoles(String query, Role.Target target, int offset, int limit, Boolean hasUser) {
     if (query == null) {
       throw new IllegalArgumentException("Query must be set");
     }
@@ -166,13 +174,14 @@ public class UserIdRoleProvider implements RoleProvider, ManagedService {
       return Collections.emptyIterator();
     }
 
-    logger.debug("findRoles(query={} offset={} limit={})", query, offset, limit);
+    logger.debug("findRoles(query={} offset={} limit={} hasUser={})", query, offset, limit, hasUser);
 
     HashSet<Role> foundRoles = new HashSet<Role>();
     Organization organization = securityService.getOrganization();
 
-    // Return authenticated user role if it matches the query pattern
-    if (like(ROLE_USER, query)) {
+    // ROLE_USER never resolves to an actual user account, so it's irrelevant to a hasUser=true request -- the
+    // aggregator would filter it out anyway, but there's no reason to add it just to have it discarded.
+    if (!Boolean.TRUE.equals(hasUser) && like(ROLE_USER, query)) {
       foundRoles.add(new JaxbRole(
           ROLE_USER,
           JaxbOrganization.fromOrganization(organization),
@@ -181,11 +190,20 @@ public class UserIdRoleProvider implements RoleProvider, ManagedService {
       ));
     }
 
-    // Include user id roles if there is no real search text to filter by (a wildcard-only query), this is a
-    // bounded request (a bounded findUsers() call below is cheap regardless of the query; an unbounded one may
-    // not be, which is what this guard originally protected against), or the query specifically targets the
-    // user id role prefix.
-    if (!"%".equals(query) && limit <= 0 && !query.startsWith(userRolePrefix)) {
+    // This provider is the only one that can ever produce a role satisfying hasUser=false -- skip the
+    // (potentially expensive) user enumeration below entirely for that case, we already know none of it applies.
+    if (Boolean.FALSE.equals(hasUser)) {
+      return foundRoles.iterator();
+    }
+
+    // Include user id roles if the caller explicitly wants them (hasUser=true, regardless of the query's shape --
+    // we were told this search is about users), or -- when hasUser is unset, preserving the original behaviour
+    // for callers that don't know about hasUser -- only if there is no real search text to filter by (a
+    // wildcard-only query) or the query specifically targets the user id role prefix (iterating through users
+    // may be slow, so this guard avoids doing so for general, not-obviously-user-related searches).
+    if (!Boolean.TRUE.equals(hasUser)
+        && !"%".equals(query)
+        && !query.startsWith(userRolePrefix)) {
       return foundRoles.iterator();
     }
 

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserIdRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserIdRoleProvider.java
@@ -181,16 +181,18 @@ public class UserIdRoleProvider implements RoleProvider, ManagedService {
       ));
     }
 
-    // Include user id roles only if wildcard search or query matches user id role prefix
-    // (iterating through users may be slow)
-    if (!"%".equals(query) && !query.startsWith(userRolePrefix)) {
+    // Include user id roles if there is no real search text to filter by (a wildcard-only query), this is a
+    // bounded request (a bounded findUsers() call below is cheap regardless of the query; an unbounded one may
+    // not be, which is what this guard originally protected against), or the query specifically targets the
+    // user id role prefix.
+    if (!"%".equals(query) && limit <= 0 && !query.startsWith(userRolePrefix)) {
       return foundRoles.iterator();
     }
 
-    String userQuery = "%";
-    if (query.startsWith(userRolePrefix)) {
-      userQuery = query.substring(userRolePrefix.length());
-    }
+    // The query is already a properly-shaped search pattern (e.g. "%adm%"), so reuse it as-is to search
+    // usernames, unless it's anchored with the user id role prefix, in which case strip that prefix first to
+    // get the username pattern it actually refers to.
+    String userQuery = query.startsWith(userRolePrefix) ? query.substring(userRolePrefix.length()) : query;
 
     Iterator<User> users = userDirectoryService.findUsers(userQuery, offset, limit);
     while (users.hasNext()) {

--- a/modules/userdirectory/src/test/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImplTest.java
+++ b/modules/userdirectory/src/test/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImplTest.java
@@ -239,4 +239,60 @@ public class UserAndRoleDirectoryServiceImplTest {
             || "ROLE_MATH_2012".equals(roles.get(0).getName()));
   }
 
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testFindRolesFilteredByHasUser() {
+    // Set up a directory with its own, dedicated mocks so that "has a user" can be precisely controlled: the
+    // "linked" user account exists, everything else resolves to no user.
+    JaxbUser linkedUser = new JaxbUser("linked", "test", org);
+
+    UserProvider userProvider = EasyMock.createNiceMock(UserProvider.class);
+    EasyMock.expect(userProvider.getOrganization()).andReturn(org.getId()).anyTimes();
+    EasyMock.expect(userProvider.loadUser("linked")).andReturn(linkedUser).anyTimes();
+    // loadUser() for any other name is left unstubbed and returns null on this nice mock
+
+    List<Role> allRoles = new ArrayList<Role>();
+    allRoles.add(new JaxbRole(UserIdRoleProvider.getUserRolePrefix() + "linked", org));
+    allRoles.add(new JaxbRole(UserIdRoleProvider.getUserRolePrefix() + "unlinked", org));
+    allRoles.add(new JaxbRole("ROLE_GROUP", org));
+
+    RoleProvider roleProvider = EasyMock.createNiceMock(RoleProvider.class);
+    EasyMock.expect(roleProvider.getOrganization()).andReturn(org.getId()).anyTimes();
+    // Use andAnswer (not andReturn) so each call gets a fresh iterator: findRoles() is called multiple times
+    // below, and a single shared iterator would be exhausted after the first call.
+    EasyMock.expect(roleProvider.findRoles("%", Role.Target.ALL, 0, 0))
+        .andAnswer(allRoles::iterator).anyTimes();
+    EasyMock.expect(roleProvider.getRolesForUser((String) EasyMock.anyObject()))
+        .andReturn(new ArrayList<Role>()).anyTimes();
+
+    SecurityService securityService = EasyMock.createNiceMock(SecurityService.class);
+    EasyMock.expect(securityService.getOrganization()).andReturn(org).anyTimes();
+
+    EasyMock.replay(userProvider, roleProvider, securityService);
+
+    UserAndRoleDirectoryServiceImpl hasUserDirectory = new UserAndRoleDirectoryServiceImpl();
+    hasUserDirectory.activate(null);
+    hasUserDirectory.setSecurityService(securityService);
+    hasUserDirectory.addUserProvider(userProvider);
+    hasUserDirectory.addRoleProvider(roleProvider);
+
+    // No filter: current behaviour is preserved
+    List<Role> unfiltered = hasUserDirectory.findRoles("%", Role.Target.ALL, 0, 0, null);
+    Assert.assertEquals(3, unfiltered.size());
+
+    // Only roles with a user account
+    List<Role> withUser = hasUserDirectory.findRoles("%", Role.Target.ALL, 0, 0, true);
+    Assert.assertEquals(1, withUser.size());
+    Assert.assertEquals(UserIdRoleProvider.getUserRolePrefix() + "linked", withUser.get(0).getName());
+
+    // Only roles without a user account
+    List<Role> withoutUser = hasUserDirectory.findRoles("%", Role.Target.ALL, 0, 0, false);
+    Assert.assertEquals(2, withoutUser.size());
+
+    // Filtering must happen before offset/limit are applied: a limit of 1 on the 2 "no user" roles must return
+    // exactly 1 result, not come back short because filtering happened after pagination.
+    List<Role> pagedWithoutUser = hasUserDirectory.findRoles("%", Role.Target.ALL, 0, 1, false);
+    Assert.assertEquals(1, pagedWithoutUser.size());
+  }
+
 }

--- a/modules/userdirectory/src/test/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImplTest.java
+++ b/modules/userdirectory/src/test/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImplTest.java
@@ -113,10 +113,13 @@ public class UserAndRoleDirectoryServiceImplTest {
     RoleProvider roleProvider1 = EasyMock.createNiceMock(RoleProvider.class);
     EasyMock.expect(roleProvider1.getOrganization()).andReturn(org.getId()).anyTimes();
     EasyMock.expect(roleProvider1.getRolesForUser((String) EasyMock.anyObject())).andReturn(rolesForUser1).anyTimes();
-    EasyMock.expect(roleProvider1.findRoles("%", Role.Target.ALL, 0, 0)).andReturn(roles1.iterator()).anyTimes();
-    EasyMock.expect(roleProvider1.findRoles("%2012%", Role.Target.ALL, 0, 0)).andReturn(findRoles1.iterator()).once();
+    EasyMock.expect(roleProvider1.findRoles(EasyMock.eq("%"), EasyMock.eq(Role.Target.ALL), EasyMock.eq(0),
+        EasyMock.eq(0), EasyMock.isNull(Boolean.class))).andReturn(roles1.iterator()).anyTimes();
+    EasyMock.expect(roleProvider1.findRoles(EasyMock.eq("%2012%"), EasyMock.eq(Role.Target.ALL), EasyMock.eq(0),
+        EasyMock.eq(0), EasyMock.isNull(Boolean.class))).andReturn(findRoles1.iterator()).once();
     // offset=1, limit=1 in the test call below becomes providerLimit = offset + limit = 2 per provider
-    EasyMock.expect(roleProvider1.findRoles("%2012%", Role.Target.ALL, 0, 2)).andReturn(findRoles1.iterator()).once();
+    EasyMock.expect(roleProvider1.findRoles(EasyMock.eq("%2012%"), EasyMock.eq(Role.Target.ALL), EasyMock.eq(0),
+        EasyMock.eq(2), EasyMock.isNull(Boolean.class))).andReturn(findRoles1.iterator()).once();
 
     List<Role> roles2 = new ArrayList<Role>();
     roles2.add(new JaxbRole("ROLE_MATH_2011", org));
@@ -131,20 +134,25 @@ public class UserAndRoleDirectoryServiceImplTest {
     RoleProvider roleProvider2 = EasyMock.createNiceMock(RoleProvider.class);
     EasyMock.expect(roleProvider2.getOrganization()).andReturn(org.getId()).anyTimes();
     EasyMock.expect(roleProvider2.getRolesForUser((String) EasyMock.anyObject())).andReturn(rolesForUser2).anyTimes();
-    EasyMock.expect(roleProvider2.findRoles("%", Role.Target.ALL, 0, 0)).andReturn(roles2.iterator()).anyTimes();
-    EasyMock.expect(roleProvider2.findRoles("%2012%", Role.Target.ALL, 0, 0)).andReturn(findRoles2.iterator()).once();
+    EasyMock.expect(roleProvider2.findRoles(EasyMock.eq("%"), EasyMock.eq(Role.Target.ALL), EasyMock.eq(0),
+        EasyMock.eq(0), EasyMock.isNull(Boolean.class))).andReturn(roles2.iterator()).anyTimes();
+    EasyMock.expect(roleProvider2.findRoles(EasyMock.eq("%2012%"), EasyMock.eq(Role.Target.ALL), EasyMock.eq(0),
+        EasyMock.eq(0), EasyMock.isNull(Boolean.class))).andReturn(findRoles2.iterator()).once();
     // offset=1, limit=1 in the test call below becomes providerLimit = offset + limit = 2 per provider
-    EasyMock.expect(roleProvider2.findRoles("%2012%", Role.Target.ALL, 0, 2)).andReturn(findRoles2.iterator()).once();
+    EasyMock.expect(roleProvider2.findRoles(EasyMock.eq("%2012%"), EasyMock.eq(Role.Target.ALL), EasyMock.eq(0),
+        EasyMock.eq(2), EasyMock.isNull(Boolean.class))).andReturn(findRoles2.iterator()).once();
 
     RoleProvider otherOrgRoleProvider = EasyMock.createNiceMock(RoleProvider.class);
     EasyMock.expect(otherOrgRoleProvider.getOrganization()).andReturn("otherOrg").anyTimes();
     EasyMock.expect(otherOrgRoleProvider.getRolesForUser((String) EasyMock.anyObject())).andReturn(rolesForUser2)
             .anyTimes();
 
-    EasyMock.expect(otherOrgRoleProvider.findRoles("%", Role.Target.ALL, 0, 0))
+    EasyMock.expect(otherOrgRoleProvider.findRoles(EasyMock.eq("%"), EasyMock.eq(Role.Target.ALL), EasyMock.eq(0),
+        EasyMock.eq(0), EasyMock.isNull(Boolean.class)))
         .andReturn(roles2.iterator())
         .anyTimes();
-    EasyMock.expect(otherOrgRoleProvider.findRoles("%2012%", Role.Target.ALL, 0, 0))
+    EasyMock.expect(otherOrgRoleProvider.findRoles(EasyMock.eq("%2012%"), EasyMock.eq(Role.Target.ALL),
+        EasyMock.eq(0), EasyMock.eq(0), EasyMock.isNull(Boolean.class)))
         .andReturn(new ArrayList<Role>().iterator())
         .anyTimes();
 
@@ -260,7 +268,8 @@ public class UserAndRoleDirectoryServiceImplTest {
     EasyMock.expect(roleProvider.getOrganization()).andReturn(org.getId()).anyTimes();
     // Use andAnswer (not andReturn) so each call gets a fresh iterator: findRoles() is called multiple times
     // below, and a single shared iterator would be exhausted after the first call.
-    EasyMock.expect(roleProvider.findRoles("%", Role.Target.ALL, 0, 0))
+    EasyMock.expect(roleProvider.findRoles(EasyMock.eq("%"), EasyMock.eq(Role.Target.ALL), EasyMock.eq(0),
+        EasyMock.eq(0), EasyMock.anyObject()))
         .andAnswer(allRoles::iterator).anyTimes();
     EasyMock.expect(roleProvider.getRolesForUser((String) EasyMock.anyObject()))
         .andReturn(new ArrayList<Role>()).anyTimes();

--- a/modules/userdirectory/src/test/java/org/opencastproject/userdirectory/UserIdRoleProviderTest.java
+++ b/modules/userdirectory/src/test/java/org/opencastproject/userdirectory/UserIdRoleProviderTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.userdirectory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.opencastproject.security.api.DefaultOrganization;
+import org.opencastproject.security.api.JaxbOrganization;
+import org.opencastproject.security.api.JaxbUser;
+import org.opencastproject.security.api.Role;
+import org.opencastproject.security.api.SecurityService;
+import org.opencastproject.security.api.User;
+import org.opencastproject.security.api.UserDirectoryService;
+
+import org.easymock.Capture;
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Tests {@link UserIdRoleProvider#findRoles(String, Role.Target, int, int)}, in particular its handling of
+ * bounded, contains-style ("%text%") search queries -- the path exercised by the admin-ui's role picker once
+ * it stopped fetching every role up front and started searching the backend directly.
+ */
+public class UserIdRoleProviderTest {
+
+  private UserIdRoleProvider provider;
+  private UserDirectoryService userDirectoryService;
+  private JaxbOrganization org;
+
+  @Before
+  public void setUp() {
+    org = new DefaultOrganization();
+
+    SecurityService securityService = EasyMock.createNiceMock(SecurityService.class);
+    EasyMock.expect(securityService.getOrganization()).andReturn(org).anyTimes();
+    EasyMock.replay(securityService);
+
+    userDirectoryService = EasyMock.createMock(UserDirectoryService.class);
+
+    provider = new UserIdRoleProvider();
+    provider.setSecurityService(securityService);
+    provider.setUserDirectoryService(userDirectoryService);
+  }
+
+  private User user(String username) {
+    return new JaxbUser(username, "opencast", org);
+  }
+
+  private Set<String> roleNames(Iterator<Role> roles) {
+    List<Role> list = new ArrayList<>();
+    roles.forEachRemaining(list::add);
+    return list.stream().map(Role::getName).collect(Collectors.toSet());
+  }
+
+  @Test
+  public void findRolesWithBoundedContainsQueryStillSearchesUsers() {
+    // This is exactly the shape of query AclEndpoint now sends for a real, non-blank search
+    // ("%" + query + "%"), and the frontend always sends a bounded limit.
+    Capture<String> userQueryCapture = Capture.newInstance();
+    EasyMock.expect(userDirectoryService.findUsers(EasyMock.capture(userQueryCapture), EasyMock.eq(0), EasyMock.eq(50)))
+        .andReturn(List.of(user("admin")).iterator());
+    EasyMock.replay(userDirectoryService);
+
+    Iterator<Role> result = provider.findRoles("%adm%", Role.Target.ALL, 0, 50);
+
+    assertEquals("%adm%", userQueryCapture.getValue());
+    assertTrue(roleNames(result).contains("ROLE_USER_ADMIN"));
+  }
+
+  @Test
+  public void findRolesWithUnboundedNonPrefixedQuerySkipsUserEnumeration() {
+    // Legacy/unbounded callers (limit <= 0) with a general, non-wildcard, non-prefixed query should not trigger
+    // a full user directory scan -- this preserves the original guard's intent.
+    EasyMock.replay(userDirectoryService);
+
+    Iterator<Role> result = provider.findRoles("%adm%", Role.Target.ALL, 0, 0);
+
+    assertFalse(roleNames(result).contains("ROLE_USER_ADMIN"));
+    EasyMock.verify(userDirectoryService);
+  }
+
+  @Test
+  public void findRolesWithBlankQuerySearchesAllUsers() {
+    Capture<String> userQueryCapture = Capture.newInstance();
+    EasyMock.expect(userDirectoryService.findUsers(EasyMock.capture(userQueryCapture), EasyMock.eq(0), EasyMock.eq(50)))
+        .andReturn(List.of(user("admin"), user("anonymous")).iterator());
+    EasyMock.replay(userDirectoryService);
+
+    Iterator<Role> result = provider.findRoles("%", Role.Target.ALL, 0, 50);
+
+    assertEquals("%", userQueryCapture.getValue());
+    Set<String> names = roleNames(result);
+    assertTrue(names.contains("ROLE_USER_ADMIN"));
+    assertTrue(names.contains("ROLE_USER_ANONYMOUS"));
+  }
+
+  @Test
+  public void findRolesWithPrefixedQueryStripsPrefixRegardlessOfLimit() {
+    // A caller using the legacy prefix-anchored convention should still work, and should still search users
+    // even for an unbounded request, since the prefix itself is a strong enough signal.
+    Capture<String> userQueryCapture = Capture.newInstance();
+    EasyMock.expect(userDirectoryService.findUsers(EasyMock.capture(userQueryCapture), EasyMock.eq(0), EasyMock.eq(0)))
+        .andReturn(List.of(user("admin")).iterator());
+    EasyMock.replay(userDirectoryService);
+
+    Iterator<Role> result = provider.findRoles("ROLE_USER_adm", Role.Target.ALL, 0, 0);
+
+    assertEquals("adm", userQueryCapture.getValue());
+    assertTrue(roleNames(result).contains("ROLE_USER_ADMIN"));
+  }
+
+}

--- a/modules/userdirectory/src/test/java/org/opencastproject/userdirectory/UserIdRoleProviderTest.java
+++ b/modules/userdirectory/src/test/java/org/opencastproject/userdirectory/UserIdRoleProviderTest.java
@@ -45,9 +45,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Tests {@link UserIdRoleProvider#findRoles(String, Role.Target, int, int)}, in particular its handling of
- * bounded, contains-style ("%text%") search queries -- the path exercised by the admin-ui's role picker once
- * it stopped fetching every role up front and started searching the backend directly.
+ * Tests {@link UserIdRoleProvider#findRoles(String, Role.Target, int, int, Boolean)}, in particular its handling
+ * of hasUser=true/false and contains-style ("%text%") search queries -- the path exercised by the admin-ui's role
+ * picker once it stopped fetching every role up front and started searching the backend directly.
  */
 public class UserIdRoleProviderTest {
 
@@ -81,24 +81,42 @@ public class UserIdRoleProviderTest {
   }
 
   @Test
-  public void findRolesWithBoundedContainsQueryStillSearchesUsers() {
-    // This is exactly the shape of query AclEndpoint now sends for a real, non-blank search
-    // ("%" + query + "%"), and the frontend always sends a bounded limit.
+  public void findRolesWithHasUserTrueSearchesUsersRegardlessOfLimitOrQueryShape() {
+    // This is exactly the shape of query AclEndpoint now sends for a real, non-blank search ("%" + query + "%"),
+    // with hasUser=true (the "Users" table). Deliberately using limit=0 here: hasUser=true must be enough on its
+    // own to trigger the search, independent of whether a caller also bounds the request (e.g. via
+    // fix/acl-roles-provider-pagination, a separate, independently-mergeable change).
     Capture<String> userQueryCapture = Capture.newInstance();
-    EasyMock.expect(userDirectoryService.findUsers(EasyMock.capture(userQueryCapture), EasyMock.eq(0), EasyMock.eq(50)))
+    EasyMock.expect(userDirectoryService.findUsers(EasyMock.capture(userQueryCapture), EasyMock.eq(0), EasyMock.eq(0)))
         .andReturn(List.of(user("admin")).iterator());
     EasyMock.replay(userDirectoryService);
 
-    Iterator<Role> result = provider.findRoles("%adm%", Role.Target.ALL, 0, 50);
+    Iterator<Role> result = provider.findRoles("%adm%", Role.Target.ALL, 0, 0, true);
 
     assertEquals("%adm%", userQueryCapture.getValue());
     assertTrue(roleNames(result).contains("ROLE_USER_ADMIN"));
   }
 
   @Test
-  public void findRolesWithUnboundedNonPrefixedQuerySkipsUserEnumeration() {
-    // Legacy/unbounded callers (limit <= 0) with a general, non-wildcard, non-prefixed query should not trigger
-    // a full user directory scan -- this preserves the original guard's intent.
+  public void findRolesWithHasUserFalseSkipsUserEnumerationButKeepsRoleUser() {
+    // hasUser=false (the "Groups & other roles" table): the (potentially expensive) user enumeration should be
+    // skipped entirely, since none of it could ever satisfy hasUser=false -- but the generic ROLE_USER role,
+    // which itself never resolves to a user account, should still be included if it matches the query.
+    EasyMock.replay(userDirectoryService);
+
+    Iterator<Role> result = provider.findRoles("%", Role.Target.ALL, 0, 0, false);
+
+    Set<String> names = roleNames(result);
+    assertTrue(names.contains("ROLE_USER"));
+    assertFalse(names.contains("ROLE_USER_ADMIN"));
+    EasyMock.verify(userDirectoryService);
+  }
+
+  @Test
+  public void findRolesWithNoHasUserFilterAndUnboundedNonPrefixedQuerySkipsUserEnumeration() {
+    // Legacy callers that don't know about hasUser (hasUser=null) and make an unbounded, general,
+    // non-wildcard, non-prefixed query should not trigger a full user directory scan -- this preserves the
+    // original guard's intent for callers like RoleEndpoint that have nothing to do with hasUser filtering.
     EasyMock.replay(userDirectoryService);
 
     Iterator<Role> result = provider.findRoles("%adm%", Role.Target.ALL, 0, 0);


### PR DESCRIPTION
Corresponding backend changes for https://github.com/opencast/admin-interface/pull/1660
Best together with: #7955 and #7956

Adds a new flag `hasUser` to the `findRoles()`. If set, this causes the function to either return only user roles or only non-user roles. If undefined, the behaviour is the same as before.

This allows us to not having to do split roles between user and non-user in the frontend, which in turn means the frontend does not have to fetch all roles when loading the acl tab. Also allows the frontend to actually use `limit` and `offset` to be more efficient.



### How to test this patch

Can be tested on its own by querying the relevant endpoints and checking that they still work. Really intended to be tested together with https://github.com/opencast/admin-interface/pull/1660.

### AI Usage

Claude Sonnet was used for code analysis, making the changes and writing tests.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
