### PR TITLE
Handle null properties in service registry updated() #1174

### DIFF
--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -629,6 +629,11 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
   public void updated(Dictionary properties) throws ConfigurationException {
     logger.info("Updating service registry properties");
 
+    if (properties == null) {
+      logger.info("No configuration available, using defaults");
+      return;
+    }
+
     maxAttemptsBeforeErrorState = DEFAULT_MAX_ATTEMPTS_BEFORE_ERROR_STATE;
     errorStatesEnabled = DEFAULT_ERROR_STATES_ENABLED;
     String maxAttempts = StringUtils.trimToNull((String) properties.get(MAX_ATTEMPTS_CONFIG_KEY));

--- a/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
+++ b/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
@@ -618,4 +618,9 @@ public class ServiceRegistryJpaImplTest {
     Assert.assertEquals(dateCompleted, updatedJob.getDateCompleted());
     Assert.assertEquals(runTime, updatedJob.getRunTime());
   }
+
+  @Test
+  public void testUpdatedWithNullProperties() throws ConfigurationException {
+    serviceRegistryJpaImpl.updated(null);
+  }
 }


### PR DESCRIPTION
Config Admin can call ManagedService.updated() with a null dictionary. The service registry used that object without a check, so a missing config threw NPE.

I added the same null guard other services already use and a test that updated(null) does not throw.

Closes #1174

### How to test this patch

`mvn -pl modules/serviceregistry test -Dtest=ServiceRegistryJpaImplTest#testUpdatedWithNullProperties`

### AI Usage

