### PR TITLE
fix: Return 400 instead of 500 when signing a URL with a malformed date

### DIFF
--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SecurityEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SecurityEndpoint.java
@@ -162,7 +162,7 @@ public class SecurityEndpoint implements ManagedService {
     if (isNotBlank(validUntilUtc)) {
       try {
         validUntil = new DateTime(fromUTC(validUntilUtc));
-      } catch (IllegalStateException | ParseException e) {
+      } catch (IllegalArgumentException | IllegalStateException | ParseException e) {
         return R.badRequest("Query parameter 'valid-until' is not a valid ISO-8601 date string");
       }
     } else {

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/SecurityEndpointTest.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/SecurityEndpointTest.java
@@ -21,6 +21,7 @@
 package org.opencastproject.external.endpoint;
 
 import static io.restassured.RestAssured.given;
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_ACCEPTABLE;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.junit.Assert.assertEquals;
@@ -89,6 +90,13 @@ public class SecurityEndpointTest {
     final JSONObject json = (JSONObject) parser.parse(response);
     assertEquals("http://mycdn.com/path/movie.mp4?signature", json.get("url"));
     assertTrue(new Date().getTime() < fromUTC((String) json.get("valid-until")));
+  }
+
+  @Test
+  public void testSignUrlWithMalformedValidity() throws Exception {
+    // A date without the 'T' separator is not ISO-8601 and must not end up as a server error
+    given().formParam("url", "http://mycdn.com/path/movie.mp4").formParam("valid-until", "2015-04-17 07:30:32Z")
+            .accept(APP_V1_0_0_JSON).log().all().expect().statusCode(SC_BAD_REQUEST).when().post(env.host("/sign"));
   }
 
   @Test


### PR DESCRIPTION
While developing the Bruno tests, I found that sending a POST request to the external security API with an invalid timestamp returns a 500 Internal Server Error. This pull request aims to fix this. Please merge this pull request only after the [Bruno Tests pull request](https://github.com/opencast/opencast/pull/7775) is merged, so I can see how the tests behave.

The /api/security/sign endpoint parses the optional `valid-until` parameter with DateTimeSupport.fromUTC(), which throws an IllegalArgumentException when the string is not ISO-8601. The catch clause only handled IllegalStateException and ParseException, so the exception escaped the endpoint and surfaced as a server error.
This is fixed by catching a IllegalArgumentException as well.
Furthermore a test case was added for this issue.

<!--
Explain what this pull request does.  If this fixes a bug, also explain how to reproduce the issue.
-->

<!--
If your pull request is targeting the legacy (second oldest release branch), explain why this patch is so important that
it needs to go into the legacy and can not go just into stable or develop.
-->

### How to test this patch

<!--
Explain how to test this patch. If this requires a particular set-up or configuration, explain that as well and provide
the necessary configuration if possible. The easier it is for others to test the patch, the faster this will get
reviewed and merged.

For more information, see https://docs.opencast.org/develop/#participate/development-process/#ai-policy-for-pull-requests
-->
Build opencast with the patch and send the following curl request:
```
curl -X POST "http://localhost:8080/api/security/sign" \
     -u "admin:opencast" \
     -H "Content-Type: application/x-www-form-urlencoded" \
     --data-urlencode "url=https://develop.opencast.org/" \
     --data-urlencode "valid-until=invalid-timestamp-format"
```
     
It should return error code 400.

### AI Usage
<!--
If you used AI in a significant way to create this pull request, please explain how you used it and what you used it for. This is for us to better understand and deal with AI contributions. Your pull request will not be declined just becasue of AI usage.
-->
Claude was used to locate the relevant source files and explain the structure of the Opencast codebase. The fix itself was implemented without AI.
### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] does not incorrectly update the submodules
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [x] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
