### PR TITLE
Modernize deprecated stringutils usages

### DIFF
--- a/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -164,6 +164,7 @@ import net.fortuna.ical4j.model.property.RRule;
 
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.codehaus.jettison.json.JSONException;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -2515,7 +2516,7 @@ public abstract class AbstractEventEndpoint {
 
     long workflowInstanceId;
     try {
-      workflowId = StringUtils.remove(workflowId, ".json");
+      workflowId = Strings.CS.remove(workflowId, ".json");
       workflowInstanceId = Long.parseLong(workflowId);
     } catch (Exception e) {
       logger.warn("Unable to parse workflow id {}", workflowId);

--- a/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/JobEndpoint.java
+++ b/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/JobEndpoint.java
@@ -54,6 +54,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -198,13 +199,13 @@ public class JobEndpoint {
       List<HostRegistration> servers = serviceRegistry.getHostRegistrations();
       for (Job job : serviceRegistry.getActiveJobs()) {
         // filter workflow jobs
-        if (StringUtils.equals(WorkflowService.JOB_TYPE, job.getJobType())
-                && StringUtils.equals("START_WORKFLOW", job.getOperation())) {
+        if (Strings.CS.equals(WorkflowService.JOB_TYPE, job.getJobType())
+                && Strings.CS.equals("START_WORKFLOW", job.getOperation())) {
           continue;
         }
 
         // filter by hostname
-        if (fHostname != null && !StringUtils.equalsIgnoreCase(job.getProcessingHost(), fHostname)) {
+        if (fHostname != null && !Strings.CI.equals(job.getProcessingHost(), fHostname)) {
           continue;
         }
 
@@ -212,25 +213,25 @@ public class JobEndpoint {
         vNodeName = server.isPresent() ? server.get().getNodeName() : "";
 
         // filter by node name
-        if (fNodeName != null && (server.isPresent()) && !StringUtils.equalsIgnoreCase(vNodeName, fNodeName)) {
+        if (fNodeName != null && (server.isPresent()) && !Strings.CI.equals(vNodeName, fNodeName)) {
           continue;
         }
 
         // filter by status
-        if (fStatus != null && !StringUtils.equalsIgnoreCase(job.getStatus().toString(), fStatus)) {
+        if (fStatus != null && !Strings.CI.equals(job.getStatus().toString(), fStatus)) {
           continue;
         }
 
         // fitler by user free text
         if (fFreeText != null
-            && !StringUtils.equalsIgnoreCase(job.getProcessingHost(), fFreeText)
-            && !StringUtils.equalsIgnoreCase(vNodeName, fFreeText)
-            && !StringUtils.equalsIgnoreCase(job.getJobType(), fFreeText)
-            && !StringUtils.equalsIgnoreCase(job.getOperation(), fFreeText)
-            && !StringUtils.equalsIgnoreCase(job.getCreator(), fFreeText)
-            && !StringUtils.equalsIgnoreCase(job.getStatus().toString(), fFreeText)
-            && !StringUtils.equalsIgnoreCase(Long.toString(job.getId()), fFreeText)
-            && (job.getRootJobId() != null && !StringUtils.equalsIgnoreCase(Long.toString(job.getRootJobId()),
+            && !Strings.CI.equals(job.getProcessingHost(), fFreeText)
+            && !Strings.CI.equals(vNodeName, fFreeText)
+            && !Strings.CI.equals(job.getJobType(), fFreeText)
+            && !Strings.CI.equals(job.getOperation(), fFreeText)
+            && !Strings.CI.equals(job.getCreator(), fFreeText)
+            && !Strings.CI.equals(job.getStatus().toString(), fFreeText)
+            && !Strings.CI.equals(Long.toString(job.getId()), fFreeText)
+            && (job.getRootJobId() != null && !Strings.CI.equals(Long.toString(job.getRootJobId()),
             fFreeText))) {
           continue;
         }

--- a/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/ServerEndpoint.java
+++ b/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/ServerEndpoint.java
@@ -39,6 +39,7 @@ import org.opencastproject.util.requests.SortCriterion.Order;
 import com.google.gson.Gson;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -223,7 +224,7 @@ public class ServerEndpoint {
         continue;
       }
 
-      if (!StringUtils.equalsIgnoreCase(filters.getOrDefault(KEY_NODE_NAME, server.nodeName), server.nodeName)) {
+      if (!Strings.CI.equals(filters.getOrDefault(KEY_NODE_NAME, server.nodeName), server.nodeName)) {
         continue;
       }
 
@@ -241,7 +242,7 @@ public class ServerEndpoint {
       }
 
       final String text = filters.getOrDefault(KEY_TEXT_FILTER, "");
-      if (Stream.of(server.hostname, server.nodeName).noneMatch(v -> StringUtils.containsIgnoreCase(v, text))) {
+      if (Stream.of(server.hostname, server.nodeName).noneMatch(v -> Strings.CI.contains(v, text))) {
         continue;
       }
 

--- a/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/ServicesEndpoint.java
+++ b/modules/admin-service/src/main/java/org/opencastproject/adminui/endpoint/ServicesEndpoint.java
@@ -43,6 +43,7 @@ import org.opencastproject.util.requests.SortCriterion.Order;
 import com.google.gson.JsonObject;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.json.simple.JSONAware;
 import org.json.simple.JSONObject;
 import org.osgi.service.component.annotations.Activate;
@@ -152,19 +153,19 @@ public class ServicesEndpoint {
     List<Service> services = new ArrayList<Service>();
     for (ServiceStatistics stats : serviceRegistry.getServiceStatistics()) {
       Service service = new Service(stats, findServerByHost(stats.getServiceRegistration().getHost(), servers));
-      if (fName != null && !StringUtils.equalsIgnoreCase(service.getName(), fName)) {
+      if (fName != null && !Strings.CI.equals(service.getName(), fName)) {
         continue;
       }
 
-      if (fHostname != null && !StringUtils.equalsIgnoreCase(service.getHost(), fHostname)) {
+      if (fHostname != null && !Strings.CI.equals(service.getHost(), fHostname)) {
         continue;
       }
 
-      if (fNodeName != null && !StringUtils.equalsIgnoreCase(service.getNodeName(), fNodeName)) {
+      if (fNodeName != null && !Strings.CI.equals(service.getNodeName(), fNodeName)) {
         continue;
       }
 
-      if (fStatus != null && !StringUtils.equalsIgnoreCase(service.getStatus().toString(), fStatus)) {
+      if (fStatus != null && !Strings.CI.equals(service.getStatus().toString(), fStatus)) {
         continue;
       }
 
@@ -182,10 +183,10 @@ public class ServicesEndpoint {
         }
       }
 
-      if (fFreeText != null && !StringUtils.containsIgnoreCase(service.getName(), fFreeText)
-          && !StringUtils.containsIgnoreCase(service.getHost(), fFreeText)
-          && !StringUtils.containsIgnoreCase(service.getNodeName(), fFreeText)
-          && !StringUtils.containsIgnoreCase(service.getStatus().toString(), fFreeText)) {
+      if (fFreeText != null && !Strings.CI.contains(service.getName(), fFreeText)
+          && !Strings.CI.contains(service.getHost(), fFreeText)
+          && !Strings.CI.contains(service.getNodeName(), fFreeText)
+          && !Strings.CI.contains(service.getStatus().toString(), fFreeText)) {
         continue;
       }
 
@@ -407,23 +408,23 @@ public class ServicesEndpoint {
 
     /** Constructor. */
     ServiceStatisticsComparator(String sortBy, boolean ascending) {
-      if (StringUtils.equalsIgnoreCase(Service.COMPLETED_NAME, sortBy)) {
+      if (Strings.CI.equals(Service.COMPLETED_NAME, sortBy)) {
         this.sortBy = Service.COMPLETED_NAME;
-      } else if (StringUtils.equalsIgnoreCase(Service.HOST_NAME, sortBy)) {
+      } else if (Strings.CI.equals(Service.HOST_NAME, sortBy)) {
         this.sortBy = Service.HOST_NAME;
-      } else if (StringUtils.equalsIgnoreCase(Service.NODE_NAME, sortBy)) {
+      } else if (Strings.CI.equals(Service.NODE_NAME, sortBy)) {
         this.sortBy = Service.NODE_NAME;
-      } else if (StringUtils.equalsIgnoreCase(Service.MEAN_QUEUE_TIME_NAME, sortBy)) {
+      } else if (Strings.CI.equals(Service.MEAN_QUEUE_TIME_NAME, sortBy)) {
         this.sortBy = Service.MEAN_QUEUE_TIME_NAME;
-      } else if (StringUtils.equalsIgnoreCase(Service.MEAN_RUN_TIME_NAME, sortBy)) {
+      } else if (Strings.CI.equals(Service.MEAN_RUN_TIME_NAME, sortBy)) {
         this.sortBy = Service.MEAN_RUN_TIME_NAME;
-      } else if (StringUtils.equalsIgnoreCase(Service.NAME_NAME, sortBy)) {
+      } else if (Strings.CI.equals(Service.NAME_NAME, sortBy)) {
         this.sortBy = Service.NAME_NAME;
-      } else if (StringUtils.equalsIgnoreCase(Service.QUEUED_NAME, sortBy)) {
+      } else if (Strings.CI.equals(Service.QUEUED_NAME, sortBy)) {
         this.sortBy = Service.QUEUED_NAME;
-      } else if (StringUtils.equalsIgnoreCase(Service.RUNNING_NAME, sortBy)) {
+      } else if (Strings.CI.equals(Service.RUNNING_NAME, sortBy)) {
         this.sortBy = Service.RUNNING_NAME;
-      } else if (StringUtils.equalsIgnoreCase(Service.STATUS_NAME, sortBy)) {
+      } else if (Strings.CI.equals(Service.STATUS_NAME, sortBy)) {
         this.sortBy = Service.STATUS_NAME;
       } else {
         throw new IllegalArgumentException(String.format("Can't sort services by %s.", sortBy));

--- a/modules/admin-service/src/main/java/org/opencastproject/adminui/util/TextFilter.java
+++ b/modules/admin-service/src/main/java/org/opencastproject/adminui/util/TextFilter.java
@@ -22,6 +22,7 @@
 package org.opencastproject.adminui.util;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 /**
  * Utility class to simplify the implementation of the filter 'text' in case no search index is available.
@@ -52,7 +53,7 @@ public final class TextFilter {
 
     for (String searchString : StringUtils.split(searchStrings)) {
       for (String word : text) {
-        if (StringUtils.indexOfIgnoreCase(word, searchString) >= 0) {
+        if (Strings.CI.indexOf(word, searchString) >= 0) {
           return true;
         }
       }

--- a/modules/analyze-mediapackage-workflowoperation/src/test/java/org/opencastproject/workflow/handler/analyzemediapackage/AnalyzeMediapackageWorkflowOperationHandlerTest.java
+++ b/modules/analyze-mediapackage-workflowoperation/src/test/java/org/opencastproject/workflow/handler/analyzemediapackage/AnalyzeMediapackageWorkflowOperationHandlerTest.java
@@ -34,7 +34,7 @@ import org.opencastproject.workflow.api.WorkflowOperationException;
 import org.opencastproject.workflow.api.WorkflowOperationInstance;
 import org.opencastproject.workflow.api.WorkflowOperationResult;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -81,19 +81,19 @@ public class AnalyzeMediapackageWorkflowOperationHandlerTest {
     var wfProperties = result.getProperties();
 
     Assert.assertTrue("Workflowproperty 'dublincore_episode_exists' must be set to 'true'.",
-        StringUtils.equals("true", wfProperties.get("dublincore_episode_exists")));
+        Strings.CS.equals("true", wfProperties.get("dublincore_episode_exists")));
     Assert.assertTrue("Workflowproperty 'dublincore_episode_type' must be set to 'Catalog'.",
-        StringUtils.equals("Catalog", wfProperties.get("dublincore_episode_type")));
+        Strings.CS.equals("Catalog", wfProperties.get("dublincore_episode_type")));
 
     Assert.assertTrue("Workflowproperty 'security_episode+xacml_exists' must be set to 'true'.",
-        StringUtils.equals("true", wfProperties.get("security_episode+xacml_exists")));
+        Strings.CS.equals("true", wfProperties.get("security_episode+xacml_exists")));
     Assert.assertTrue("Workflowproperty 'security_episode+xacml_type' must be set to 'Attachment'.",
-        StringUtils.equals("Attachment", wfProperties.get("security_episode+xacml_type")));
+        Strings.CS.equals("Attachment", wfProperties.get("security_episode+xacml_type")));
 
     Assert.assertTrue("Workflowproperty 'presenter_source_exists' must be set to 'true'.",
-        StringUtils.equals("true", wfProperties.get("presenter_source_exists")));
+        Strings.CS.equals("true", wfProperties.get("presenter_source_exists")));
     Assert.assertTrue("Workflowproperty 'presenter_source_type' must be set to 'Track'.",
-        StringUtils.equals("Track", wfProperties.get("presenter_source_type")));
+        Strings.CS.equals("Track", wfProperties.get("presenter_source_type")));
 
     Assert.assertFalse("Workflowproperty 'foo_bar_exists' must not exists.",
         wfProperties.containsKey("foo_bar_exists"));
@@ -118,9 +118,9 @@ public class AnalyzeMediapackageWorkflowOperationHandlerTest {
     var wfProperties = result.getProperties();
 
     Assert.assertTrue("Workflowproperty 'presenter_source_exists' must be set to 'true'.",
-        StringUtils.equals("true", wfProperties.get("presenter_source_exists")));
+        Strings.CS.equals("true", wfProperties.get("presenter_source_exists")));
     Assert.assertTrue("Workflowproperty 'presenter_source_type' must be set to 'Track'.",
-        StringUtils.equals("Track", wfProperties.get("presenter_source_type")));
+        Strings.CS.equals("Track", wfProperties.get("presenter_source_type")));
 
     Assert.assertFalse("Workflowproperty 'dublincore_episode_exists' must not exists.",
         wfProperties.containsKey("dublincore_episode_exists"));

--- a/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/endpoint/CaptureAgentStateRestService.java
+++ b/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/endpoint/CaptureAgentStateRestService.java
@@ -48,6 +48,7 @@ import com.google.gson.JsonSyntaxException;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -384,7 +385,7 @@ public class CaptureAgentStateRestService {
 
     Properties caps;
 
-    if (StringUtils.startsWith(configuration, "{")) {
+    if (Strings.CS.startsWith(configuration, "{")) {
       // JSON
       Gson gson = new Gson();
       try {

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
@@ -114,6 +114,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -269,7 +270,7 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
   @Activate
   public void activate(ComponentContext cc) {
     super.activate(cc);
-    ffmpegBinary = StringUtils.defaultString(cc.getBundleContext().getProperty(CONFIG_FFMPEG_PATH),
+    ffmpegBinary = Objects.toString(cc.getBundleContext().getProperty(CONFIG_FFMPEG_PATH),
             FFMPEG_BINARY_DEFAULT);
     logger.debug("ffmpeg binary: {}", ffmpegBinary);
     logger.info("Activating composer service");

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
@@ -81,6 +81,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.LocaleUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedService;
@@ -423,7 +424,7 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
     // Handle lang:<LOCALE> tags
     tracks.entrySet().stream()
         .map(e -> new Tuple<>(e.getKey(), Arrays.stream(e.getValue().getTags())
-            .filter(t -> StringUtils.startsWith(t, "lang:"))
+            .filter(t -> Strings.CS.startsWith(t, "lang:"))
             .map(t -> StringUtils.substring(t, 5))
             .filter(StringUtils::isNotBlank)
             .findFirst()))

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/EncoderEngine.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/EncoderEngine.java
@@ -32,6 +32,7 @@ import org.opencastproject.util.IoSupport;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -444,20 +445,20 @@ public class EncoderEngine implements AutoCloseable {
     }
 
     // Others go to trace logging
-    if (StringUtils.startsWithAny(message.toLowerCase(),
+    if (Strings.CS.startsWithAny(message.toLowerCase(),
           "ffmpeg version", "configuration", "lib", "size=", "frame=", "built with")) {
       logger.trace(message);
 
     // Handle output files
-    } else if (StringUtils.startsWith(message, "Output #")) {
+    } else if (Strings.CS.startsWith(message, "Output #")) {
       logger.debug(message);
       Matcher matcher = outputPattern.matcher(message);
       if (matcher.find()) {
         String type = matcher.group(1);
         String outputPath = matcher.group(2);
-        if (!StringUtils.equals("NUL", outputPath) && !StringUtils.equals("/dev/null", outputPath)
-                && !StringUtils.equals("/dev/null", outputPath)
-                && !StringUtils.startsWith("pipe:", outputPath)) {
+        if (!Strings.CS.equals("NUL", outputPath) && !Strings.CS.equals("/dev/null", outputPath)
+                && !Strings.CS.equals("/dev/null", outputPath)
+                && !Strings.CS.startsWith("pipe:", outputPath)) {
           File outputFile = new File(outputPath);
           if (!type.startsWith("hls")) {
             logger.info("Identified output file {}", outputFile);
@@ -465,13 +466,13 @@ public class EncoderEngine implements AutoCloseable {
           }
         }
       }
-    } else if (StringUtils.startsWith(message, "[hls @ ")) {
+    } else if (Strings.CS.startsWith(message, "[hls @ ")) {
       logger.debug(message);
       Matcher matcher = outputPatternHLS.matcher(message);
       if (matcher.find()) {
         final String outputPath = Objects.toString(matcher.group(1), matcher.group(2));
-        if (!StringUtils.equals("NUL", outputPath) && !StringUtils.equals("/dev/null", outputPath)
-                && !StringUtils.startsWith("pipe:", outputPath)) {
+        if (!Strings.CS.equals("NUL", outputPath) && !Strings.CS.equals("/dev/null", outputPath)
+                && !Strings.CS.startsWith("pipe:", outputPath)) {
           File outputFile = new File(outputPath);
           // HLS generates the filenames based on a template with %v and %d replaced
           // HLS writes into the same manifest file to add each segment
@@ -483,7 +484,7 @@ public class EncoderEngine implements AutoCloseable {
       }
 
     // Some to debug
-    } else if (StringUtils.startsWithAny(message.toLowerCase(),
+    } else if (Strings.CS.startsWithAny(message.toLowerCase(),
         "artist", "compatible_brands", "copyright", "creation_time", "description", "composer", "date", "duration",
         "encoder", "handler_name", "input #", "last message repeated", "major_brand", "metadata", "minor_version",
         "output #", "program", "side data:", "stream #", "stream mapping", "title", "video:", "[libx264 @ ",

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ConcatWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ConcatWorkflowOperationHandler.java
@@ -51,6 +51,7 @@ import org.opencastproject.workspace.api.Workspace;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -216,7 +217,7 @@ public class ConcatWorkflowOperationHandler extends AbstractWorkflowOperationHan
     float fps = -1.0f;
     // Ignore fps if same Codec - no scaling
     if (!sameCodec && StringUtils.isNotEmpty(outputFrameRate)) {
-      if (StringUtils.startsWith(outputFrameRate, OUTPUT_PART_PREFIX)) {
+      if (Strings.CS.startsWith(outputFrameRate, OUTPUT_PART_PREFIX)) {
         if (!NumberUtils.isCreatable(outputFrameRate.substring(OUTPUT_PART_PREFIX.length()))
                 || !trackSelectors.keySet().contains(Integer.parseInt(
                         outputFrameRate.substring(OUTPUT_PART_PREFIX.length())))) {
@@ -278,7 +279,7 @@ public class ConcatWorkflowOperationHandler extends AbstractWorkflowOperationHan
           logger.info("No video stream available in the track with flavor {}! {}", currentFlavor, t);
           return createResult(mediaPackage, Action.SKIP);
         }
-        if (StringUtils.startsWith(outputResolution, OUTPUT_PART_PREFIX)
+        if (Strings.CS.startsWith(outputResolution, OUTPUT_PART_PREFIX)
             && NumberUtils.isCreatable(outputResolution.substring(OUTPUT_PART_PREFIX.length()))
             && trackSelector.getKey() == Integer.parseInt(outputResolution.substring(OUTPUT_PART_PREFIX.length()))) {
           outputDimension = new Dimension(videoStreams[0].getFrameWidth(), videoStreams[0].getFrameHeight());
@@ -287,7 +288,7 @@ public class ConcatWorkflowOperationHandler extends AbstractWorkflowOperationHan
             return createResult(mediaPackage, Action.SKIP);
           }
         }
-        if (fps <= 0 && StringUtils.startsWith(outputFrameRate, OUTPUT_PART_PREFIX)
+        if (fps <= 0 && Strings.CS.startsWith(outputFrameRate, OUTPUT_PART_PREFIX)
                 && NumberUtils.isCreatable(outputFrameRate.substring(OUTPUT_PART_PREFIX.length()))
                 && trackSelector.getKey() == Integer.parseInt(outputFrameRate.substring(OUTPUT_PART_PREFIX.length()))) {
           fps = videoStreams[0].getFrameRate();

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageConvertWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageConvertWorkflowOperationHandler.java
@@ -45,6 +45,7 @@ import org.opencastproject.workspace.api.Workspace;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
@@ -191,11 +192,11 @@ public class ImageConvertWorkflowOperationHandler extends AbstractWorkflowOperat
           // set flavor on target element
           if (targetFlavor != null) {
             targetElement.setFlavor(targetFlavor);
-            if (StringUtils.equalsAny("*", targetFlavor.getType())) {
+            if (Strings.CS.equalsAny("*", targetFlavor.getType())) {
               targetElement.setFlavor(MediaPackageElementFlavor.flavor(
                       sourceElement.getFlavor().getType(), targetElement.getFlavor().getSubtype()));
             }
-            if (StringUtils.equalsAny("*", targetFlavor.getSubtype())) {
+            if (Strings.CS.equalsAny("*", targetFlavor.getSubtype())) {
               targetElement.setFlavor(MediaPackageElementFlavor.flavor(
                       targetElement.getFlavor().getType(), sourceElement.getFlavor().getSubtype()));
             }

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/MuxWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/MuxWorkflowOperationHandler.java
@@ -46,6 +46,7 @@ import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
 import org.opencastproject.workspace.api.Workspace;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
@@ -163,7 +164,7 @@ public class MuxWorkflowOperationHandler extends AbstractWorkflowOperationHandle
     final String sourceTagPrefix = "source-tag-";
     final String sourceTagsPrefix = "source-tags-";
     for (String flavorConfKey : operation.getConfigurationKeys().stream().filter(
-        confKey -> StringUtils.startsWith(confKey, sourceFlavorPrefix) || StringUtils.startsWith(confKey,
+        confKey -> Strings.CS.startsWith(confKey, sourceFlavorPrefix) || Strings.CS.startsWith(confKey,
             sourceFlavorsPrefix)).collect(Collectors.toSet())) {
       elementSelector = new TrackSelector();
       for (String srcFlavor : StringUtils.split(operation.getConfiguration(flavorConfKey), ",")) {
@@ -171,8 +172,8 @@ public class MuxWorkflowOperationHandler extends AbstractWorkflowOperationHandle
       }
       String srcType = StringUtils.split(flavorConfKey, "-", 3)[2];
       for (String srcTag : operation.getConfigurationKeys().stream().filter(
-          confKey -> StringUtils.equals(confKey, sourceTagPrefix + srcType)
-              || StringUtils.equals(confKey, sourceTagsPrefix + srcType)).collect(Collectors.toSet())) {
+          confKey -> Strings.CS.equals(confKey, sourceTagPrefix + srcType)
+              || Strings.CS.equals(confKey, sourceTagsPrefix + srcType)).collect(Collectors.toSet())) {
         asList(StringUtils.trimToNull(srcTag)).stream().filter(Objects::nonNull).forEach(elementSelector::addTag);
       }
       srcTracks = elementSelector.select(mediaPackage, false);
@@ -186,7 +187,7 @@ public class MuxWorkflowOperationHandler extends AbstractWorkflowOperationHandle
     }
     // Handle tags-only inputs
     for (String tagConfKey : operation.getConfigurationKeys().stream().filter(
-        confKey -> StringUtils.startsWith(confKey, sourceTagPrefix) || StringUtils.startsWith(confKey,
+        confKey -> Strings.CS.startsWith(confKey, sourceTagPrefix) || Strings.CS.startsWith(confKey,
             sourceTagsPrefix)).collect(Collectors.toSet())) {
       String srcType = StringUtils.split(tagConfKey, "-", 3)[2];
       if (inputTracks.containsKey(srcType)) {

--- a/modules/distribution-service-aws-s3/src/main/java/org/opencastproject/distribution/aws/s3/AwsS3DistributionServiceImpl.java
+++ b/modules/distribution-service-aws-s3/src/main/java/org/opencastproject/distribution/aws/s3/AwsS3DistributionServiceImpl.java
@@ -74,6 +74,7 @@ import com.google.gson.reflect.TypeToken;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpHead;
@@ -296,7 +297,7 @@ public class AwsS3DistributionServiceImpl extends AbstractDistributionService
 
       // AWS presigned URL
       String presignedUrlConfigValue = OsgiUtil.getComponentContextProperty(cc, AWS_S3_PRESIGNED_URL_CONFIG, "false");
-      presignedUrl = StringUtils.equalsIgnoreCase("true", presignedUrlConfigValue);
+      presignedUrl = Strings.CI.equals("true", presignedUrlConfigValue);
       logger.info("AWS use presigned URL: {}", presignedUrl);
 
       // AWS presigned URL expiration time in millis

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java
@@ -88,6 +88,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -247,11 +248,11 @@ public class PublishEngageWorkflowOperationHandler extends AbstractWorkflowOpera
     String streamingSourceFlavors = StringUtils.trimToEmpty(op.getConfiguration(STREAMING_SOURCE_FLAVORS));
     String streamingTargetSubflavor = StringUtils.trimToNull(op.getConfiguration(STREAMING_TARGET_SUBFLAVOR));
     String republishStrategy = StringUtils.trimToEmpty(
-            StringUtils.defaultString(op.getConfiguration(STRATEGY), PUBLISH_STRATEGY_DEFAULT));
+            Objects.toString(op.getConfiguration(STRATEGY), PUBLISH_STRATEGY_DEFAULT));
     String mergeForceFlavorsStr = StringUtils.trimToEmpty(
-            StringUtils.defaultString(op.getConfiguration(MERGE_FORCE_FLAVORS), MERGE_FORCE_FLAVORS_DEFAULT));
+            Objects.toString(op.getConfiguration(MERGE_FORCE_FLAVORS), MERGE_FORCE_FLAVORS_DEFAULT));
     String addForceFlavorsStr = StringUtils.trimToEmpty(
-            StringUtils.defaultString(op.getConfiguration(ADD_FORCE_FLAVORS), ADD_FORCE_FLAVORS_DEFAULT));
+            Objects.toString(op.getConfiguration(ADD_FORCE_FLAVORS), ADD_FORCE_FLAVORS_DEFAULT));
 
 
     boolean checkAvailability = Optional.ofNullable(op.getConfiguration(CHECK_AVAILABILITY))

--- a/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
+++ b/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
@@ -317,7 +317,7 @@ public class EditorServiceImpl implements EditorService {
 
     // SMIL catalog flavor
     smilCatalogFlavor = MediaPackageElementFlavor.parseFlavor(
-            StringUtils.defaultString((String) properties.get(OPT_SMIL_CATALOG_FLAVOR), DEFAULT_SMIL_CATALOG_FLAVOR));
+            Objects.toString(properties.get(OPT_SMIL_CATALOG_FLAVOR), DEFAULT_SMIL_CATALOG_FLAVOR));
     logger.debug("Smil catalog flavor configuration set to '{}'", smilCatalogFlavor);
 
     // SMIL catalog tags
@@ -330,7 +330,7 @@ public class EditorServiceImpl implements EditorService {
 
     // SMIL silence flavor
     smilSilenceFlavor = MediaPackageElementFlavor.parseFlavor(
-            StringUtils.defaultString((String) properties.get(OPT_SMIL_SILENCE_FLAVOR), DEFAULT_SMIL_SILENCE_FLAVOR));
+            Objects.toString(properties.get(OPT_SMIL_SILENCE_FLAVOR), DEFAULT_SMIL_SILENCE_FLAVOR));
     logger.debug("Smil silence flavor configuration set to '{}'", smilSilenceFlavor);
 
     // Preview Video subtype
@@ -340,12 +340,12 @@ public class EditorServiceImpl implements EditorService {
 
     // Flavor for captions
     captionsFlavor = MediaPackageElementFlavor.parseFlavor(
-            StringUtils.defaultString((String) properties.get(OPT_CAPTIONS_FLAVOR), DEFAULT_CAPTIONS_FLAVOR));
+            Objects.toString(properties.get(OPT_CAPTIONS_FLAVOR), DEFAULT_CAPTIONS_FLAVOR));
     logger.debug("Caption flavor set to '{}'", captionsFlavor);
 
     // Flavor for chapters
     chapterFlavor = MediaPackageElementFlavor.parseFlavor(
-        StringUtils.defaultString((String) properties.get(OPT_CHAPTER_FLAVOR), DEFAULT_CHAPTER_FLAVOR));
+        Objects.toString(properties.get(OPT_CHAPTER_FLAVOR), DEFAULT_CHAPTER_FLAVOR));
     logger.debug("Chapter flavor set to '{}'", chapterFlavor);
 
     thumbnailSubType =  Objects.toString(properties.get(OPT_THUMBNAILSUBTYPE), DEFAULT_THUMBNAIL_SUBTYPE);

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -123,6 +123,7 @@ import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.commons.fileupload.util.Streams;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.json.simple.JSONArray;
@@ -2557,7 +2558,7 @@ public class EventsEndpoint implements ManagedService {
               tags = List.of(StringUtils.split(tagsString, ','));
               // find lang tag if exists
               for (String tag : tags) {
-                if (StringUtils.startsWith(StringUtils.trimToEmpty(tag), "lang:")) {
+                if (Strings.CS.startsWith(StringUtils.trimToEmpty(tag), "lang:")) {
                   // lang tag is set
                   langTag = StringUtils.trimToEmpty(tag);
                   break;

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -400,12 +400,12 @@ public class EventsEndpoint implements ManagedService {
 
     // Read preview subtype configuration
     // Default to DEFAULT_PREVIEW_SUBTYPE
-    previewSubtype = StringUtils.defaultString((String) properties.get(PREVIEW_SUBTYPE), DEFAULT_PREVIEW_SUBTYPE);
+    previewSubtype = Objects.toString(properties.get(PREVIEW_SUBTYPE), DEFAULT_PREVIEW_SUBTYPE);
     logger.debug("Preview subtype is '{}'", previewSubtype);
 
     configuredMetadataFields = DublinCoreMetadataUtil.getDublinCoreProperties(properties);
 
-    retractWorkflowId = StringUtils.defaultString((String) properties.get(RETRACT_WORKFLOW), DEFAULT_RETRACT_WORKFLOW);
+    retractWorkflowId = Objects.toString(properties.get(RETRACT_WORKFLOW), DEFAULT_RETRACT_WORKFLOW);
     logger.debug("Retract Workflow is '{}'", retractWorkflowId);
   }
 

--- a/modules/graphql/src/main/java/org/opencastproject/graphql/datafetcher/user/UserOffsetDataFetcher.java
+++ b/modules/graphql/src/main/java/org/opencastproject/graphql/datafetcher/user/UserOffsetDataFetcher.java
@@ -29,6 +29,7 @@ import org.opencastproject.security.api.UserDirectoryService;
 import org.opencastproject.util.SmartIterator;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -73,7 +74,7 @@ public class UserOffsetDataFetcher extends ParameterDataFetcher<GqlUserList> {
   public static boolean match(String searchStrings, String... text) {
     for (String searchString : StringUtils.split(searchStrings)) {
       for (String word : text) {
-        if (StringUtils.indexOfIgnoreCase(word, searchString) >= 0) {
+        if (Strings.CI.indexOf(word, searchString) >= 0) {
           return true;
         }
       }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -131,6 +131,7 @@ import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.commons.fileupload.util.Streams;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.codehaus.jettison.json.JSONException;
 import org.joda.time.DateTimeZone;
 import org.json.simple.JSONArray;
@@ -1150,7 +1151,7 @@ public class IndexServiceImpl implements IndexService {
           if (tags != null) {
             tagsArray = tags.split(",");
             for (String tag : tagsArray) {
-              if (StringUtils.startsWith(StringUtils.trimToEmpty(tag), "lang:")) {
+              if (Strings.CS.startsWith(StringUtils.trimToEmpty(tag), "lang:")) {
                 langTag = StringUtils.trimToEmpty(tag);
                 break;
               }
@@ -1683,7 +1684,7 @@ public class IndexServiceImpl implements IndexService {
     }
 
     // update series catalogs
-    if (!StringUtils.equals(oldSeriesId, mp.getSeries())) {
+    if (!Strings.CS.equals(oldSeriesId, mp.getSeries())) {
       List<String> seriesDcTags = new ArrayList<>();
       List<String> seriesAclTags = new ArrayList<>();
       Map<String, List<String>> seriesExtDcTags = new HashMap<>();

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/CustomPasswordEncoder.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/CustomPasswordEncoder.java
@@ -21,7 +21,7 @@
 
 package org.opencastproject.kernel.security;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -66,7 +66,7 @@ public class CustomPasswordEncoder implements PasswordEncoder {
     // Test BCrypt encoded hash
     logger.debug("Verifying bcrypt hash {}", encodedPassword);
     try {
-      return StringUtils.startsWith(encodedPassword, "$") && encoder.matches(rawPassword, encodedPassword);
+      return Strings.CS.startsWith(encodedPassword, "$") && encoder.matches(rawPassword, encodedPassword);
     } catch (IllegalArgumentException e) {
       logger.debug("bcrypt hash verification failed", e);
     }

--- a/modules/list-providers-common/src/main/java/org/opencastproject/list/common/provider/BooleanListProvider.java
+++ b/modules/list-providers-common/src/main/java/org/opencastproject/list/common/provider/BooleanListProvider.java
@@ -25,6 +25,7 @@ import org.opencastproject.list.api.ResourceListProvider;
 import org.opencastproject.list.api.ResourceListQuery;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.osgi.service.component.annotations.Component;
 
 import java.util.HashMap;
@@ -61,12 +62,12 @@ public class BooleanListProvider implements ResourceListProvider {
 
     String listNameTrimmed = StringUtils.trimToEmpty(listName);
 
-    if (StringUtils.equalsIgnoreCase(YES, listNameTrimmed)
-            || StringUtils.equalsIgnoreCase(YES_NO, listNameTrimmed)) {
+    if (Strings.CI.equals(YES, listNameTrimmed)
+            || Strings.CI.equals(YES_NO, listNameTrimmed)) {
       result.put("true", YES);
     }
-    if (StringUtils.equalsIgnoreCase(NO, listNameTrimmed)
-            || StringUtils.equalsIgnoreCase(YES_NO, listNameTrimmed)) {
+    if (Strings.CI.equals(NO, listNameTrimmed)
+            || Strings.CI.equals(YES_NO, listNameTrimmed)) {
       result.put("false", NO);
     }
 
@@ -81,11 +82,11 @@ public class BooleanListProvider implements ResourceListProvider {
    */
   public static <Boolean> Optional<Boolean> parseValue(String filterValue) {
     String value = StringUtils.trimToEmpty(filterValue);
-    if (StringUtils.equalsIgnoreCase(YES, value)
-            || StringUtils.equalsIgnoreCase("true", value)) {
+    if (Strings.CI.equals(YES, value)
+            || Strings.CI.equals("true", value)) {
       return (Optional<Boolean>) Optional.ofNullable(true);
-    } else if (StringUtils.equalsIgnoreCase(NO, value)
-            || StringUtils.equalsIgnoreCase("false", value)) {
+    } else if (Strings.CI.equals(NO, value)
+            || Strings.CI.equals("false", value)) {
       return (Optional<Boolean>) Optional.ofNullable(false);
     } else {
       return Optional.<Boolean> empty();

--- a/modules/list-providers-common/src/main/java/org/opencastproject/list/common/provider/JobsListProvider.java
+++ b/modules/list-providers-common/src/main/java/org/opencastproject/list/common/provider/JobsListProvider.java
@@ -29,6 +29,7 @@ import org.opencastproject.workflow.api.WorkflowDefinition;
 import org.opencastproject.workflow.api.WorkflowService;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -79,12 +80,12 @@ public class JobsListProvider implements ResourceListProvider {
 
     String listNameTrimmed = StringUtils.trimToEmpty(listName);
     Map<String, String> jobList = new HashMap<String, String>();
-    if (StringUtils.equalsIgnoreCase(LIST_STATUS, listName)) {
+    if (Strings.CI.equals(LIST_STATUS, listName)) {
       jobList.put(Job.Status.PAUSED.toString(), JOB_STATUS_FILTER_PREFIX + Job.Status.PAUSED.toString());
       jobList.put(Job.Status.QUEUED.toString(), JOB_STATUS_FILTER_PREFIX + Job.Status.QUEUED.toString());
       jobList.put(Job.Status.RUNNING.toString(), JOB_STATUS_FILTER_PREFIX + Job.Status.RUNNING.toString());
       jobList.put(Job.Status.WAITING.toString(), JOB_STATUS_FILTER_PREFIX + Job.Status.WAITING.toString());
-    } else if (StringUtils.equalsIgnoreCase(LIST_WORKFLOW, listNameTrimmed)) {
+    } else if (Strings.CI.equals(LIST_WORKFLOW, listNameTrimmed)) {
       try {
         for (WorkflowDefinition workflowDef : workflowService.listAvailableWorkflowDefinitions()) {
           if (StringUtils.isNotBlank(workflowDef.getTitle())
@@ -115,7 +116,7 @@ public class JobsListProvider implements ResourceListProvider {
 
   @Override
   public boolean isTranslatable(String listName) {
-    return StringUtils.equalsIgnoreCase(LIST_STATUS, listName);
+    return Strings.CI.equals(LIST_STATUS, listName);
   }
 
   @Override

--- a/modules/list-providers-common/src/main/java/org/opencastproject/list/common/provider/ServersListProvider.java
+++ b/modules/list-providers-common/src/main/java/org/opencastproject/list/common/provider/ServersListProvider.java
@@ -30,6 +30,7 @@ import org.opencastproject.serviceregistry.api.ServiceRegistry;
 import org.opencastproject.serviceregistry.api.ServiceRegistryException;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -96,7 +97,7 @@ public class ServersListProvider implements ResourceListProvider {
           throws ListProviderException {
     Map<String, String> list = new HashMap<String, String>();
 
-    if (StringUtils.equalsIgnoreCase(LIST_STATUS, listName)) {
+    if (Strings.CI.equals(LIST_STATUS, listName)) {
       list.put(SERVER_STATUS_ONLINE, SERVER_STATUS_LABEL_ONLINE);
       list.put(SERVER_STATUS_OFFLINE, SERVER_STATUS_LABEL_OFFLINE);
       list.put(SERVER_STATUS_MAINTENANCE, SERVER_STATUS_LABEL_MAINTENANCE);
@@ -127,11 +128,11 @@ public class ServersListProvider implements ResourceListProvider {
       String vHostname = server.getBaseUrl();
       String vNodeName = server.getNodeName();
 
-      if (fHostname.isPresent() && !StringUtils.equalsIgnoreCase(StringUtils.trimToEmpty(fHostname.get()), vHostname)) {
+      if (fHostname.isPresent() && !Strings.CI.equals(StringUtils.trimToEmpty(fHostname.get()), vHostname)) {
         continue;
       }
 
-      if (fNodeName.isPresent() && !StringUtils.equalsIgnoreCase(StringUtils.trimToEmpty(fNodeName.get()), vNodeName)) {
+      if (fNodeName.isPresent() && !Strings.CI.equals(StringUtils.trimToEmpty(fNodeName.get()), vNodeName)) {
         continue;
       }
 
@@ -187,7 +188,7 @@ public class ServersListProvider implements ResourceListProvider {
 
   @Override
   public boolean isTranslatable(String listName) {
-    return StringUtils.equalsIgnoreCase(LIST_STATUS, listName);
+    return Strings.CI.equals(LIST_STATUS, listName);
   }
 
   @Override

--- a/modules/list-providers-common/src/main/java/org/opencastproject/list/common/provider/ServicesListProvider.java
+++ b/modules/list-providers-common/src/main/java/org/opencastproject/list/common/provider/ServicesListProvider.java
@@ -31,7 +31,7 @@ import org.opencastproject.serviceregistry.api.ServiceRegistryException;
 import org.opencastproject.serviceregistry.api.ServiceState;
 import org.opencastproject.util.SmartIterator;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -108,7 +108,7 @@ public class ServicesListProvider implements ResourceListProvider {
 
     for (ServiceRegistration serviceRegistration : serviceRegistrations) {
       if (servicesQuery.getHostname().isPresent()
-              && !StringUtils.equals(servicesQuery.getHostname().get(), serviceRegistration.getHost())) {
+              && !Strings.CS.equals(servicesQuery.getHostname().get(), serviceRegistration.getHost())) {
         continue;
       }
 

--- a/modules/list-providers-common/src/test/java/provider/JobsListProviderTest.java
+++ b/modules/list-providers-common/src/test/java/provider/JobsListProviderTest.java
@@ -35,7 +35,7 @@ import org.opencastproject.workflow.api.WorkflowDefinition;
 import org.opencastproject.workflow.api.WorkflowDefinitionImpl;
 import org.opencastproject.workflow.api.WorkflowService;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
@@ -86,7 +86,7 @@ public class JobsListProviderTest {
         fail("Can not parse job state");
       }
 
-      assertTrue(StringUtils.startsWith(entry.getValue(), JobsListProvider.JOB_STATUS_FILTER_PREFIX));
+      assertTrue(Strings.CS.startsWith(entry.getValue(), JobsListProvider.JOB_STATUS_FILTER_PREFIX));
     }
   }
 
@@ -102,8 +102,8 @@ public class JobsListProviderTest {
 
       boolean match = false;
       for (WorkflowDefinition wfD : workflowDefinitions) {
-        if (StringUtils.equals(wfD.getId(), entry.getKey())
-                && StringUtils.equals(wfD.getTitle(), entry.getValue())) {
+        if (Strings.CS.equals(wfD.getId(), entry.getKey())
+                && Strings.CS.equals(wfD.getTitle(), entry.getValue())) {
           match = true;
           break;
         }

--- a/modules/mattermost-notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/mattermost/notification/MattermostNotificationWorkflowOperationHandler.java
+++ b/modules/mattermost-notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/mattermost/notification/MattermostNotificationWorkflowOperationHandler.java
@@ -39,7 +39,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.config.RequestConfig;
@@ -173,9 +173,9 @@ public class MattermostNotificationWorkflowOperationHandler extends AbstractWork
 
     // Figure out which request method to use
     HttpEntityEnclosingRequestBase request;
-    if (StringUtils.equalsIgnoreCase(POST, method)) {
+    if (Strings.CI.equals(POST, method)) {
       request = new HttpPost(urlPath);
-    } else if (StringUtils.equalsIgnoreCase(PUT, method)) {
+    } else if (Strings.CI.equals(PUT, method)) {
       request = new HttpPut(urlPath);
     } else {
       throw new WorkflowOperationException("The configuration key '" + OPT_METHOD + "' only supports 'post' and 'put'");

--- a/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/HttpNotificationWorkflowOperationHandler.java
+++ b/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/HttpNotificationWorkflowOperationHandler.java
@@ -36,7 +36,7 @@ import org.opencastproject.workflow.api.WorkflowOperationHandler;
 import org.opencastproject.workflow.api.WorkflowOperationResult;
 import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.config.RequestConfig;
@@ -156,9 +156,9 @@ public class HttpNotificationWorkflowOperationHandler extends AbstractWorkflowOp
 
     // Figure out which request method to use
     HttpEntityEnclosingRequestBase request = null;
-    if (StringUtils.equalsIgnoreCase("post", method)) {
+    if (Strings.CI.equals("post", method)) {
       request = new HttpPost(urlPath);
-    } else if (StringUtils.equalsIgnoreCase("put", method)) {
+    } else if (Strings.CI.equals("put", method)) {
       request = new HttpPut(urlPath);
     } else {
       throw new WorkflowOperationException("The configuration key '" + OPT_METHOD + "' only supports 'post' and 'put'");

--- a/modules/oaipmh-persistence/src/main/java/org/opencastproject/oaipmh/persistence/OaiPmhEntity.java
+++ b/modules/oaipmh-persistence/src/main/java/org/opencastproject/oaipmh/persistence/OaiPmhEntity.java
@@ -23,7 +23,7 @@ package org.opencastproject.oaipmh.persistence;
 import org.opencastproject.mediapackage.Attachment;
 import org.opencastproject.mediapackage.Catalog;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -247,7 +247,7 @@ public class OaiPmhEntity {
     // as we do not expect to many media package elements per media package, we can filter them in java
     List<OaiPmhElementEntity> filteredElements = new ArrayList<>();
     for (OaiPmhElementEntity element : mediaPackageElements) {
-      if (StringUtils.equals(elementType, element.getElementType())) {
+      if (Strings.CS.equals(elementType, element.getElementType())) {
         filteredElements.add(element);
       }
     }

--- a/modules/oaipmh-persistence/src/main/java/org/opencastproject/oaipmh/persistence/OaiPmhSetDefinitionImpl.java
+++ b/modules/oaipmh-persistence/src/main/java/org/opencastproject/oaipmh/persistence/OaiPmhSetDefinitionImpl.java
@@ -21,6 +21,7 @@
 package org.opencastproject.oaipmh.persistence;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -64,9 +65,9 @@ public class OaiPmhSetDefinitionImpl implements OaiPmhSetDefinition {
       throw new IllegalArgumentException(String.format(
           "Set definition '%s' flavor not set for filter identified by '%s'.", setSpec, filterId));
     }
-    if (!StringUtils.equals(OaiPmhSetDefinitionFilter.CRITERION_CONTAINS, criterion)
-        && !StringUtils.equals(OaiPmhSetDefinitionFilter.CRITERION_CONTAINSNOT, criterion)
-        && !StringUtils.equals(OaiPmhSetDefinitionFilter.CRITERION_MATCH, criterion)) {
+    if (!Strings.CS.equals(OaiPmhSetDefinitionFilter.CRITERION_CONTAINS, criterion)
+        && !Strings.CS.equals(OaiPmhSetDefinitionFilter.CRITERION_CONTAINSNOT, criterion)
+        && !Strings.CS.equals(OaiPmhSetDefinitionFilter.CRITERION_MATCH, criterion)) {
       throw new IllegalArgumentException(String.format(
           "Set definition '%s' filter (idenfied by '%s') criterion '%s' should be one of %s",
           setSpec, filterId, criterion, StringUtils.joinWith(", ",

--- a/modules/oaipmh-persistence/src/main/java/org/opencastproject/oaipmh/persistence/impl/AbstractOaiPmhDatabase.java
+++ b/modules/oaipmh-persistence/src/main/java/org/opencastproject/oaipmh/persistence/impl/AbstractOaiPmhDatabase.java
@@ -42,6 +42,7 @@ import org.opencastproject.workspace.api.Workspace;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -302,33 +303,33 @@ public abstract class AbstractOaiPmhDatabase implements OaiPmhDatabase {
   private boolean matchSetDefFilter(OaiPmhSetDefinitionFilter filter, List<SearchResultElementItem> elements) {
     // At least one filter criterion should match
     for (String criterion : filter.getCriteria().keySet()) {
-      if (StringUtils.equals(OaiPmhSetDefinitionFilter.CRITERION_CONTAINS, criterion)) {
+      if (Strings.CS.equals(OaiPmhSetDefinitionFilter.CRITERION_CONTAINS, criterion)) {
         for (SearchResultElementItem element : elements) {
-          if (!StringUtils.equals(filter.getFlavor(), element.getFlavor())) {
+          if (!Strings.CS.equals(filter.getFlavor(), element.getFlavor())) {
             continue;
           }
           for (String criterionValue : filter.getCriteria().get(criterion)) {
-            if (StringUtils.contains(element.getXml(), criterionValue)) {
+            if (Strings.CS.contains(element.getXml(), criterionValue)) {
               return true;
             }
           }
         }
-      } else if (StringUtils.equals(OaiPmhSetDefinitionFilter.CRITERION_CONTAINSNOT, criterion)) {
+      } else if (Strings.CS.equals(OaiPmhSetDefinitionFilter.CRITERION_CONTAINSNOT, criterion)) {
         for (SearchResultElementItem element : elements) {
-          if (!StringUtils.equals(filter.getFlavor(), element.getFlavor())) {
+          if (!Strings.CS.equals(filter.getFlavor(), element.getFlavor())) {
             continue;
           }
           for (String criterionValue : filter.getCriteria().get(criterion)) {
-            if (!StringUtils.contains(element.getXml(), criterionValue)) {
+            if (!Strings.CS.contains(element.getXml(), criterionValue)) {
               return true;
             }
           }
         }
-      } else if (StringUtils.equals(OaiPmhSetDefinitionFilter.CRITERION_MATCH, criterion)) {
+      } else if (Strings.CS.equals(OaiPmhSetDefinitionFilter.CRITERION_MATCH, criterion)) {
         for (String criterionValue : filter.getCriteria().get(criterion)) {
           Pattern matchPattern = null; // wait with initialization until we found an element to test
           for (SearchResultElementItem element : elements) {
-            if (!StringUtils.equals(filter.getFlavor(), element.getFlavor())) {
+            if (!Strings.CS.equals(filter.getFlavor(), element.getFlavor())) {
               continue;
             }
             // initialize regex pattern once and only if we need it (for performance reasons)

--- a/modules/oaipmh/src/main/java/org/opencastproject/oaipmh/server/OaiPmhRepository.java
+++ b/modules/oaipmh/src/main/java/org/opencastproject/oaipmh/server/OaiPmhRepository.java
@@ -43,6 +43,7 @@ import org.opencastproject.oaipmh.util.XmlGen;
 
 import org.apache.commons.collections4.EnumerationUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedService;
 import org.slf4j.Logger;
@@ -265,7 +266,7 @@ public abstract class OaiPmhRepository implements ManagedService {
       var metadataProviders = p.getMetadataPrefix().flatMap(mp -> getMetadataProvider(mp)).stream().toList();
       for (final MetadataProvider metadataProvider : metadataProviders) {
         if (p.getSet().isPresent() && !sets.stream().anyMatch(
-            setDef -> StringUtils.equals(setDef.getSetSpec(), p.getSet().get()))) {
+            setDef -> Strings.CS.equals(setDef.getSetSpec(), p.getSet().get()))) {
           // If there is no set specification, immediately return a no result response
           return createNoRecordsMatchResponse(p);
         }
@@ -580,7 +581,7 @@ public abstract class OaiPmhRepository implements ManagedService {
           if (!resumptionTokenExists) {
             // start a new query
             if (p.getSet().isPresent() && !sets.stream().anyMatch(
-                setDef -> StringUtils.equals(setDef.getSetSpec(), p.getSet().get()))) {
+                setDef -> Strings.CS.equals(setDef.getSetSpec(), p.getSet().get()))) {
               // If there is no set specification, immediately return a no result response
               return createNoRecordsMatchResponse(p);
             }

--- a/modules/oaipmh/src/main/java/org/opencastproject/oaipmh/server/OaiPmhServer.java
+++ b/modules/oaipmh/src/main/java/org/opencastproject/oaipmh/server/OaiPmhServer.java
@@ -32,6 +32,7 @@ import org.opencastproject.util.OsgiUtil;
 import org.opencastproject.util.UrlSupport;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.component.ComponentContext;
@@ -257,7 +258,7 @@ public final class OaiPmhServer extends HttpServlet implements OaiPmhServerInfo 
    *          the base path of the OAI-PMH server, e.g. /oaipmh
    */
   public static Optional<String> repositoryId(HttpServletRequest req, String mountPoint) {
-    String[] parts = StringUtils.removeStart(UrlSupport.removeDoubleSeparator(req.getRequestURI()), mountPoint)
+    String[] parts = Strings.CS.removeStart(UrlSupport.removeDoubleSeparator(req.getRequestURI()), mountPoint)
         .split("/");
 
     return Arrays.stream(parts)

--- a/modules/publication-service-oaipmh/src/main/java/org/opencastproject/publication/oaipmh/OaiPmhPublicationServiceImpl.java
+++ b/modules/publication-service-oaipmh/src/main/java/org/opencastproject/publication/oaipmh/OaiPmhPublicationServiceImpl.java
@@ -61,6 +61,7 @@ import org.opencastproject.util.data.Collections;
 
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.http.client.utils.URIUtils;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -114,7 +115,7 @@ public class OaiPmhPublicationServiceImpl extends AbstractJobProducer implements
 
   @Override
   protected String process(Job job) throws Exception {
-    if (!StringUtils.equalsIgnoreCase(JOB_TYPE, job.getJobType())) {
+    if (!Strings.CI.equals(JOB_TYPE, job.getJobType())) {
       throw new IllegalArgumentException("Can not handle job type " + job.getJobType());
     }
 
@@ -657,7 +658,7 @@ public class OaiPmhPublicationServiceImpl extends AbstractJobProducer implements
 
     String publicationChannel = getPublicationChannelName(repository);
     for (Publication p : mediaPackage.getPublications()) {
-      if (StringUtils.equals(publicationChannel, p.getChannel())) {
+      if (Strings.CS.equals(publicationChannel, p.getChannel())) {
         return p;
       }
     }
@@ -818,7 +819,7 @@ public class OaiPmhPublicationServiceImpl extends AbstractJobProducer implements
     // return the publication
     String publicationChannel = getPublicationChannelName(repository);
     for (Publication p : mediaPackage.getPublications()) {
-      if (StringUtils.equals(publicationChannel, p.getChannel())) {
+      if (Strings.CS.equals(publicationChannel, p.getChannel())) {
         return p;
       }
     }

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
@@ -48,6 +48,7 @@ import com.google.api.services.youtube.model.SearchResult;
 import com.google.api.services.youtube.model.Video;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.osgi.service.cm.ConfigurationException;
@@ -205,8 +206,8 @@ public class YouTubeV3PublicationServiceImpl
           //
           tags = StringUtils.split(YouTubeUtils.get(properties, YouTubeKey.keywords), ',');
           defaultPlaylist = YouTubeUtils.get(properties, YouTubeKey.defaultPlaylist);
-          makeVideosPrivate = StringUtils
-                  .containsIgnoreCase(YouTubeUtils.get(properties, YouTubeKey.makeVideosPrivate), "true");
+          makeVideosPrivate = Strings.CI
+                  .contains(YouTubeUtils.get(properties, YouTubeKey.makeVideosPrivate), "true");
           defaultMaxFieldLength(YouTubeUtils.get(properties, YouTubeKey.maxFieldLength, false));
         } else {
           logger.warn("Client information file does not exist: " + path);

--- a/modules/security-aai/src/main/java/org/opencastproject/security/aai/ConfigurableLoginHandler.java
+++ b/modules/security-aai/src/main/java/org/opencastproject/security/aai/ConfigurableLoginHandler.java
@@ -37,6 +37,7 @@ import org.opencastproject.userdirectory.api.UserReferenceProvider;
 
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.service.cm.ConfigurationException;
@@ -463,7 +464,7 @@ public class ConfigurableLoginHandler implements ShibbolethLoginHandler, RolePro
       String homeOrganization = request.getHeader(headerHomeOrganization);
       roles.add(new JpaRole(roleOrganizationPrefix + homeOrganization + roleOrganizationSuffix, organization));
     }
-    if (StringUtils.equals(id, bootstrapUserId)) {
+    if (Strings.CS.equals(id, bootstrapUserId)) {
       roles.add(new JpaRole(GLOBAL_ADMIN_ROLE, organization));
     }
     if (headerAffiliation != null) {

--- a/modules/transcription-service-microsoft-azure/src/main/java/org/opencastproject/transcription/microsoft/azure/MicrosoftAzureAuthorization.java
+++ b/modules/transcription-service-microsoft-azure/src/main/java/org/opencastproject/transcription/microsoft/azure/MicrosoftAzureAuthorization.java
@@ -25,6 +25,7 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.digest.HmacAlgorithms;
 import org.apache.commons.codec.digest.HmacUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -180,7 +181,7 @@ public class MicrosoftAzureAuthorization {
     //    canonicalizedResource ()
     String canonicalizedResource = Paths.get("/blob", azureStorageAccountName, StringUtils.trimToEmpty(resource))
         .normalize().toString();
-    if (StringUtils.endsWith(canonicalizedResource,"/")) {
+    if (Strings.CS.endsWith(canonicalizedResource,"/")) {
       canonicalizedResource = StringUtils.substring(canonicalizedResource, 0, canonicalizedResource.length() - 1);
     }
     stringBuilder.append(canonicalizedResource + "\n");

--- a/modules/transcription-service-microsoft-azure/src/main/java/org/opencastproject/transcription/microsoft/azure/MicrosoftAzureStorageClient.java
+++ b/modules/transcription-service-microsoft-azure/src/main/java/org/opencastproject/transcription/microsoft/azure/MicrosoftAzureStorageClient.java
@@ -23,6 +23,7 @@ package org.opencastproject.transcription.microsoft.azure;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.http.HttpStatus;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -71,7 +72,7 @@ public class MicrosoftAzureStorageClient {
           throws MicrosoftAzureStorageClientException, IOException, MicrosoftAzureNotAllowedException {
     try {
       Map<String, String> containerProperties = getContainerProperties(azureContainerName);
-      return containerProperties.containsKey("x-ms-blob-public-access") && StringUtils.equalsIgnoreCase("unlocked",
+      return containerProperties.containsKey("x-ms-blob-public-access") && Strings.CI.equals("unlocked",
           containerProperties.getOrDefault("x-ms-lease-status", "INVALID"));
     } catch (MicrosoftAzureNotFoundException ex) {
       return false;

--- a/modules/transcription-service-microsoft-azure/src/main/java/org/opencastproject/transcription/microsoft/azure/model/MicrosoftAzureSpeechTranscription.java
+++ b/modules/transcription-service-microsoft-azure/src/main/java/org/opencastproject/transcription/microsoft/azure/model/MicrosoftAzureSpeechTranscription.java
@@ -22,6 +22,7 @@
 package org.opencastproject.transcription.microsoft.azure.model;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import java.net.URI;
 import java.util.List;
@@ -66,9 +67,9 @@ public class MicrosoftAzureSpeechTranscription {
     }
     URI selfUriPath = URI.create(URI.create(self).getPath());
     String speechServiceEndpointPath = "/speechtotext/v3.1/transcriptions/";
-    if (StringUtils.startsWithIgnoreCase(selfUriPath.getPath(), speechServiceEndpointPath)) {
+    if (Strings.CI.startsWith(selfUriPath.getPath(), speechServiceEndpointPath)) {
       String id = StringUtils.substringAfter(selfUriPath.getPath(), speechServiceEndpointPath);
-      if (!StringUtils.contains(id, "/")) {
+      if (!Strings.CS.contains(id, "/")) {
         return id;
       }
       return StringUtils.substringBefore(id, "/");
@@ -77,14 +78,14 @@ public class MicrosoftAzureSpeechTranscription {
   }
 
   public boolean isFailed() {
-    return StringUtils.equalsIgnoreCase("Failed", status);
+    return Strings.CI.equals("Failed", status);
   }
 
   public boolean isRunning() {
-    return StringUtils.equalsIgnoreCase("Running", status);
+    return Strings.CI.equals("Running", status);
   }
 
   public boolean isSucceeded() {
-    return StringUtils.equalsIgnoreCase("Succeeded", status);
+    return Strings.CI.equals("Succeeded", status);
   }
 }

--- a/modules/transcription-service-microsoft-azure/src/main/java/org/opencastproject/transcription/microsoft/azure/model/MicrosoftAzureSpeechTranscriptionFile.java
+++ b/modules/transcription-service-microsoft-azure/src/main/java/org/opencastproject/transcription/microsoft/azure/model/MicrosoftAzureSpeechTranscriptionFile.java
@@ -21,7 +21,7 @@
 
 package org.opencastproject.transcription.microsoft.azure.model;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import java.util.Map;
 
@@ -63,6 +63,6 @@ public class MicrosoftAzureSpeechTranscriptionFile {
   public MicrosoftAzureSpeechTranscriptionFile() { }
 
   public boolean isTranscriptionFile() {
-    return StringUtils.equalsIgnoreCase("Transcription", kind);
+    return Strings.CI.equals("Transcription", kind);
   }
 }

--- a/modules/transcription-service-microsoft-azure/src/main/java/org/opencastproject/transcription/microsoft/azure/model/MicrosoftAzureSpeechTranscriptionJsonRecognizedPhrases.java
+++ b/modules/transcription-service-microsoft-azure/src/main/java/org/opencastproject/transcription/microsoft/azure/model/MicrosoftAzureSpeechTranscriptionJsonRecognizedPhrases.java
@@ -22,6 +22,7 @@
 package org.opencastproject.transcription.microsoft.azure.model;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -131,7 +132,7 @@ public class MicrosoftAzureSpeechTranscriptionJsonRecognizedPhrases {
         result.add(StringUtils.trimToEmpty(StringUtils.substring(text, start, textLength)));
         break;
       }
-      int end = StringUtils.lastIndexOf(text, " ", start + maxCueLength);
+      int end = Strings.CS.lastIndexOf(text, " ", start + maxCueLength);
       if (start >= end) {
         end = Math.min(textLength, start + maxCueLength);
       }

--- a/modules/transcription-service-microsoft-azure/src/test/java/org/opencastproject/transcription/microsoft/azure/MicrosoftAzureStorageClientTest.java
+++ b/modules/transcription-service-microsoft-azure/src/test/java/org/opencastproject/transcription/microsoft/azure/MicrosoftAzureStorageClientTest.java
@@ -22,6 +22,7 @@
 package org.opencastproject.transcription.microsoft.azure;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -114,7 +115,7 @@ public class MicrosoftAzureStorageClientTest {
     File testFile = new File(testFileUrl.toURI());
     String blobUrl = azureStorageClient.uploadFile(testFile, azureStorageContainerName, null, "test.txt");
     Assert.assertTrue("Azure storage blob URL should end with /" + azureStorageContainerName + "/test.txt",
-        StringUtils.endsWithIgnoreCase(blobUrl, "/" + azureStorageContainerName + "/test.txt"));
+        Strings.CI.endsWith(blobUrl, "/" + azureStorageContainerName + "/test.txt"));
   }
 
   @Test
@@ -128,7 +129,7 @@ public class MicrosoftAzureStorageClientTest {
     File testFile = new File(testFileUrl.toURI());
     String blobUrl = azureStorageClient.uploadFile(testFile, azureStorageContainerName, null, "test.ogg");
     Assert.assertTrue("Azure storage blob URL should end with /" + azureStorageContainerName + "/test.txt",
-        StringUtils.endsWithIgnoreCase(blobUrl, "/" + azureStorageContainerName + "/test.ogg"));
+        Strings.CI.endsWith(blobUrl, "/" + azureStorageContainerName + "/test.ogg"));
   }
 
   @Test

--- a/modules/urlsigning-verifier-service-impl/src/main/java/org/opencastproject/security/urlsigning/verifier/impl/UrlSigningVerifierImpl.java
+++ b/modules/urlsigning-verifier-service-impl/src/main/java/org/opencastproject/security/urlsigning/verifier/impl/UrlSigningVerifierImpl.java
@@ -25,6 +25,7 @@ import org.opencastproject.urlsigning.common.ResourceRequest;
 import org.opencastproject.urlsigning.utils.ResourceRequestUtil;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedService;
 import org.osgi.service.component.annotations.Component;
@@ -81,7 +82,7 @@ public class UrlSigningVerifierImpl implements UrlSigningVerifier, ManagedServic
     Enumeration<String> ids = properties.keys();
     while (ids.hasMoreElements()) {
       String propertyKey = ids.nextElement();
-      String id = StringUtils.removeStart(propertyKey, KEY_PREFIX);
+      String id = Strings.CS.removeStart(propertyKey, KEY_PREFIX);
       if (id != propertyKey) {
         String key = StringUtils.trimToNull(Objects.toString(properties.get(propertyKey), null));
         if (key == null) {

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/CustomRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/CustomRoleProvider.java
@@ -31,6 +31,7 @@ import org.opencastproject.security.api.RoleProvider;
 import org.opencastproject.security.api.SecurityService;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -153,7 +154,7 @@ public class CustomRoleProvider implements RoleProvider {
 
     // Match the custom regular expression first if this is an ACL role query
     if ((target == Role.Target.ACL) && (rolematch != null)) {
-      String exactQuery = StringUtils.removeEnd(query, "%");
+      String exactQuery = Strings.CS.removeEnd(query, "%");
       Matcher m = rolematch.matcher(exactQuery);
       if (m.matches()) {
         return Collections

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
@@ -65,6 +65,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
@@ -448,7 +449,7 @@ public class UserAndRoleDirectoryServiceImpl implements UserDirectoryService, Us
 
     final String name = StringUtils.defaultIfBlank(user1.getName(), user2.getName());
     final String email = StringUtils.defaultIfBlank(user1.getEmail(), user2.getEmail());
-    final String password = StringUtils.defaultString(user1.getPassword(), user2.getPassword());
+    final String password = Objects.toString(user1.getPassword(), user2.getPassword());
     final boolean manageable = user1.isManageable() || user2.isManageable();
 
     final JaxbOrganization organization = JaxbOrganization.fromOrganization(user1.getOrganization());

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/utils/UserDirectoryUtils.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/utils/UserDirectoryUtils.java
@@ -27,7 +27,7 @@ import org.opencastproject.security.api.SecurityConstants;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.User;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import java.util.Set;
 
@@ -57,11 +57,11 @@ public final class UserDirectoryUtils {
     Organization org = user.getOrganization();
 
     for (Role role : roles) {
-      if (StringUtils.equals(SecurityConstants.GLOBAL_ADMIN_ROLE, role.getName())) {
+      if (Strings.CS.equals(SecurityConstants.GLOBAL_ADMIN_ROLE, role.getName())) {
         return user.hasRole(SecurityConstants.GLOBAL_ADMIN_ROLE);
       }
 
-      if (org != null && StringUtils.equals(org.getAdminRole(), role.getName())) {
+      if (org != null && Strings.CS.equals(org.getAdminRole(), role.getName())) {
         return user.hasRole(SecurityConstants.GLOBAL_ADMIN_ROLE)
                 || user.hasRole(org.getAdminRole());
       }

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/AbstractWorkflowOperationHandler.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/AbstractWorkflowOperationHandler.java
@@ -36,6 +36,7 @@ import org.opencastproject.workspace.api.Workspace;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
@@ -583,7 +584,7 @@ public abstract class AbstractWorkflowOperationHandler implements WorkflowOperat
     List<String> removeTags = new ArrayList();
 
     for (String targetTag : tags) {
-      if (!StringUtils.startsWithAny(targetTag, plus, minus)) {
+      if (!Strings.CS.startsWithAny(targetTag, plus, minus)) {
         if (addTags.size() > 0
             || removeTags.size() > 0) {
           logger.warn("You may not mix override tags and tag changes. "
@@ -591,9 +592,9 @@ public abstract class AbstractWorkflowOperationHandler implements WorkflowOperat
               + "The tag {} is not prefixed with '{}' or '{}'.", overrideTags, targetTag, plus, minus);
         }
         overrideTags.add(targetTag);
-      } else if (StringUtils.startsWith(targetTag, plus)) {
+      } else if (Strings.CS.startsWith(targetTag, plus)) {
         addTags.add(StringUtils.substring(targetTag, 1));
-      } else if (StringUtils.startsWith(targetTag, minus)) {
+      } else if (Strings.CS.startsWith(targetTag, minus)) {
         removeTags.add(StringUtils.substring(targetTag, 1));
       }
     }

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowDefinitionImpl.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowDefinitionImpl.java
@@ -21,7 +21,7 @@
 
 package org.opencastproject.workflow.api;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -365,7 +365,7 @@ public class WorkflowDefinitionImpl implements WorkflowDefinition {
 
     // nullsafe comparison where null is lesser than non-null
     // workflows with null title probably aren't for displaying anyway
-    return StringUtils.compareIgnoreCase(this.getTitle(), workflowDefinition.getTitle());
+    return Strings.CI.compare(this.getTitle(), workflowDefinition.getTitle());
   }
 
   static class Adapter extends XmlAdapter<WorkflowDefinitionImpl, WorkflowDefinition> {

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/CleanupWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/CleanupWorkflowOperationHandler.java
@@ -47,6 +47,7 @@ import org.opencastproject.workspace.api.Workspace;
 
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpDelete;
@@ -281,11 +282,11 @@ public class CleanupWorkflowOperationHandler extends AbstractWorkflowOperationHa
 
     String elementUri = elementToRemove.getURI().toString();
     String deleteUri;
-    if (StringUtils.containsIgnoreCase(elementUri, UrlSupport.concat(WorkingFileRepository.MEDIAPACKAGE_PATH_PREFIX,
+    if (Strings.CI.contains(elementUri, UrlSupport.concat(WorkingFileRepository.MEDIAPACKAGE_PATH_PREFIX,
               elementToRemove.getMediaPackage().getIdentifier().toString(), elementToRemove.getIdentifier()))) {
       deleteUri = UrlSupport.concat(repositoryBaseUrl, WorkingFileRepository.MEDIAPACKAGE_PATH_PREFIX,
               elementToRemove.getMediaPackage().getIdentifier().toString(), elementToRemove.getIdentifier());
-    } else if (StringUtils.containsIgnoreCase(elementUri, WorkingFileRepository.COLLECTION_PATH_PREFIX)) {
+    } else if (Strings.CI.contains(elementUri, WorkingFileRepository.COLLECTION_PATH_PREFIX)) {
       deleteUri = UrlSupport.concat(repositoryBaseUrl, WorkingFileRepository.COLLECTION_PATH_PREFIX,
           StringUtils.substringAfter(elementToRemove.getURI().getPath(), WorkingFileRepository.COLLECTION_PATH_PREFIX));
     } else {

--- a/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/CleanupWorkflowOperationHandlerTest.java
+++ b/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/CleanupWorkflowOperationHandlerTest.java
@@ -40,7 +40,7 @@ import org.opencastproject.workflow.api.WorkflowOperationInstance;
 import org.opencastproject.workingfilerepository.api.WorkingFileRepository;
 import org.opencastproject.workspace.api.Workspace;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.StatusLine;
@@ -320,7 +320,7 @@ public class CleanupWorkflowOperationHandlerTest {
       }
       HttpUriRequest req = (HttpUriRequest) arg;
       uriStore.add(req.getURI());
-      boolean result = StringUtils.startsWith(req.getURI().toString(), matchBaseUri.toString());
+      boolean result = Strings.CS.startsWith(req.getURI().toString(), matchBaseUri.toString());
       return result;
     }
 

--- a/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryImpl.java
+++ b/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryImpl.java
@@ -39,6 +39,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -424,7 +425,7 @@ public class WorkingFileRepositoryImpl implements WorkingFileRepository, PathMap
         if (!fileToDelete.equals(f) && !fileToDelete.equals(md5File)
             // On shared filesystems like NFS the move operation may create temporary .nfsXXX files
             // which will be removed by the NFS subsystem itself. We should skip these files.
-            && !StringUtils.startsWith(fileToDelete.getName(), ".nfs")) {
+            && !Strings.CS.startsWith(fileToDelete.getName(), ".nfs")) {
           logger.trace("delete {}", fileToDelete.getAbsolutePath());
           if (!fileToDelete.delete() && fileToDelete.exists()) {
             throw new IllegalStateException("Unable to delete file: " + fileToDelete.getAbsolutePath());


### PR DESCRIPTION
commons-lang3 3.18 deprecated a bunch of methods. This replaces them with non-deprecated methods from the same package, or Objects.toString in one case.

### How to test this patch



### AI Usage

The changes were made by Claude Sonnet 5.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
