### PR TITLE
Modernize deprecated commons-io usages

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageElementParser.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageElementParser.java
@@ -29,6 +29,7 @@ import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -88,7 +89,7 @@ public final class MediaPackageElementParser {
     Unmarshaller m = null;
     try {
       m = MediaPackageImpl.context.createUnmarshaller();
-      return (MediaPackageElement) m.unmarshal(XmlSafeParser.parse(toInputStream(xml)));
+      return (MediaPackageElement) m.unmarshal(XmlSafeParser.parse(toInputStream(xml, StandardCharsets.UTF_8)));
     } catch (JAXBException e) {
       throw new MediaPackageException(e.getLinkedException() != null ? e.getLinkedException() : e);
     } catch (IOException | SAXException e) {

--- a/modules/common/src/main/java/org/opencastproject/security/api/OrganizationParser.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/OrganizationParser.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -61,7 +62,7 @@ public final class OrganizationParser {
   public static Organization fromXml(String xml) {
     InputStream in = null;
     try {
-      in = IOUtils.toInputStream(xml);
+      in = IOUtils.toInputStream(xml, StandardCharsets.UTF_8);
       Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
       return unmarshaller.unmarshal(XmlSafeParser.parse(in), JaxbOrganization.class).getValue();
     } catch (JAXBException e) {

--- a/modules/common/src/main/java/org/opencastproject/security/api/UserParser.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/UserParser.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -60,7 +61,7 @@ public final class UserParser {
   public static User fromXml(String xml) {
     InputStream in = null;
     try {
-      in = IOUtils.toInputStream(xml);
+      in = IOUtils.toInputStream(xml, StandardCharsets.UTF_8);
       Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
       return unmarshaller.unmarshal(XmlSafeParser.parse(in), JaxbUser.class).getValue();
     } catch (JAXBException e) {

--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
@@ -957,7 +957,7 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
           HttpGet getExtendedMetadata = new HttpGet(seriesElement.getURI());
           response = httpClient.execute(getExtendedMetadata);
           in = response.getEntity().getContent();
-          data = IOUtils.readFully(in, (int) response.getEntity().getContentLength());
+          data = IOUtils.toByteArray(in, (int) response.getEntity().getContentLength());
         } catch (Exception e) {
           throw new IngestException("Unable to read series " + catalogType + " metadata catalog for series "
               + seriesId + ".", e);

--- a/modules/oaipmh/src/main/java/org/opencastproject/oaipmh/util/XmlGen.java
+++ b/modules/oaipmh/src/main/java/org/opencastproject/oaipmh/util/XmlGen.java
@@ -37,6 +37,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -122,7 +123,7 @@ public abstract class XmlGen {
   public String generateAsString() {
     return withResource(new ByteArrayOutputStream(), out -> {
       generate(out);
-      return out.toString();
+      return out.toString(StandardCharsets.UTF_8);
     });
   }
 

--- a/modules/series-service-remote/src/main/java/org/opencastproject/series/remote/SeriesServiceRemoteImpl.java
+++ b/modules/series-service-remote/src/main/java/org/opencastproject/series/remote/SeriesServiceRemoteImpl.java
@@ -390,7 +390,7 @@ public class SeriesServiceRemoteImpl extends RemoteBase implements SeriesService
     HttpResponse response = getResponse(get);
     try {
       if (response != null) {
-        int count = Integer.parseInt(IOUtils.toString(response.getEntity().getContent()));
+        int count = Integer.parseInt(IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8));
         logger.info("Successfully get series dublin core catalog list from the remote series index");
         return count;
       }
@@ -582,7 +582,8 @@ public class SeriesServiceRemoteImpl extends RemoteBase implements SeriesService
         final int statusCode = response.getStatusLine().getStatusCode();
         switch (statusCode) {
           case SC_OK:
-            JSONArray elementArray = (JSONArray) parser.parse(IOUtils.toString(response.getEntity().getContent()));
+            JSONArray elementArray = (JSONArray) parser.parse(
+                IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8));
             Map<String, byte[]> elements = new HashMap<>();
             for (int i = 0; i < elementArray.length(); i++) {
               final String type = elementArray.getString(i);

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/JobDispatcher.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/JobDispatcher.java
@@ -64,6 +64,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -568,7 +569,8 @@ public class JobDispatcher {
             job.setStatus(Job.Status.FAILED);
             job = serviceRegistry.updateJob(job); // will open a tx
             logger.debug("Service {} refused to accept {}", registration, job);
-            throw new UndispatchableJobException(IOUtils.toString(response.getEntity().getContent()));
+            throw new UndispatchableJobException(
+                IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8));
           } else if (responseStatusCode == HttpStatus.SC_METHOD_NOT_ALLOWED) {
             logger.debug("Service {} is not yet reachable", registration);
             continue;

--- a/modules/smil-impl/src/main/java/org/opencastproject/smil/impl/SmilResponseImpl.java
+++ b/modules/smil-impl/src/main/java/org/opencastproject/smil/impl/SmilResponseImpl.java
@@ -35,6 +35,7 @@ import org.xml.sax.SAXException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -176,7 +177,7 @@ public class SmilResponseImpl implements SmilResponse {
    * @throws JAXBException if deserialization fail
    */
   public static SmilResponse fromXml(String smilResponseXml) throws JAXBException {
-    InputStream smilStream = IOUtils.toInputStream(smilResponseXml);
+    InputStream smilStream = IOUtils.toInputStream(smilResponseXml, StandardCharsets.UTF_8);
     try {
       return fromXml(smilStream);
     } finally {

--- a/modules/subtitle-parser/src/main/java/org/opencastproject/subtitleparser/webvttparser/WebVTTParser.java
+++ b/modules/subtitle-parser/src/main/java/org/opencastproject/subtitleparser/webvttparser/WebVTTParser.java
@@ -67,7 +67,7 @@ public class WebVTTParser {
 
   public WebVTTSubtitle parse(InputStream is) throws IOException, SubtitleParsingException {
     // Wrap input stream into Apache Commons IO BOMInputStream
-    BOMInputStream bomIn = new BOMInputStream(is, false);
+    BOMInputStream bomIn = BOMInputStream.builder().setInputStream(is).setInclude(false).get();
 
     // Create subtitle object
     WebVTTSubtitle subtitle = new WebVTTSubtitle();

--- a/modules/userdirectory-sakai/src/main/java/org/opencastproject/userdirectory/sakai/SakaiUserProviderInstance.java
+++ b/modules/userdirectory-sakai/src/main/java/org/opencastproject/userdirectory/sakai/SakaiUserProviderInstance.java
@@ -52,6 +52,7 @@ import java.io.FileNotFoundException;
 import java.io.StringReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -412,7 +413,7 @@ public class SakaiUserProviderInstance implements UserProvider, RoleProvider {
       connection.setRequestProperty("Authorization", "Basic " + encoded);
       connection.setRequestProperty("User-Agent", OC_USERAGENT);
 
-      String xml = IOUtils.toString(new BufferedInputStream(connection.getInputStream()));
+      String xml = IOUtils.toString(new BufferedInputStream(connection.getInputStream()), StandardCharsets.UTF_8);
       logger.debug(xml);
 
       DocumentBuilder parser = XmlSafeParser.newDocumentBuilderFactory().newDocumentBuilder();
@@ -474,7 +475,7 @@ public class SakaiUserProviderInstance implements UserProvider, RoleProvider {
       connection.setRequestProperty("Authorization", "Basic " + encoded);
       connection.setRequestProperty("User-Agent", OC_USERAGENT);
 
-      String xml = IOUtils.toString(new BufferedInputStream(connection.getInputStream()));
+      String xml = IOUtils.toString(new BufferedInputStream(connection.getInputStream()), StandardCharsets.UTF_8);
       logger.debug(xml);
 
       // Parse the document

--- a/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryImpl.java
+++ b/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryImpl.java
@@ -51,6 +51,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -391,7 +392,7 @@ public class WorkingFileRepositoryImpl implements WorkingFileRepository, PathMap
       // Store the hash
       String md5 = Checksum.convertToHex(dis.getMessageDigest().digest());
       try {
-        FileUtils.writeStringToFile(md5FileTmp, md5);
+        FileUtils.writeStringToFile(md5FileTmp, md5, StandardCharsets.UTF_8);
       } catch (IOException e) {
         FileUtils.deleteQuietly(md5FileTmp);
         throw e;
@@ -452,7 +453,7 @@ public class WorkingFileRepositoryImpl implements WorkingFileRepository, PathMap
       String md5 = DigestUtils.md5Hex(md5In);
       IOUtils.closeQuietly(md5In);
       md5File = getMd5File(f);
-      FileUtils.writeStringToFile(md5File, md5);
+      FileUtils.writeStringToFile(md5File, md5, StandardCharsets.UTF_8);
       return md5File;
     } catch (IOException e) {
       FileUtils.deleteQuietly(md5File);
@@ -688,7 +689,7 @@ public class WorkingFileRepositoryImpl implements WorkingFileRepository, PathMap
       File md5File = null;
       try {
         md5File = getMd5File(f);
-        FileUtils.writeStringToFile(md5File, md5);
+        FileUtils.writeStringToFile(md5File, md5, StandardCharsets.UTF_8);
       } catch (IOException e) {
         FileUtils.deleteQuietly(md5File);
         throw e;


### PR DESCRIPTION
IOUtils.toString(InputStream), IOUtils.toInputStream(String), and FileUtils.writeStringToFile(File, String) were all deprecated in favor of overloads taking an explicit Charset, since relying on the JVM's platform default charset is itself a latent correctness risk. Used UTF-8 throughout, matching what these call sites already assume (XML/JSON/text content exchanged between Opencast's own services).

### How to test this patch

### AI Usage

The changes were made by Claude Sonnet 5.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
