### PR TITLE
Remove deprecated methods from EqualsUtil

### DIFF
--- a/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/ThemesEndpoint.java
+++ b/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/ThemesEndpoint.java
@@ -53,7 +53,6 @@ import org.opencastproject.themes.ThemesServiceDatabase;
 import org.opencastproject.themes.list.ThemesListQuery;
 import org.opencastproject.themes.persistence.ThemesServiceDatabaseException;
 import org.opencastproject.util.DateTimeSupport;
-import org.opencastproject.util.EqualsUtil;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.RestUtil;
 import org.opencastproject.util.RestUtil.R;
@@ -82,6 +81,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.servlet.http.HttpServletResponse;
@@ -770,7 +770,7 @@ public class ThemesEndpoint {
    *           If there was an error while persisting or deleting one of the files.
    */
   private void updateReferencedFile(String original, String updated) throws NotFoundException, IOException {
-    if (EqualsUtil.ne(original, updated)) {
+    if (!Objects.equals(original, updated)) {
       if (isNotBlank(original)) {
         staticFileService.deleteFile(original);
       }

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/dto/Adopter.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/dto/Adopter.java
@@ -22,7 +22,6 @@
 package org.opencastproject.adopter.registration.dto;
 
 import org.opencastproject.security.api.Organization;
-import org.opencastproject.util.EqualsUtil;
 
 import java.util.Date;
 import java.util.Objects;
@@ -208,7 +207,7 @@ public class Adopter {
 
   @Override
   public int hashCode() {
-    return EqualsUtil.hash(adopterKey);
+    return Objects.hash(adopterKey);
   }
 
   @Override

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/VersionImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/VersionImpl.java
@@ -20,9 +20,9 @@
  */
 package org.opencastproject.assetmanager.impl;
 
-import static org.opencastproject.util.EqualsUtil.hash;
-
 import org.opencastproject.assetmanager.api.Version;
+
+import java.util.Objects;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -88,7 +88,7 @@ public final class VersionImpl implements Version {
 
   @Override
   public int hashCode() {
-    return hash(nr);
+    return Objects.hash(nr);
   }
 
   @Override

--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/security/impl/jpa/JpaGroup.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/security/impl/jpa/JpaGroup.java
@@ -23,9 +23,9 @@ package org.opencastproject.security.impl.jpa;
 
 import org.opencastproject.security.api.Group;
 import org.opencastproject.security.api.Role;
-import org.opencastproject.util.EqualsUtil;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -318,7 +318,7 @@ public final class JpaGroup implements Group {
 
   @Override
   public int hashCode() {
-    return EqualsUtil.hash(id, organization);
+    return Objects.hash(id, organization);
   }
 
   @Override

--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/security/impl/jpa/JpaOrganization.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/security/impl/jpa/JpaOrganization.java
@@ -21,10 +21,10 @@
 package org.opencastproject.security.impl.jpa;
 
 import org.opencastproject.security.api.Organization;
-import org.opencastproject.util.EqualsUtil;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.persistence.Access;
 import javax.persistence.AccessType;
@@ -295,7 +295,7 @@ public class JpaOrganization implements Organization {
 
   @Override
   public int hashCode() {
-    return EqualsUtil.hash(id);
+    return Objects.hash(id);
   }
 
   @Override

--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/security/impl/jpa/JpaRole.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/security/impl/jpa/JpaRole.java
@@ -21,7 +21,6 @@
 package org.opencastproject.security.impl.jpa;
 
 import org.opencastproject.security.api.Role;
-import org.opencastproject.util.EqualsUtil;
 
 import java.util.Objects;
 
@@ -183,7 +182,7 @@ public final class JpaRole implements Role {
 
   @Override
   public int hashCode() {
-    return EqualsUtil.hash(name, getOrganizationId());
+    return Objects.hash(name, getOrganizationId());
   }
 
   @Override

--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/security/impl/jpa/JpaUser.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/security/impl/jpa/JpaUser.java
@@ -23,7 +23,6 @@ package org.opencastproject.security.impl.jpa;
 import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.Role;
 import org.opencastproject.security.api.User;
-import org.opencastproject.util.EqualsUtil;
 
 import java.util.HashSet;
 import java.util.Objects;
@@ -297,7 +296,7 @@ public class JpaUser implements User {
     }
     User other = (User) obj;
     return username.equals(other.getUsername()) && organization.equals(other.getOrganization())
-            && EqualsUtil.eq(provider, other.getProvider());
+            && Objects.equals(provider, other.getProvider());
   }
 
   /**

--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/security/impl/jpa/JpaUserReference.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/security/impl/jpa/JpaUserReference.java
@@ -26,7 +26,6 @@ import org.opencastproject.security.api.JaxbUser;
 import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.Role;
 import org.opencastproject.security.api.User;
-import org.opencastproject.util.EqualsUtil;
 
 import java.util.Date;
 import java.util.HashSet;
@@ -263,7 +262,7 @@ public class JpaUserReference {
    */
   @Override
   public int hashCode() {
-    return EqualsUtil.hash(username, organization);
+    return Objects.hash(username, organization);
   }
 
   /**

--- a/modules/common/src/main/java/org/opencastproject/job/api/IncidentImpl.java
+++ b/modules/common/src/main/java/org/opencastproject/job/api/IncidentImpl.java
@@ -21,7 +21,6 @@
 
 package org.opencastproject.job.api;
 
-import static org.opencastproject.util.EqualsUtil.eq;
 import static org.opencastproject.util.EqualsUtil.hash;
 
 import org.opencastproject.util.data.Tuple;
@@ -30,6 +29,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public final class IncidentImpl implements Incident {
   private final long id;
@@ -118,14 +118,14 @@ public final class IncidentImpl implements Incident {
   }
 
   private boolean eqFields(Incident that) {
-    return eq(id, that.getId())
-            && eq(jobId, that.getJobId())
-            && eq(serviceType, that.getServiceType())
-            && eq(processingHost, that.getProcessingHost())
-            && eq(timestamp, that.getTimestamp())
-            && eq(severity, that.getSeverity())
-            && eq(code, that.getCode())
-            && eq(details, that.getDetails())
-            && eq(parameters, that.getDescriptionParameters());
+    return Objects.equals(id, that.getId())
+            && Objects.equals(jobId, that.getJobId())
+            && Objects.equals(serviceType, that.getServiceType())
+            && Objects.equals(processingHost, that.getProcessingHost())
+            && Objects.equals(timestamp, that.getTimestamp())
+            && Objects.equals(severity, that.getSeverity())
+            && Objects.equals(code, that.getCode())
+            && Objects.equals(details, that.getDetails())
+            && Objects.equals(parameters, that.getDescriptionParameters());
   }
 }

--- a/modules/common/src/main/java/org/opencastproject/job/api/IncidentImpl.java
+++ b/modules/common/src/main/java/org/opencastproject/job/api/IncidentImpl.java
@@ -21,8 +21,6 @@
 
 package org.opencastproject.job.api;
 
-import static org.opencastproject.util.EqualsUtil.hash;
-
 import org.opencastproject.util.data.Tuple;
 
 import java.util.Collections;
@@ -109,7 +107,7 @@ public final class IncidentImpl implements Incident {
 
   @Override
   public int hashCode() {
-    return hash(id, jobId, serviceType, processingHost, timestamp, severity, code, details, parameters);
+    return Objects.hash(id, jobId, serviceType, processingHost, timestamp, severity, code, details, parameters);
   }
 
   @Override

--- a/modules/common/src/main/java/org/opencastproject/job/api/IncidentTreeImpl.java
+++ b/modules/common/src/main/java/org/opencastproject/job/api/IncidentTreeImpl.java
@@ -21,11 +21,11 @@
 
 package org.opencastproject.job.api;
 
-import static org.opencastproject.util.EqualsUtil.eq;
 import static org.opencastproject.util.EqualsUtil.hash;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public final class IncidentTreeImpl implements IncidentTree {
   private final List<Incident> incidents;
@@ -58,7 +58,7 @@ public final class IncidentTreeImpl implements IncidentTree {
   }
 
   private boolean eqFields(IncidentTree that) {
-    return eq(incidents, that.getIncidents())
-            && eq(descendants, that.getDescendants());
+    return Objects.equals(incidents, that.getIncidents())
+            && Objects.equals(descendants, that.getDescendants());
   }
 }

--- a/modules/common/src/main/java/org/opencastproject/job/api/IncidentTreeImpl.java
+++ b/modules/common/src/main/java/org/opencastproject/job/api/IncidentTreeImpl.java
@@ -21,8 +21,6 @@
 
 package org.opencastproject.job.api;
 
-import static org.opencastproject.util.EqualsUtil.hash;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -50,7 +48,7 @@ public final class IncidentTreeImpl implements IncidentTree {
   }
 
   @Override public int hashCode() {
-    return hash(incidents, descendants);
+    return Objects.hash(incidents, descendants);
   }
 
   @Override public boolean equals(Object that) {

--- a/modules/common/src/main/java/org/opencastproject/mediapackage/EName.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/EName.java
@@ -22,7 +22,6 @@
 package org.opencastproject.mediapackage;
 
 import static java.lang.String.format;
-import static org.opencastproject.util.EqualsUtil.eq;
 import static org.opencastproject.util.EqualsUtil.hash;
 
 import org.opencastproject.util.RequireUtil;
@@ -30,6 +29,7 @@ import org.opencastproject.util.RequireUtil;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -119,7 +119,7 @@ public final class EName implements Serializable, Comparable<EName> {
   }
 
   private boolean eqFields(EName that) {
-    return eq(localName, that.localName) && eq(namespaceURI, that.namespaceURI);
+    return Objects.equals(localName, that.localName) && Objects.equals(namespaceURI, that.namespaceURI);
   }
 
   /** Return a W3C compliant string representation <code>{namespaceURI}localname</code>. */

--- a/modules/common/src/main/java/org/opencastproject/mediapackage/EName.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/EName.java
@@ -22,7 +22,6 @@
 package org.opencastproject.mediapackage;
 
 import static java.lang.String.format;
-import static org.opencastproject.util.EqualsUtil.hash;
 
 import org.opencastproject.util.RequireUtil;
 
@@ -110,7 +109,7 @@ public final class EName implements Serializable, Comparable<EName> {
 
   @Override
   public int hashCode() {
-    return hash(namespaceURI, localName);
+    return Objects.hash(namespaceURI, localName);
   }
 
   @Override

--- a/modules/common/src/main/java/org/opencastproject/mediapackage/XMLCatalogImpl.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/XMLCatalogImpl.java
@@ -26,7 +26,6 @@ import static javax.xml.XMLConstants.DEFAULT_NS_PREFIX;
 import static javax.xml.XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI;
 import static javax.xml.XMLConstants.XMLNS_ATTRIBUTE;
 import static javax.xml.XMLConstants.XML_NS_URI;
-import static org.opencastproject.util.EqualsUtil.hash;
 
 import org.opencastproject.util.RequireUtil;
 import org.opencastproject.util.XmlNamespaceBinding;
@@ -56,6 +55,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -679,7 +679,7 @@ public abstract class XMLCatalogImpl extends CatalogImpl implements XMLCatalog {
 
     @Override
     public int hashCode() {
-      return hash(name, value);
+      return Objects.hash(name, value);
     }
 
     @Override

--- a/modules/common/src/main/java/org/opencastproject/security/api/JaxbGroup.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/JaxbGroup.java
@@ -21,9 +21,8 @@
 
 package org.opencastproject.security.api;
 
-import org.opencastproject.util.EqualsUtil;
-
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -211,7 +210,7 @@ public final class JaxbGroup implements Group {
    */
   @Override
   public int hashCode() {
-    return EqualsUtil.hash(groupId, organization);
+    return Objects.hash(groupId, organization);
   }
 
   /**

--- a/modules/common/src/main/java/org/opencastproject/security/api/JaxbOrganization.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/JaxbOrganization.java
@@ -21,13 +21,12 @@
 
 package org.opencastproject.security.api;
 
-import org.opencastproject.util.EqualsUtil;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -223,7 +222,7 @@ public class JaxbOrganization implements Organization {
    */
   @Override
   public int hashCode() {
-    return EqualsUtil.hash(id);
+    return Objects.hash(id);
   }
 
   /**

--- a/modules/common/src/main/java/org/opencastproject/security/api/JaxbUser.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/JaxbUser.java
@@ -21,8 +21,6 @@
 
 package org.opencastproject.security.api;
 
-import org.opencastproject.util.EqualsUtil;
-
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
@@ -315,7 +313,7 @@ public final class JaxbUser implements User {
    */
   @Override
   public int hashCode() {
-    return EqualsUtil.hash(userName, organization, provider);
+    return Objects.hash(userName, organization, provider);
   }
 
   /**

--- a/modules/common/src/main/java/org/opencastproject/security/util/SecurityContext.java
+++ b/modules/common/src/main/java/org/opencastproject/security/util/SecurityContext.java
@@ -21,12 +21,11 @@
 
 package org.opencastproject.security.util;
 
-import static org.opencastproject.util.EqualsUtil.ne;
-
 import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.User;
 
+import java.util.Objects;
 import java.util.function.Supplier;
 
 /**
@@ -39,7 +38,7 @@ public class SecurityContext {
   private final Organization org;
 
   public SecurityContext(SecurityService sec, Organization org, User user) {
-    if (ne(org, user.getOrganization())) {
+    if (!Objects.equals(org, user.getOrganization())) {
       throw new IllegalArgumentException("User is not a member of organization " + org.getId());
     }
     this.sec = sec;

--- a/modules/common/src/main/java/org/opencastproject/util/EqualsUtil.java
+++ b/modules/common/src/main/java/org/opencastproject/util/EqualsUtil.java
@@ -39,15 +39,9 @@ public final class EqualsUtil {
     return Objects.equals(a, b);
   }
 
-  /** Check if <code>a</code> and <code>b</code> are equal. Each of them may be null. */
-  @Deprecated
-  public static boolean eq(Object a, Object b) {
-    return Objects.equals(a, b);
-  }
-
   /** Check if <code>a</code> and <code>b</code> are not equal. Each of them may be null. */
   public static boolean ne(Object a, Object b) {
-    return !eq(a, b);
+    return !Objects.equals(a, b);
   }
 
   /** Check if <code>a</code> and <code>b</code> have the same class ({@link Object#getClass()}). Each may be null. */

--- a/modules/common/src/main/java/org/opencastproject/util/EqualsUtil.java
+++ b/modules/common/src/main/java/org/opencastproject/util/EqualsUtil.java
@@ -114,13 +114,4 @@ public final class EqualsUtil {
     return a != null && b != null;
   }
 
-  /**
-   * Create a hash code for a list of objects. Each of them may be null.
-   * Algorithm adapted from "Programming in Scala, Second Edition", p670.
-   */
-  @Deprecated
-  public static int hash(Object... as) {
-    return Objects.hash(as);
-  }
-
 }

--- a/modules/common/src/main/java/org/opencastproject/util/EqualsUtil.java
+++ b/modules/common/src/main/java/org/opencastproject/util/EqualsUtil.java
@@ -31,11 +31,6 @@ public final class EqualsUtil {
   private EqualsUtil() {
   }
 
-  /** Check if <code>a</code> and <code>b</code> are not equal. Each of them may be null. */
-  public static boolean ne(Object a, Object b) {
-    return !Objects.equals(a, b);
-  }
-
   /** Check if <code>a</code> and <code>b</code> have the same class ({@link Object#getClass()}). Each may be null. */
   public static boolean eqClasses(Object a, Object b) {
     return bothNotNull(a, b) && a.getClass().equals(b.getClass());

--- a/modules/common/src/main/java/org/opencastproject/util/EqualsUtil.java
+++ b/modules/common/src/main/java/org/opencastproject/util/EqualsUtil.java
@@ -22,9 +22,7 @@
 
 package org.opencastproject.util;
 
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -72,41 +70,6 @@ public final class EqualsUtil {
       }
     }
 
-    return true;
-  }
-
-  /**
-   * Compare the elements of two lists one by one.
-   *
-   * @deprecated use {@link Objects#equals(Object, Object)} or {@link java.util.List#equals(Object)}
-   */
-  public static boolean eqListSorted(List<?> as, List<?> bs) {
-    if (as != null && bs != null && as.size() == bs.size()) {
-      final Iterator<?> asi = as.iterator();
-      final Iterator<?> bsi = bs.iterator();
-      while (asi.hasNext() && bsi.hasNext()) {
-        if (!asi.next().equals(bsi.next())) {
-          return false;
-        }
-      }
-      return true;
-    } else {
-      return Objects.equals(as, bs);
-    }
-  }
-
-  /**
-   * Compare two maps.
-   *
-   * @deprecated use {@link Objects#equals(Object, Object)} or {@link java.util.Map#equals(Object)}
-   */
-  public static boolean eqMap(Map<?, ?> as, Map<?, ?> bs) {
-    for (Map.Entry<?, ?> ae : as.entrySet()) {
-      final Object bv = bs.get(ae.getKey());
-      if (bv == null || !Objects.equals(ae.getValue(), bv)) {
-        return false;
-      }
-    }
     return true;
   }
 

--- a/modules/common/src/main/java/org/opencastproject/util/EqualsUtil.java
+++ b/modules/common/src/main/java/org/opencastproject/util/EqualsUtil.java
@@ -33,12 +33,6 @@ public final class EqualsUtil {
   private EqualsUtil() {
   }
 
-  /** Check if <code>a</code> and <code>b</code> are equal. Each of them may be null. */
-  @Deprecated
-  public static boolean eqObj(Object a, Object b) {
-    return Objects.equals(a, b);
-  }
-
   /** Check if <code>a</code> and <code>b</code> are not equal. Each of them may be null. */
   public static boolean ne(Object a, Object b) {
     return !Objects.equals(a, b);
@@ -63,7 +57,7 @@ public final class EqualsUtil {
    */
   public static boolean eqListUnsorted(List<?> as, List<?> bs) {
     if (as == null || bs == null) {
-      return eqObj(as, bs);
+      return Objects.equals(as, bs);
     }
 
     as = as.stream().distinct().collect(Collectors.toList());
@@ -84,7 +78,7 @@ public final class EqualsUtil {
   /**
    * Compare the elements of two lists one by one.
    *
-   * @deprecated use {@link #eqObj(Object, Object)} or {@link java.util.List#equals(Object)}
+   * @deprecated use {@link Objects#equals(Object, Object)} or {@link java.util.List#equals(Object)}
    */
   public static boolean eqListSorted(List<?> as, List<?> bs) {
     if (as != null && bs != null && as.size() == bs.size()) {
@@ -97,19 +91,19 @@ public final class EqualsUtil {
       }
       return true;
     } else {
-      return eqObj(as, bs);
+      return Objects.equals(as, bs);
     }
   }
 
   /**
    * Compare two maps.
    *
-   * @deprecated use {@link #eqObj(Object, Object)} or {@link java.util.Map#equals(Object)}
+   * @deprecated use {@link Objects#equals(Object, Object)} or {@link java.util.Map#equals(Object)}
    */
   public static boolean eqMap(Map<?, ?> as, Map<?, ?> bs) {
     for (Map.Entry<?, ?> ae : as.entrySet()) {
       final Object bv = bs.get(ae.getKey());
-      if (bv == null || !eqObj(ae.getValue(), bv)) {
+      if (bv == null || !Objects.equals(ae.getValue(), bv)) {
         return false;
       }
     }

--- a/modules/common/src/main/java/org/opencastproject/util/MimeType.java
+++ b/modules/common/src/main/java/org/opencastproject/util/MimeType.java
@@ -22,13 +22,12 @@
 
 package org.opencastproject.util;
 
-import static org.opencastproject.util.EqualsUtil.eqObj;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -267,8 +266,8 @@ public final class MimeType implements Comparable<MimeType>, Serializable {
   }
 
   private boolean eqFields(MimeType that) {
-    return eqObj(this.type, that.type)
-            && eqObj(this.subtype, that.subtype);
+    return Objects.equals(this.type, that.type)
+            && Objects.equals(this.subtype, that.subtype);
   }
 
   static class Adapter extends XmlAdapter<String, MimeType> {

--- a/modules/common/src/main/java/org/opencastproject/util/MimeType.java
+++ b/modules/common/src/main/java/org/opencastproject/util/MimeType.java
@@ -257,7 +257,7 @@ public final class MimeType implements Comparable<MimeType>, Serializable {
 
   @Override
   public int hashCode() {
-    return EqualsUtil.hash(type, subtype);
+    return Objects.hash(type, subtype);
   }
 
   @Override

--- a/modules/common/src/main/java/org/opencastproject/util/XmlNamespaceBinding.java
+++ b/modules/common/src/main/java/org/opencastproject/util/XmlNamespaceBinding.java
@@ -21,10 +21,10 @@
 
 package org.opencastproject.util;
 
-import static org.opencastproject.util.EqualsUtil.eq;
 import static org.opencastproject.util.EqualsUtil.hash;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Declaration of an XML namespace binding which is the association of a prefix to a namespace URI (namespace name).
@@ -77,6 +77,6 @@ public final class XmlNamespaceBinding implements Serializable {
   }
 
   private boolean eqFields(XmlNamespaceBinding that) {
-    return eq(prefix, that.prefix) && eq(namespaceURI, that.namespaceURI);
+    return Objects.equals(prefix, that.prefix) && Objects.equals(namespaceURI, that.namespaceURI);
   }
 }

--- a/modules/common/src/main/java/org/opencastproject/util/XmlNamespaceBinding.java
+++ b/modules/common/src/main/java/org/opencastproject/util/XmlNamespaceBinding.java
@@ -21,8 +21,6 @@
 
 package org.opencastproject.util;
 
-import static org.opencastproject.util.EqualsUtil.hash;
-
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -69,7 +67,7 @@ public final class XmlNamespaceBinding implements Serializable {
   }
 
   @Override public int hashCode() {
-    return hash(prefix, namespaceURI);
+    return Objects.hash(prefix, namespaceURI);
   }
 
   @Override public boolean equals(Object that) {

--- a/modules/common/src/main/java/org/opencastproject/util/XmlNamespaceContext.java
+++ b/modules/common/src/main/java/org/opencastproject/util/XmlNamespaceContext.java
@@ -21,7 +21,6 @@
 
 package org.opencastproject.util;
 
-import static org.opencastproject.util.EqualsUtil.eq;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,6 +29,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.xml.XMLConstants;
@@ -146,7 +146,7 @@ public final class XmlNamespaceContext implements NamespaceContext {
     return new NamespaceContext() {
       @Override public String getNamespaceURI(String prefix) {
         final String uri = b.getNamespaceURI(prefix);
-        if (eq(XMLConstants.DEFAULT_NS_PREFIX, prefix) && eq(XMLConstants.NULL_NS_URI, uri)) {
+        if (Objects.equals(XMLConstants.DEFAULT_NS_PREFIX, prefix) && Objects.equals(XMLConstants.NULL_NS_URI, uri)) {
           return a.getNamespaceURI(prefix);
         } else {
           return uri;

--- a/modules/common/src/main/java/org/opencastproject/util/data/Cells.java
+++ b/modules/common/src/main/java/org/opencastproject/util/data/Cells.java
@@ -21,8 +21,9 @@
 
 package org.opencastproject.util.data;
 
-import static org.opencastproject.util.EqualsUtil.ne;
 import static org.opencastproject.util.data.Tuple.tuple;
+
+import java.util.Objects;
 
 public final class Cells {
   private Cells() {
@@ -53,7 +54,7 @@ public final class Cells {
     return new FCell<A>() {
       @Override protected A calc() {
         final Tuple<B, Object> mChange = master.change();
-        if (ne(mChange.getB(), change)) {
+        if (!Objects.equals(mChange.getB(), change)) {
           a = f.apply(mChange.getA());
           change = mChange.getB();
         }

--- a/modules/common/src/main/java/org/opencastproject/util/data/Tuple3.java
+++ b/modules/common/src/main/java/org/opencastproject/util/data/Tuple3.java
@@ -23,7 +23,8 @@
 package org.opencastproject.util.data;
 
 import static org.opencastproject.util.EqualsUtil.eqClasses;
-import static org.opencastproject.util.EqualsUtil.hash;
+
+import java.util.Objects;
 
 /** A 3-tuple. */
 public final class Tuple3<A, B, C> {
@@ -64,7 +65,7 @@ public final class Tuple3<A, B, C> {
 
   @Override
   public int hashCode() {
-    return hash(a, b, c);
+    return Objects.hash(a, b, c);
   }
 
   public static <A, B, C> Tuple3<A, B, C> tuple3(A a, B b, C c) {

--- a/modules/common/src/main/java/org/opencastproject/util/data/VCell.java
+++ b/modules/common/src/main/java/org/opencastproject/util/data/VCell.java
@@ -22,11 +22,11 @@
 
 package org.opencastproject.util.data;
 
-import static org.opencastproject.util.EqualsUtil.ne;
 import static org.opencastproject.util.RequireUtil.notNull;
 import static org.opencastproject.util.data.Cells.fcell;
 import static org.opencastproject.util.data.Tuple.tuple;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -82,7 +82,7 @@ public final class VCell<A> extends Cell<A> {
   /** Set the cell's value. */
   public void set(A a) {
     synchronized (lock) {
-      if (ne(a, this.a)) {
+      if (!Objects.equals(a, this.a)) {
         this.a = a;
         change += 1;
       }

--- a/modules/common/src/main/java/org/opencastproject/util/data/functions/Booleans.java
+++ b/modules/common/src/main/java/org/opencastproject/util/data/functions/Booleans.java
@@ -21,8 +21,7 @@
 
 package org.opencastproject.util.data.functions;
 
-import org.opencastproject.util.EqualsUtil;
-
+import java.util.Objects;
 import java.util.function.Function;
 
 /** Boolean functions. */
@@ -31,7 +30,7 @@ public final class Booleans {
   }
 
   public static <A> Function<A, Boolean> eq(final A a) {
-    return x -> EqualsUtil.eq(x, a);
+    return x -> Objects.equals(x, a);
   }
 
   public static <A extends Comparable<A>> Function<A, Boolean> lt(final A a) {

--- a/modules/common/src/main/java/org/opencastproject/util/data/functions/Misc.java
+++ b/modules/common/src/main/java/org/opencastproject/util/data/functions/Misc.java
@@ -21,9 +21,8 @@
 
 package org.opencastproject.util.data.functions;
 
-import static org.opencastproject.util.EqualsUtil.eq;
-
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -56,17 +55,17 @@ public final class Misc {
   /** Cast from A to B with special treatment of the Number classes. */
   public static <A, B> B cast(A v, Class<B> to) {
     if (Number.class.isAssignableFrom(v.getClass())) {
-      if (eq(Integer.class, to)) {
+      if (Objects.equals(Integer.class, to)) {
         return (B) ((Object) (((Number) v).intValue()));
-      } else if (eq(Long.class, to)) {
+      } else if (Objects.equals(Long.class, to)) {
         return (B) ((Object) (((Number) v).longValue()));
-      } else if (eq(Double.class, to)) {
+      } else if (Objects.equals(Double.class, to)) {
         return (B) ((Object) (((Number) v).doubleValue()));
-      } else if (eq(Float.class, to)) {
+      } else if (Objects.equals(Float.class, to)) {
         return (B) ((Object) (((Number) v).floatValue()));
-      } else if (eq(Short.class, to)) {
+      } else if (Objects.equals(Short.class, to)) {
         return (B) ((Object) (((Number) v).shortValue()));
-      } else if (eq(Byte.class, to)) {
+      } else if (Objects.equals(Byte.class, to)) {
         return (B) ((Object) (((Number) v).byteValue()));
       } else {
         return (B) v;

--- a/modules/common/src/test/java/org/opencastproject/util/EqualUtilTest.java
+++ b/modules/common/src/test/java/org/opencastproject/util/EqualUtilTest.java
@@ -26,25 +26,12 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.opencastproject.util.EqualsUtil.eqListUnsorted;
-import static org.opencastproject.util.EqualsUtil.eqMap;
-import static org.opencastproject.util.data.Arrays.array;
 
 import org.junit.Test;
 
 import java.util.List;
-import java.util.Map;
 
 public class EqualUtilTest {
-  @Test
-  public void testEqualMap() {
-    assertTrue(eqMap(Map.of("a", "b"), Map.of("a", "b")));
-    assertTrue(eqMap(Map.of("a", Map.of(1, "bla")), Map.of("a", Map.of(1, "bla"))));
-    // this yields false since Java does not define equality on arrays.
-    assertFalse(eqMap(Map.of(4, array(1, 2, 4)), Map.of(4, array(1, 2, 4))));
-    assertFalse(eqMap(Map.of(1, new Object()), Map.of(1, new Object())));
-    assertFalse(eqMap(Map.of("a", "b", "x", "y"), Map.of("a", "b", "x", "z")));
-  }
-
   @Test
   public void testEqualListUnsorted() {
     // A List is equal to itself

--- a/modules/composer-service-api/src/main/java/org/opencastproject/composer/api/EncodingProfileImpl.java
+++ b/modules/composer-service-api/src/main/java/org/opencastproject/composer/api/EncodingProfileImpl.java
@@ -22,8 +22,6 @@
 
 package org.opencastproject.composer.api;
 
-import org.opencastproject.util.EqualsUtil;
-
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
@@ -31,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -493,7 +492,7 @@ public class EncodingProfileImpl implements EncodingProfile {
 
     @Override
     public int hashCode() {
-      return EqualsUtil.hash(key, value);
+      return Objects.hash(key, value);
     }
   }
 

--- a/modules/composer-service-api/src/main/java/org/opencastproject/composer/layout/AbsolutePositionLayoutSpec.java
+++ b/modules/composer-service-api/src/main/java/org/opencastproject/composer/layout/AbsolutePositionLayoutSpec.java
@@ -21,8 +21,9 @@
 
 package org.opencastproject.composer.layout;
 
-import static org.opencastproject.util.EqualsUtil.eq;
 import static org.opencastproject.util.EqualsUtil.hash;
+
+import java.util.Objects;
 
 /**
  * This layout specification describes where to position a shape in relation to another.
@@ -55,7 +56,7 @@ public final class AbsolutePositionLayoutSpec {
   }
 
   private boolean eqFields(AbsolutePositionLayoutSpec that) {
-    return eq(anchorOffset, that.anchorOffset);
+    return Objects.equals(anchorOffset, that.anchorOffset);
   }
 
   @Override

--- a/modules/composer-service-api/src/main/java/org/opencastproject/composer/layout/AbsolutePositionLayoutSpec.java
+++ b/modules/composer-service-api/src/main/java/org/opencastproject/composer/layout/AbsolutePositionLayoutSpec.java
@@ -21,8 +21,6 @@
 
 package org.opencastproject.composer.layout;
 
-import static org.opencastproject.util.EqualsUtil.hash;
-
 import java.util.Objects;
 
 /**
@@ -61,6 +59,6 @@ public final class AbsolutePositionLayoutSpec {
 
   @Override
   public int hashCode() {
-    return hash(anchorOffset);
+    return Objects.hash(anchorOffset);
   }
 }

--- a/modules/composer-service-api/src/main/java/org/opencastproject/composer/layout/Anchor.java
+++ b/modules/composer-service-api/src/main/java/org/opencastproject/composer/layout/Anchor.java
@@ -22,9 +22,10 @@
 package org.opencastproject.composer.layout;
 
 import static java.lang.String.format;
-import static org.opencastproject.util.EqualsUtil.hash;
 
 import org.opencastproject.util.RequireUtil;
+
+import java.util.Objects;
 
 /** Anchor point of a rectangular shape, expressed relatively to its width and height. */
 public final class Anchor {
@@ -63,7 +64,7 @@ public final class Anchor {
 
   @Override
   public int hashCode() {
-    return hash(left, top);
+    return Objects.hash(left, top);
   }
 
   @Override

--- a/modules/composer-service-api/src/main/java/org/opencastproject/composer/layout/AnchorOffset.java
+++ b/modules/composer-service-api/src/main/java/org/opencastproject/composer/layout/AnchorOffset.java
@@ -22,7 +22,6 @@
 package org.opencastproject.composer.layout;
 
 import static java.lang.String.format;
-import static org.opencastproject.util.EqualsUtil.hash;
 
 import java.util.Objects;
 
@@ -79,7 +78,7 @@ public final class AnchorOffset {
 
   @Override
   public int hashCode() {
-    return hash(offset, referenceAnchor, referringAnchor);
+    return Objects.hash(offset, referenceAnchor, referringAnchor);
   }
 
   @Override

--- a/modules/composer-service-api/src/main/java/org/opencastproject/composer/layout/AnchorOffset.java
+++ b/modules/composer-service-api/src/main/java/org/opencastproject/composer/layout/AnchorOffset.java
@@ -22,8 +22,9 @@
 package org.opencastproject.composer.layout;
 
 import static java.lang.String.format;
-import static org.opencastproject.util.EqualsUtil.eq;
 import static org.opencastproject.util.EqualsUtil.hash;
+
+import java.util.Objects;
 
 /** The offset between the anchor points of two rectangular shapes. */
 public final class AnchorOffset {
@@ -72,8 +73,8 @@ public final class AnchorOffset {
   }
 
   private boolean eqFields(AnchorOffset that) {
-    return eq(offset, that.offset) && eq(referenceAnchor, that.referenceAnchor)
-            && eq(referringAnchor, that.referringAnchor);
+    return Objects.equals(offset, that.offset) && Objects.equals(referenceAnchor, that.referenceAnchor)
+            && Objects.equals(referringAnchor, that.referringAnchor);
   }
 
   @Override

--- a/modules/composer-service-api/src/main/java/org/opencastproject/composer/layout/Dimension.java
+++ b/modules/composer-service-api/src/main/java/org/opencastproject/composer/layout/Dimension.java
@@ -22,9 +22,10 @@
 package org.opencastproject.composer.layout;
 
 import static java.lang.String.format;
-import static org.opencastproject.util.EqualsUtil.hash;
 
 import org.opencastproject.util.RequireUtil;
+
+import java.util.Objects;
 
 /** Dimension of a rectangular shape. */
 public final class Dimension {
@@ -59,7 +60,7 @@ public final class Dimension {
 
   @Override
   public int hashCode() {
-    return hash(width, height);
+    return Objects.hash(width, height);
   }
 
   @Override

--- a/modules/composer-service-api/src/main/java/org/opencastproject/composer/layout/HorizontalCoverageLayoutSpec.java
+++ b/modules/composer-service-api/src/main/java/org/opencastproject/composer/layout/HorizontalCoverageLayoutSpec.java
@@ -21,10 +21,11 @@
 
 package org.opencastproject.composer.layout;
 
-import static org.opencastproject.util.EqualsUtil.eq;
 import static org.opencastproject.util.EqualsUtil.hash;
 
 import org.opencastproject.util.RequireUtil;
+
+import java.util.Objects;
 
 /**
  * This layout specification describes how to position a shape and how much of the underlying width of the canvas it
@@ -65,7 +66,7 @@ public final class HorizontalCoverageLayoutSpec {
   }
 
   private boolean eqFields(HorizontalCoverageLayoutSpec that) {
-    return eq(anchorOffset, that.anchorOffset) && horizontalCoverage == that.horizontalCoverage;
+    return Objects.equals(anchorOffset, that.anchorOffset) && horizontalCoverage == that.horizontalCoverage;
   }
 
   @Override

--- a/modules/composer-service-api/src/main/java/org/opencastproject/composer/layout/HorizontalCoverageLayoutSpec.java
+++ b/modules/composer-service-api/src/main/java/org/opencastproject/composer/layout/HorizontalCoverageLayoutSpec.java
@@ -21,8 +21,6 @@
 
 package org.opencastproject.composer.layout;
 
-import static org.opencastproject.util.EqualsUtil.hash;
-
 import org.opencastproject.util.RequireUtil;
 
 import java.util.Objects;
@@ -71,6 +69,6 @@ public final class HorizontalCoverageLayoutSpec {
 
   @Override
   public int hashCode() {
-    return hash(anchorOffset, horizontalCoverage);
+    return Objects.hash(anchorOffset, horizontalCoverage);
   }
 }

--- a/modules/composer-service-api/src/main/java/org/opencastproject/composer/layout/Layout.java
+++ b/modules/composer-service-api/src/main/java/org/opencastproject/composer/layout/Layout.java
@@ -21,8 +21,6 @@
 
 package org.opencastproject.composer.layout;
 
-import static org.opencastproject.util.EqualsUtil.hash;
-
 import java.util.Objects;
 
 /** The layout of a rectangular shape on a rectangular canvas. */
@@ -64,6 +62,6 @@ public final class Layout {
 
   @Override
   public int hashCode() {
-    return hash(dim, offset);
+    return Objects.hash(dim, offset);
   }
 }

--- a/modules/composer-service-api/src/main/java/org/opencastproject/composer/layout/Layout.java
+++ b/modules/composer-service-api/src/main/java/org/opencastproject/composer/layout/Layout.java
@@ -21,8 +21,9 @@
 
 package org.opencastproject.composer.layout;
 
-import static org.opencastproject.util.EqualsUtil.eq;
 import static org.opencastproject.util.EqualsUtil.hash;
+
+import java.util.Objects;
 
 /** The layout of a rectangular shape on a rectangular canvas. */
 public final class Layout {
@@ -58,7 +59,7 @@ public final class Layout {
   }
 
   private boolean eqFields(Layout that) {
-    return eq(dim, that.dim) && eq(offset, that.offset);
+    return Objects.equals(dim, that.dim) && Objects.equals(offset, that.offset);
   }
 
   @Override

--- a/modules/composer-service-api/src/main/java/org/opencastproject/composer/layout/Offset.java
+++ b/modules/composer-service-api/src/main/java/org/opencastproject/composer/layout/Offset.java
@@ -22,7 +22,8 @@
 package org.opencastproject.composer.layout;
 
 import static java.lang.String.format;
-import static org.opencastproject.util.EqualsUtil.hash;
+
+import java.util.Objects;
 
 /** Offset in a left-handed cartesian coordinate system. */
 public final class Offset {
@@ -59,7 +60,7 @@ public final class Offset {
 
   @Override
   public int hashCode() {
-    return hash(x, y);
+    return Objects.hash(x, y);
   }
 
   @Override

--- a/modules/composer-service-api/src/main/java/org/opencastproject/composer/layout/TwoShapeLayout.java
+++ b/modules/composer-service-api/src/main/java/org/opencastproject/composer/layout/TwoShapeLayout.java
@@ -21,8 +21,9 @@
 
 package org.opencastproject.composer.layout;
 
-import static org.opencastproject.util.EqualsUtil.eq;
 import static org.opencastproject.util.EqualsUtil.hash;
+
+import java.util.Objects;
 
 /** Layout of two shapes on a common canvas. */
 public final class TwoShapeLayout {
@@ -57,7 +58,8 @@ public final class TwoShapeLayout {
   }
 
   private boolean eqFields(TwoShapeLayout that) {
-    return eq(upper, that.upper) && eq(lower, that.lower) && eq(canvas, that.canvas);
+    return Objects.equals(upper, that.upper) && Objects.equals(lower, that.lower)
+            && Objects.equals(canvas, that.canvas);
   }
 
   @Override

--- a/modules/composer-service-api/src/main/java/org/opencastproject/composer/layout/TwoShapeLayout.java
+++ b/modules/composer-service-api/src/main/java/org/opencastproject/composer/layout/TwoShapeLayout.java
@@ -21,8 +21,6 @@
 
 package org.opencastproject.composer.layout;
 
-import static org.opencastproject.util.EqualsUtil.hash;
-
 import java.util.Objects;
 
 /** Layout of two shapes on a common canvas. */
@@ -64,6 +62,6 @@ public final class TwoShapeLayout {
 
   @Override
   public int hashCode() {
-    return hash(upper, lower, canvas);
+    return Objects.hash(upper, lower, canvas);
   }
 }

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageWorkflowOperationHandler.java
@@ -22,7 +22,6 @@
 package org.opencastproject.workflow.handler.composer;
 
 import static java.lang.String.format;
-import static org.opencastproject.util.EqualsUtil.eq;
 
 import org.opencastproject.composer.api.ComposerService;
 import org.opencastproject.composer.api.EncodingProfile;
@@ -195,10 +194,10 @@ public class ImageWorkflowOperationHandler extends AbstractWorkflowOperationHand
   protected void adjustMetadata(Extraction extraction, Attachment image, Cfg cfg) {
     // Adjust the target flavor. Make sure to account for partial updates
     for (final MediaPackageElementFlavor flavor : cfg.targetImageFlavor) {
-      final String flavorType = eq("*", flavor.getType())
+      final String flavorType = Objects.equals("*", flavor.getType())
           ? extraction.track.getFlavor().getType()
           : flavor.getType();
-      final String flavorSubtype = eq("*", flavor.getSubtype())
+      final String flavorSubtype = Objects.equals("*", flavor.getSubtype())
           ? extraction.track.getFlavor().getSubtype()
           : flavor.getSubtype();
       image.setFlavor(new MediaPackageElementFlavor(flavorType, flavorSubtype));
@@ -596,7 +595,7 @@ public class ImageWorkflowOperationHandler extends AbstractWorkflowOperationHand
     }
 
     private boolean eqFields(MediaPosition that) {
-      return position == that.position && eq(type, that.type);
+      return position == that.position && Objects.equals(type, that.type);
     }
 
     @Override public String toString() {

--- a/modules/distribution-service-download/src/main/java/org/opencastproject/distribution/download/DownloadDistributionServiceImpl.java
+++ b/modules/distribution-service-download/src/main/java/org/opencastproject/distribution/download/DownloadDistributionServiceImpl.java
@@ -22,7 +22,6 @@ package org.opencastproject.distribution.download;
 
 import static java.lang.String.format;
 import static org.opencastproject.systems.OpencastConstants.DIGEST_USER_PROPERTY;
-import static org.opencastproject.util.EqualsUtil.ne;
 import static org.opencastproject.util.HttpUtil.waitForResource;
 import static org.opencastproject.util.PathSupport.path;
 import static org.opencastproject.util.RequireUtil.notNull;
@@ -92,6 +91,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -897,7 +897,7 @@ public class DownloadDistributionServiceImpl extends AbstractDistributionService
           .fold(
               Misc.chuck(),
               status -> {
-                if (ne(status, HttpServletResponse.SC_OK)) {
+                if (!Objects.equals(status, HttpServletResponse.SC_OK)) {
                   logger.warn("Attempt to access distributed file {} returned code {}", uri, status);
                   Misc.chuck(new DistributionException("Unable to load distributed file " + uri.toString()));
                 }

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreValue.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreValue.java
@@ -24,7 +24,6 @@ package org.opencastproject.metadata.dublincore;
 import static java.lang.String.format;
 
 import org.opencastproject.mediapackage.EName;
-import org.opencastproject.util.EqualsUtil;
 import org.opencastproject.util.RequireUtil;
 
 import java.io.Serializable;
@@ -154,7 +153,7 @@ public final class DublinCoreValue implements Serializable {
 
   @Override
   public int hashCode() {
-    return EqualsUtil.hash(value, language, encodingScheme);
+    return Objects.hash(value, language, encodingScheme);
   }
 
   @Override public String toString() {

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreValue.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreValue.java
@@ -22,13 +22,13 @@
 package org.opencastproject.metadata.dublincore;
 
 import static java.lang.String.format;
-import static org.opencastproject.util.EqualsUtil.eq;
 
 import org.opencastproject.mediapackage.EName;
 import org.opencastproject.util.EqualsUtil;
 import org.opencastproject.util.RequireUtil;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -148,7 +148,8 @@ public final class DublinCoreValue implements Serializable {
   }
 
   private boolean eqFields(DublinCoreValue that) {
-    return eq(value, that.value) && eq(language, that.language) && eq(encodingScheme, that.encodingScheme);
+    return Objects.equals(value, that.value) && Objects.equals(language, that.language)
+            && Objects.equals(encodingScheme, that.encodingScheme);
   }
 
   @Override

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/series/Series.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/series/Series.java
@@ -23,7 +23,6 @@ package org.opencastproject.elasticsearch.index.objects.series;
 
 import org.opencastproject.elasticsearch.index.objects.IndexObject;
 import org.opencastproject.util.DateTimeSupport.UtcTimestampAdapter;
-import org.opencastproject.util.EqualsUtil;
 import org.opencastproject.util.IoSupport;
 import org.opencastproject.util.XmlSafeParser;
 import org.opencastproject.util.jaxb.ExtendedMetadataAdapter;
@@ -46,6 +45,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -213,7 +213,7 @@ public class Series implements IndexObject {
    *          the title
    */
   public void setTitle(String title) {
-    if (EqualsUtil.eq(this.title, title)) {
+    if (Objects.equals(this.title, title)) {
       return;
     }
 

--- a/modules/event-comment/src/main/java/org/opencastproject/event/comment/EventComment.java
+++ b/modules/event-comment/src/main/java/org/opencastproject/event/comment/EventComment.java
@@ -26,7 +26,6 @@ import static org.opencastproject.util.RequireUtil.notNull;
 
 import org.opencastproject.security.api.User;
 import org.opencastproject.util.DateTimeSupport;
-import org.opencastproject.util.EqualsUtil;
 import org.opencastproject.util.Jsons;
 import org.opencastproject.util.Jsons.Obj;
 import org.opencastproject.util.Jsons.Val;
@@ -36,6 +35,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -356,7 +356,7 @@ public final class EventComment {
 
   @Override
   public int hashCode() {
-    return EqualsUtil.hash(text, creationDate, modificationDate, author, reason, resolvedStatus);
+    return Objects.hash(text, creationDate, modificationDate, author, reason, resolvedStatus);
   }
 
   @Override

--- a/modules/event-comment/src/main/java/org/opencastproject/event/comment/EventCommentReply.java
+++ b/modules/event-comment/src/main/java/org/opencastproject/event/comment/EventCommentReply.java
@@ -26,7 +26,6 @@ import static org.opencastproject.util.RequireUtil.notNull;
 
 import org.opencastproject.security.api.User;
 import org.opencastproject.util.DateTimeSupport;
-import org.opencastproject.util.EqualsUtil;
 import org.opencastproject.util.Jsons;
 import org.opencastproject.util.Jsons.Obj;
 import org.opencastproject.util.Jsons.Val;
@@ -34,6 +33,7 @@ import org.opencastproject.util.Jsons.Val;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Date;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -167,7 +167,7 @@ public final class EventCommentReply {
 
   @Override
   public int hashCode() {
-    return EqualsUtil.hash(text, creationDate, modificationDate, author);
+    return Objects.hash(text, creationDate, modificationDate, author);
   }
 
   @Override

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/bundleinfo/BundleInfoRestEndpoint.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/bundleinfo/BundleInfoRestEndpoint.java
@@ -23,7 +23,6 @@ package org.opencastproject.kernel.bundleinfo;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
-import static org.opencastproject.util.EqualsUtil.ne;
 import static org.opencastproject.util.Jsons.arr;
 import static org.opencastproject.util.Jsons.obj;
 import static org.opencastproject.util.Jsons.p;
@@ -44,6 +43,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Dictionary;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -130,7 +130,7 @@ public abstract class BundleInfoRestEndpoint {
       final String bundleVersion = infos.get(0).getBundleVersion();
       final Optional<String> buildNumber = infos.get(0).getBuildNumber();
       for (BundleInfo a : infos) {
-        if (ne(a.getBundleVersion(), bundleVersion) || ne(a.getBuildNumber(), buildNumber)) {
+        if (!Objects.equals(a.getBundleVersion(), bundleVersion) || !Objects.equals(a.getBuildNumber(), buildNumber)) {
           return ok(TEXT_PLAIN_TYPE, "false");
         }
       }

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/bundleinfo/BundleVersion.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/bundleinfo/BundleVersion.java
@@ -21,8 +21,6 @@
 
 package org.opencastproject.kernel.bundleinfo;
 
-import static org.opencastproject.util.EqualsUtil.hash;
-
 import java.util.Objects;
 import java.util.Optional;
 
@@ -52,6 +50,6 @@ public final class BundleVersion {
   }
 
   @Override public int hashCode() {
-    return hash(bundleVersion, buildNumber);
+    return Objects.hash(bundleVersion, buildNumber);
   }
 }

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/bundleinfo/BundleVersion.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/bundleinfo/BundleVersion.java
@@ -21,9 +21,9 @@
 
 package org.opencastproject.kernel.bundleinfo;
 
-import static org.opencastproject.util.EqualsUtil.eq;
 import static org.opencastproject.util.EqualsUtil.hash;
 
+import java.util.Objects;
 import java.util.Optional;
 
 public final class BundleVersion {
@@ -48,7 +48,7 @@ public final class BundleVersion {
   }
 
   private boolean eqFields(BundleVersion that) {
-    return eq(this.bundleVersion, that.bundleVersion) && eq(this.buildNumber, that.buildNumber);
+    return Objects.equals(this.bundleVersion, that.bundleVersion) && Objects.equals(this.buildNumber, that.buildNumber);
   }
 
   @Override public int hashCode() {

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/mail/EmailAddress.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/mail/EmailAddress.java
@@ -21,8 +21,9 @@
 
 package org.opencastproject.kernel.mail;
 
-import static org.opencastproject.util.EqualsUtil.eqObj;
 import static org.opencastproject.util.EqualsUtil.hash;
+
+import java.util.Objects;
 
 /** An email address. */
 public final class EmailAddress {
@@ -45,7 +46,7 @@ public final class EmailAddress {
   }
 
   private boolean eqFields(EmailAddress that) {
-    return eqObj(this.address, that.address) && eqObj(this.name, that.name);
+    return Objects.equals(this.address, that.address) && Objects.equals(this.name, that.name);
   }
 
   @Override

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/mail/EmailAddress.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/mail/EmailAddress.java
@@ -21,8 +21,6 @@
 
 package org.opencastproject.kernel.mail;
 
-import static org.opencastproject.util.EqualsUtil.hash;
-
 import java.util.Objects;
 
 /** An email address. */
@@ -37,7 +35,7 @@ public final class EmailAddress {
 
   @Override
   public int hashCode() {
-    return hash(address, name);
+    return Objects.hash(address, name);
   }
 
   @Override

--- a/modules/oaipmh/src/test/java/org/opencastproject/oaipmh/server/OaiPmhRepositoryTest.java
+++ b/modules/oaipmh/src/test/java/org/opencastproject/oaipmh/server/OaiPmhRepositoryTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.opencastproject.oaipmh.server.OaiPmhRepositoryTest.OaiPmhResponseStatus.IsError;
 import static org.opencastproject.oaipmh.server.OaiPmhRepositoryTest.OaiPmhResponseStatus.IsValid;
-import static org.opencastproject.util.EqualsUtil.eq;
 import static org.opencastproject.util.IoSupport.withResource;
 import static org.opencastproject.util.data.functions.Misc.chuck;
 import static org.xmlmatchers.transform.XmlConverters.the;
@@ -75,6 +74,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.TimeZone;
 
@@ -286,11 +286,13 @@ public class OaiPmhRepositoryTest {
             final String className = JsonVal.asString(messageObj.val("className").get()).trim();
             final String text = JsonVal.asString(messageObj.val("text").get()).trim();
             logger.info("[{}] {}", className, text);
-            ok = ok && (eq(className, "correct")
+            ok = ok && (Objects.equals(className, "correct")
                     // since the validator does not validate everything correctly here are some exclusions
-                    || (status == IsError && eq(text, "Could not find a valid OAI-PMH command.")))
-                    || (eq(verb, OaiPmhConstants.VERB_IDENTIFY) && eq(text, "Invalid OAI-PMH protocol version ."))
-                    || (eq(verb, OaiPmhConstants.VERB_IDENTIFY) && eq(text, "Invalid adminEmail ."));
+                    || (status == IsError && Objects.equals(text, "Could not find a valid OAI-PMH command.")))
+                    || (Objects.equals(verb, OaiPmhConstants.VERB_IDENTIFY)
+                            && Objects.equals(text, "Invalid OAI-PMH protocol version ."))
+                    || (Objects.equals(verb, OaiPmhConstants.VERB_IDENTIFY)
+                            && Objects.equals(text, "Invalid adminEmail ."));
           }
         }
       }

--- a/modules/oaipmh/src/test/java/org/opencastproject/oaipmh/server/TestRestService.java
+++ b/modules/oaipmh/src/test/java/org/opencastproject/oaipmh/server/TestRestService.java
@@ -20,9 +20,9 @@
  */
 package org.opencastproject.oaipmh.server;
 
-import static org.opencastproject.util.EqualsUtil.eq;
-
 import org.junit.Ignore;
+
+import java.util.Objects;
 
 import javax.ws.rs.Path;
 
@@ -31,7 +31,7 @@ import javax.ws.rs.Path;
 public class TestRestService extends AbstractOaiPmhServerInfoRestEndpoint {
   private final OaiPmhServerInfo s = new OaiPmhServerInfo() {
     @Override public boolean hasRepo(String id) {
-      return eq("default", id);
+      return Objects.equals("default", id);
     }
 
     @Override public String getMountPoint() {

--- a/modules/scheduler-api/src/main/java/org/opencastproject/scheduler/api/Period.java
+++ b/modules/scheduler-api/src/main/java/org/opencastproject/scheduler/api/Period.java
@@ -20,11 +20,11 @@
  */
 package org.opencastproject.scheduler.api;
 
-import static org.opencastproject.util.EqualsUtil.eq;
 
 import org.opencastproject.util.EqualsUtil;
 
 import java.util.Date;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -120,8 +120,9 @@ public final class Period {
   }
 
   private boolean eqFields(Period that) {
-    return eq(this.id, that.id) && eq(this.start, that.start) && eq(this.end, that.end)
-            && eq(this.purpose, that.purpose) && eq(this.comment, that.comment);
+    return Objects.equals(this.id, that.id) && Objects.equals(this.start, that.start)
+            && Objects.equals(this.end, that.end) && Objects.equals(this.purpose, that.purpose)
+            && Objects.equals(this.comment, that.comment);
   }
 
   @Override

--- a/modules/scheduler-api/src/main/java/org/opencastproject/scheduler/api/Period.java
+++ b/modules/scheduler-api/src/main/java/org/opencastproject/scheduler/api/Period.java
@@ -20,9 +20,6 @@
  */
 package org.opencastproject.scheduler.api;
 
-
-import org.opencastproject.util.EqualsUtil;
-
 import java.util.Date;
 import java.util.Objects;
 import java.util.Optional;
@@ -127,7 +124,7 @@ public final class Period {
 
   @Override
   public int hashCode() {
-    return EqualsUtil.hash(id, start, end, purpose, comment);
+    return Objects.hash(id, start, end, purpose, comment);
   }
 
 }

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -23,7 +23,6 @@ package org.opencastproject.scheduler.impl;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.opencastproject.scheduler.impl.SchedulerUtil.calculateChecksum;
 import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
-import static org.opencastproject.util.EqualsUtil.ne;
 import static org.opencastproject.util.RequireUtil.notEmpty;
 import static org.opencastproject.util.RequireUtil.notNull;
 import static org.opencastproject.util.RequireUtil.requireTrue;
@@ -133,6 +132,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TimeZone;
@@ -732,7 +732,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
       if (mediaPackageOpt.isPresent()) {
         MediaPackage mediaPackage = mediaPackageOpt.get();
         // Check for series change
-        if (ne(archivedMediaPackage.getSeries(), mediaPackage.getSeries())) {
+        if (!Objects.equals(archivedMediaPackage.getSeries(), mediaPackage.getSeries())) {
           propertiesChanged = true;
           seriesId = Optional.ofNullable(mediaPackage.getSeries());
         }

--- a/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
+++ b/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
@@ -55,7 +55,6 @@ import static org.opencastproject.metadata.dublincore.DublinCore.PROPERTY_TYPE;
 import static org.opencastproject.scheduler.api.RecordingState.CAPTURING;
 import static org.opencastproject.scheduler.api.RecordingState.UPLOADING;
 import static org.opencastproject.scheduler.api.RecordingState.UPLOAD_FINISHED;
-import static org.opencastproject.util.EqualsUtil.eqObj;
 import static org.opencastproject.util.UrlSupport.uri;
 import static org.opencastproject.util.data.Tuple.tuple;
 import static org.opencastproject.util.data.functions.Misc.chuck;
@@ -170,6 +169,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -1547,7 +1547,7 @@ public class SchedulerServiceImplTest {
           .map(p -> parseProperties(decodeBase64(getValue(p))))
           .toList();
       assertEquals("number of CA property sets", 1, caPropsIcal.size());
-      assertTrue("CA properties", eqObj(caProps, caPropsIcal.get(0)));
+      assertTrue("CA properties", Objects.equals(caProps, caPropsIcal.get(0)));
     }
   }
 

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
@@ -22,7 +22,6 @@
 package org.opencastproject.series.impl;
 
 import static org.opencastproject.util.EqualsUtil.bothNotNull;
-import static org.opencastproject.util.EqualsUtil.eqListSorted;
 import static org.opencastproject.util.EqualsUtil.eqListUnsorted;
 import static org.opencastproject.util.RequireUtil.notNull;
 
@@ -79,6 +78,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -425,7 +425,7 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
     final Map<EName, List<DublinCoreValue>> bv = b.getValues();
     if (av.size() == bv.size()) {
       for (Map.Entry<EName, List<DublinCoreValue>> ave : av.entrySet()) {
-        if (!eqListSorted(ave.getValue(), bv.get(ave.getKey()))) {
+        if (!Objects.equals(ave.getValue(), bv.get(ave.getKey()))) {
           return false;
         }
       }

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/endpoint/IncidentServiceEndpoint.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/endpoint/IncidentServiceEndpoint.java
@@ -27,7 +27,6 @@ import static javax.servlet.http.HttpServletResponse.SC_CREATED;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
-import static org.opencastproject.util.EqualsUtil.eq;
 import static org.opencastproject.util.RestUtil.R.badRequest;
 import static org.opencastproject.util.RestUtil.R.ok;
 import static org.opencastproject.util.RestUtil.getResponseType;
@@ -78,6 +77,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.DefaultValue;
@@ -193,11 +193,11 @@ public class IncidentServiceEndpoint {
     try {
       final List<Incident> incidents = svc.getIncidentsOfJob(jobIds);
       final MediaType mt = getResponseType(type);
-      if (eq(FMT_SYS, format)) {
+      if (Objects.equals(FMT_SYS, format)) {
         return ok(mt, new JaxbIncidentList(incidents));
-      } else if (eq(FMT_DIGEST, format)) {
+      } else if (Objects.equals(FMT_DIGEST, format)) {
         return ok(mt, new JaxbIncidentDigestList(svc, request.getLocale(), incidents));
-      } else if (eq(FMT_FULL, format)) {
+      } else if (Objects.equals(FMT_FULL, format)) {
         return ok(mt, new JaxbIncidentFullList(svc, request.getLocale(), incidents));
       } else {
         return unknownFormat();
@@ -247,11 +247,11 @@ public class IncidentServiceEndpoint {
     try {
       final IncidentTree tree = svc.getIncidentsOfJob(jobId, cascade);
       final MediaType mt = getResponseType(type);
-      if (eq(FMT_SYS, format)) {
+      if (Objects.equals(FMT_SYS, format)) {
         return ok(mt, new JaxbIncidentTree(tree));
-      } else if (eq(FMT_DIGEST, format)) {
+      } else if (Objects.equals(FMT_DIGEST, format)) {
         return ok(mt, new JaxbIncidentFullTree(svc, request.getLocale(), tree));
-      } else if (eq(FMT_FULL, format)) {
+      } else if (Objects.equals(FMT_FULL, format)) {
         return ok(mt, new JaxbIncidentFullTree(svc, request.getLocale(), tree));
       } else {
         return unknownFormat();

--- a/modules/workspace-impl/src/main/java/org/opencastproject/workspace/impl/WorkspaceImpl.java
+++ b/modules/workspace-impl/src/main/java/org/opencastproject/workspace/impl/WorkspaceImpl.java
@@ -23,7 +23,6 @@ package org.opencastproject.workspace.impl;
 
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
-import static org.opencastproject.util.EqualsUtil.ne;
 import static org.opencastproject.util.IoSupport.locked;
 import static org.opencastproject.util.PathSupport.path;
 import static org.opencastproject.util.RequireUtil.notNull;
@@ -84,6 +83,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -903,7 +903,7 @@ public final class WorkspaceImpl implements Workspace {
           .fold(
               chuck(),
               status -> {
-                if (ne(status, expectedStatus)) {
+                if (!Objects.equals(status, expectedStatus)) {
                   final String msg = String.format(errorMsg, uri.toString());
                   logger.warn(msg);
                   chuck(new IOException(msg));


### PR DESCRIPTION
Removes various deprecated methods (mostly one-liners) and replaces them with equivalent java.utils.Objects code (which the deprecated methods were mostly just wrapping anyway).

### How to test this patch

### AI Usage

The changes were made by Claude Sonnet 5.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
