### PR TITLE
fix: Return 400 instead of 500 when creating a group without a name

### DIFF
--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaGroupRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaGroupRoleProvider.java
@@ -551,6 +551,10 @@ public class JpaGroupRoleProvider implements AAIRoleProvider, GroupProvider, Gro
    */
   public void createGroup(String name, String description, String roles, String users)
           throws IllegalArgumentException, UnauthorizedException, ConflictException {
+
+    if (StringUtils.isBlank(name)) {
+      throw new IllegalArgumentException("name is required");
+    }
     JpaOrganization organization = (JpaOrganization) securityService.getOrganization();
 
     HashSet<JpaRole> roleSet = new HashSet<>();

--- a/modules/userdirectory/src/test/java/org/opencastproject/userdirectory/JpaGroupRoleProviderTest.java
+++ b/modules/userdirectory/src/test/java/org/opencastproject/userdirectory/JpaGroupRoleProviderTest.java
@@ -205,6 +205,12 @@ public class JpaGroupRoleProviderTest {
   }
 
   @Test
+  public void testCreateGroupWithoutName() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    provider.createGroup(null, "Test group", null, null);
+  }
+
+  @Test
   public void testRolesForUser() throws UnauthorizedException {
     Set<JpaRole> authorities = new HashSet<JpaRole>();
     authorities.add(new JpaRole("ROLE_ASTRO_101_SPRING_2011_STUDENT", org1));


### PR DESCRIPTION
<!--
Explain what this pull request does.  If this fixes a bug, also explain how to reproduce the issue.
-->
While developing the Bruno tests, I found that sending a POST request to the Groups API without a name returns a 500 Internal Server Error. This pull request aims to fix this. Please merge this pull request only after the [Bruno Tests pull request](https://github.com/opencast/opencast/pull/7775) is merged, so I can see how the tests behave.

JpaGroupRoleProvider.createGroup() derives the group id from the group name via name.toLowerCase() but never checks whether the name is null. Posting to /api/groups without a name parameter therefore throws a NullPointerException which escapes the endpoint and is rendered as a 500. 
This is fixed by checking if the name variable is empty and sending an error code 400.  Blank names are rejected as well: previously an empty name produced a group with an empty id instead of an error.
Furthermore a test case was added for this issue.

### How to test this patch
Build opencast with the patch and send the following curl request:
`curl -X POST http://localhost:8080/api/groups -H "Content-Type: application/x-www-form-urlencoded" -u "admin:opencast"`
It should return error code 400.

<!--
Explain how to test this patch. If this requires a particular set-up or configuration, explain that as well and provide
the necessary configuration if possible. The easier it is for others to test the patch, the faster this will get
reviewed and merged.

For more information, see https://docs.opencast.org/develop/#participate/development-process/#ai-policy-for-pull-requests
-->

### AI Usage
Claude was used to locate the relevant source files and explain the structure of the Opencast codebase. The fix itself was implemented without AI.
### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
