### PR TITLE
Remove deprecated WorkflowUtil.isActive(WorkflowState) and DublinCore…

### DIFF
--- a/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -1552,7 +1552,7 @@ public abstract class AbstractEventEndpoint {
 
     // lock metadata?
     final String wfState = event.getWorkflowState();
-    if (wfState != null && WorkflowUtil.isActive(WorkflowInstance.WorkflowState.valueOf(wfState))) {
+    if (wfState != null && WorkflowUtil.isActive(wfState)) {
       metadataList.setLocked(Locked.WORKFLOW_RUNNING);
     }
 
@@ -1624,7 +1624,7 @@ public abstract class AbstractEventEndpoint {
 
       // check if there's a running workflow
       final String wfState = event.getWorkflowState();
-      if (wfState != null && WorkflowUtil.isActive(WorkflowInstance.WorkflowState.valueOf(wfState))) {
+      if (wfState != null && WorkflowUtil.isActive(wfState)) {
         eventsWithRunningWorkflow.add(eventId);
         continue;
       }
@@ -2842,7 +2842,7 @@ public abstract class AbstractEventEndpoint {
     episodeAccessJson.put("acl", transformAccessControList(activeAcl, getUserDirectoryService()));
     episodeAccessJson.put("privileges", AccessInformationUtil.serializePrivilegesByRole(activeAcl));
     if (StringUtils.isNotBlank(optEvent.get().getWorkflowState())
-            && WorkflowUtil.isActive(WorkflowInstance.WorkflowState.valueOf(optEvent.get().getWorkflowState()))) {
+            && WorkflowUtil.isActive(optEvent.get().getWorkflowState())) {
       episodeAccessJson.put("locked", true);
     }
 

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCores.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCores.java
@@ -92,23 +92,6 @@ public final class DublinCores {
    * <li>The catalog does not have an {@linkplain DublinCoreCatalog#getIdentifier() identifier} and the
    *   {@link DublinCore#PROPERTY_IDENTIFIER identifier} property is not set.
    * </ul>
-   *
-   * @deprecated use {@link #mkOpencastEpisode()} instead
-   */
-  @Nonnull
-  @Deprecated
-  public static Episode mkOpencast() {
-    return mkOpencastEpisode();
-  }
-
-  /**
-   * Create a new Opencast DublinCore metadata catalog for episodes.
-   * <ul>
-   * <li>Set flavor to {@link org.opencastproject.mediapackage.MediaPackageElements#EPISODE}.
-   * <li>Register all necessary namespaces and set the root tag to {@link #OC_DC_CATALOG_ROOT_ELEMENT}.
-   * <li>The catalog does not have an {@linkplain DublinCoreCatalog#getIdentifier() identifier} and the
-   *   {@link DublinCore#PROPERTY_IDENTIFIER identifier} property is not set.
-   * </ul>
    */
   @Nonnull
   public static Episode mkOpencastEpisode() {

--- a/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
+++ b/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
@@ -81,7 +81,6 @@ import org.opencastproject.util.data.Tuple;
 import org.opencastproject.workflow.api.ConfiguredWorkflow;
 import org.opencastproject.workflow.api.WorkflowDatabaseException;
 import org.opencastproject.workflow.api.WorkflowDefinition;
-import org.opencastproject.workflow.api.WorkflowInstance;
 import org.opencastproject.workflow.api.WorkflowService;
 import org.opencastproject.workflow.api.WorkflowUtil;
 import org.opencastproject.workflow.handler.distribution.InternalPublicationChannel;
@@ -1242,7 +1241,7 @@ public class EditorServiceImpl implements EditorService {
     metadataList.add(index.getCommonEventCatalogUIAdapter(), metadataCollection);
 
     final String wfState = event.getWorkflowState();
-    if (wfState != null && WorkflowUtil.isActive(WorkflowInstance.WorkflowState.valueOf(wfState))) {
+    if (wfState != null && WorkflowUtil.isActive(wfState)) {
       metadataList.setLocked(MetadataList.Locked.WORKFLOW_RUNNING);
     }
 

--- a/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
+++ b/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
@@ -463,7 +463,7 @@ public class LtiServiceImpl implements LtiService {
     metadataList.add(this.indexService.getCommonEventCatalogUIAdapter(), metadataCollection);
 
     final String wfState = event.getWorkflowState();
-    if (wfState != null && WorkflowUtil.isActive(WorkflowInstance.WorkflowState.valueOf(wfState))) {
+    if (wfState != null && WorkflowUtil.isActive(wfState)) {
       metadataList.setLocked(MetadataList.Locked.WORKFLOW_RUNNING);
     }
     return new Gson().toJson(MetadataJson.listToJson(metadataList, true, false));

--- a/modules/series-service-impl/src/test/java/org/opencastproject/series/impl/SeriesServiceImplTest.java
+++ b/modules/series-service-impl/src/test/java/org/opencastproject/series/impl/SeriesServiceImplTest.java
@@ -228,8 +228,8 @@ public class SeriesServiceImplTest {
 
   @Test
   public void testDublinCoreCatalogEquality1() {
-    DublinCoreCatalog a = DublinCores.mkOpencast().getCatalog();
-    DublinCoreCatalog b = DublinCores.mkOpencast().getCatalog();
+    DublinCoreCatalog a = DublinCores.mkOpencastEpisode().getCatalog();
+    DublinCoreCatalog b = DublinCores.mkOpencastEpisode().getCatalog();
     a.set(DublinCore.PROPERTY_IDENTIFIER, "123");
     assertFalse(DublinCoreUtil.equals(a, b));
     b.set(DublinCore.PROPERTY_IDENTIFIER, "123");
@@ -250,8 +250,8 @@ public class SeriesServiceImplTest {
 
   @Test
   public void testDublinCoreCatalogEquality2() {
-    DublinCoreCatalog a = DublinCores.mkOpencast().getCatalog();
-    DublinCoreCatalog b = DublinCores.mkOpencast().getCatalog();
+    DublinCoreCatalog a = DublinCores.mkOpencastEpisode().getCatalog();
+    DublinCoreCatalog b = DublinCores.mkOpencastEpisode().getCatalog();
     a.set(DublinCore.PROPERTY_DESCRIPTION, "this is a test lecture");
     a.set(DublinCore.PROPERTY_SPATIAL, "room1");
     a.set(DublinCore.PROPERTY_IDENTIFIER, "123");

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowUtil.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowUtil.java
@@ -34,18 +34,6 @@ public final class WorkflowUtil {
    *          The workflow state to check.
    * @return True if the workflow is currently active, not stopped or failed.
    */
-  @Deprecated
-  public static boolean isActive(WorkflowState workflowState) {
-    return !workflowState.isTerminated();
-  }
-
-  /**
-   * Checks to see whether a given workflow state is active.
-   *
-   * @param workflowState
-   *          The workflow state to check.
-   * @return True if the workflow is currently active, not stopped or failed.
-   */
   public static boolean isActive(String workflowState) {
     if (workflowState == null || workflowState.isBlank()) {
       return false;

--- a/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/SeriesWorkflowOperationHandlerTest.java
+++ b/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/SeriesWorkflowOperationHandlerTest.java
@@ -77,7 +77,7 @@ public class SeriesWorkflowOperationHandlerTest {
     URI uri = getClass().getResource("/dublincore.xml").toURI();
     File file = new File(uri);
 
-    seriesCatalog = DublinCores.mkOpencast().getCatalog();
+    seriesCatalog = DublinCores.mkOpencastEpisode().getCatalog();
     seriesCatalog.set(DublinCore.PROPERTY_TITLE, "Series 1");
 
     SeriesService seriesService = EasyMock.createNiceMock(SeriesService.class);


### PR DESCRIPTION
…s.mkOpencast()

WorkflowUtil.isActive(WorkflowState) had callers wastefully round-tripping a String through WorkflowState.valueOf(...) just to call it; pointed them at the existing isActive(String) overload instead, which left the deprecated overload with no callers. DublinCores.mkOpencast() already just delegated to mkOpencastEpisode(); renamed its two test callers and removed the wrapper.

### How to test this patch


### AI Usage

The changes were made by Claude Sonnet 5.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
