### PR TITLE
Remove deprecated AbstractWorkflowOperationHandler.getCfg and MimeTyp…

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/util/MimeType.java
+++ b/modules/common/src/main/java/org/opencastproject/util/MimeType.java
@@ -213,14 +213,6 @@ public final class MimeType implements Comparable<MimeType>, Serializable {
     return flavor.equalsIgnoreCase(flavor);
   }
 
-  /**
-   * Returns the MimeType as a string of the form <code>type/subtype</code>
-   * @deprecated use {@link #toString()} instead
-   */
-  public String asString() {
-    return toString();
-  }
-
   /** Two mime types are considered equal if type and subtype are equal. */
   public boolean eq(MimeType other) {
     return eq(other.getType(), other.getSubtype());

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageToVideoWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageToVideoWorkflowOperationHandler.java
@@ -130,10 +130,10 @@ public class ImageToVideoWorkflowOperationHandler extends AbstractWorkflowOperat
     final ConfiguredTagsAndFlavors.TargetTags targetTags = tagsAndFlavors.getTargetTags();
     List<MediaPackageElementFlavor> targetFlavors = tagsAndFlavors.getTargetFlavors();
     final Optional<MediaPackageElementFlavor> targetFlavor = Optional.ofNullable(targetFlavors.get(0));
-    final double duration = getCfg(wi, OPT_DURATION)
+    final double duration = getOptConfig(wi, OPT_DURATION)
         .flatMap(Strings::toDouble)
         .orElseThrow(() -> new WorkflowOperationException(OPT_DURATION + " is missing or malformed"));
-    final String profile = getCfg(wi, OPT_PROFILE)
+    final String profile = getOptConfig(wi, OPT_PROFILE)
         .orElseThrow(() -> new WorkflowOperationException(OPT_PROFILE + " is missing or malformed"));
 
     // run image to video jobs

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/AbstractWorkflowOperationHandler.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/AbstractWorkflowOperationHandler.java
@@ -325,16 +325,6 @@ public abstract class AbstractWorkflowOperationHandler implements WorkflowOperat
   }
 
   /**
-   * Get a configuration option.
-   *
-   * @deprecated use {@link #getConfig(WorkflowInstance, String)} or
-   *             {@link #getOptConfig(org.opencastproject.workflow.api.WorkflowInstance, String)}
-   */
-  protected Optional<String> getCfg(WorkflowInstance wi, String key) {
-    return Optional.ofNullable(wi.getCurrentOperation().getConfiguration(key));
-  }
-
-  /**
    * Get a mandatory configuration key. Values are returned trimmed.
    *
    * @throws WorkflowOperationException


### PR DESCRIPTION
…e.asString

getCfg(WorkflowInstance, String) had javadoc pointing to getConfig/getOptConfig but was missing the @Deprecated annotation, so it never surfaced as an IDE warning. Its only two callers switched to getOptConfig, which additionally trims the value and treats blank as absent - an improvement, since the old behavior let an empty config value silently pass through where getOptConfig now correctly reports it as missing.

MimeType.asString() was likewise annotation-less and had zero real callers (just its own definition), so it was removed outright.

### How to test this patch

### AI Usage

The changes were made by Claude Sonnet 5.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
