### PR TITLE
Modernize deprecated commons-lang3 API usages

### DIFF
--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PartialImportWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PartialImportWorkflowOperationHandler.java
@@ -243,7 +243,7 @@ public class PartialImportWorkflowOperationHandler extends AbstractWorkflowOpera
 
     float outputFramerate = -1.0f;
     if (concatOutputFramerate.isPresent()) {
-      if (NumberUtils.isNumber(concatOutputFramerate.get())) {
+      if (NumberUtils.isCreatable(concatOutputFramerate.get())) {
         logger.info("Using concat output framerate");
         outputFramerate = NumberUtils.toFloat(concatOutputFramerate.get());
       } else {

--- a/modules/cover-image-impl/pom.xml
+++ b/modules/cover-image-impl/pom.xml
@@ -55,6 +55,10 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+    </dependency>
+    <dependency>
       <groupId>jakarta.ws.rs</groupId>
       <artifactId>jakarta.ws.rs-api</artifactId>
     </dependency>

--- a/modules/cover-image-impl/src/main/java/org/opencastproject/coverimage/impl/xsl/XsltHelper.java
+++ b/modules/cover-image-impl/src/main/java/org/opencastproject/coverimage/impl/xsl/XsltHelper.java
@@ -21,7 +21,7 @@
 package org.opencastproject.coverimage.impl.xsl;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.text.WordUtils;
+import org.apache.commons.text.WordUtils;
 
 /** Helper class to use within the XSLT transformation */
 public final class XsltHelper {

--- a/modules/cover-image-workflowoperation/pom.xml
+++ b/modules/cover-image-workflowoperation/pom.xml
@@ -19,6 +19,10 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-common</artifactId>
       <version>${project.version}</version>

--- a/modules/cover-image-workflowoperation/src/main/java/org/opencastproject/workflow/handler/coverimage/CoverImageWorkflowOperationHandlerBase.java
+++ b/modules/cover-image-workflowoperation/src/main/java/org/opencastproject/workflow/handler/coverimage/CoverImageWorkflowOperationHandlerBase.java
@@ -50,8 +50,8 @@ import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
 import org.opencastproject.workspace.api.Workspace;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -402,7 +402,7 @@ public abstract class CoverImageWorkflowOperationHandlerBase extends AbstractWor
     xml.append(name);
     xml.append(">");
 
-    xml.append(StringEscapeUtils.escapeXml(body));
+    xml.append(StringEscapeUtils.escapeXml10(body));
 
     xml.append("</");
     xml.append(name);

--- a/modules/crop-ffmpeg/src/main/java/org/opencastproject/crop/impl/CropServiceImpl.java
+++ b/modules/crop-ffmpeg/src/main/java/org/opencastproject/crop/impl/CropServiceImpl.java
@@ -306,7 +306,7 @@ public class CropServiceImpl extends AbstractJobProducer implements CropService,
     // FFmpeg command for cropping video
     logger.info("String for startCropping command: {}", crop);
     String croppedOutputPath = FilenameUtils.removeExtension(mediaFile.getAbsolutePath())
-        .concat(RandomStringUtils.randomAlphanumeric(8) + targetExtension);
+        .concat(RandomStringUtils.secure().nextAlphanumeric(8) + targetExtension);
     String[] cropCommand = new String[] {
         binary,
         "-i", mediaFile.getAbsolutePath(),

--- a/modules/oaipmh/src/main/java/org/opencastproject/oaipmh/util/XmlGen.java
+++ b/modules/oaipmh/src/main/java/org/opencastproject/oaipmh/util/XmlGen.java
@@ -28,7 +28,6 @@ import org.opencastproject.util.XmlSafeParser;
 
 
 import org.apache.commons.io.output.ByteArrayOutputStream;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
@@ -41,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.xml.XMLConstants;
@@ -360,7 +360,7 @@ public abstract class XmlGen {
    * Append node <code>n</code> to element <code>e</code> respecting different node types like attributes and elements.
    */
   private void appendTo(Element e, Node n) {
-    Node toAppend = ObjectUtils.equals(n.getOwnerDocument(), document) ? n : document.importNode(n, true);
+    Node toAppend = Objects.equals(n.getOwnerDocument(), document) ? n : document.importNode(n, true);
     if (toAppend instanceof Attr) {
       e.setAttributeNode((Attr) toAppend);
     } else {

--- a/modules/runtime-info/pom.xml
+++ b/modules/runtime-info/pom.xml
@@ -68,6 +68,10 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+    </dependency>
     <!-- Test Dependencies -->
     <dependency>
       <groupId>org.opencastproject</groupId>

--- a/modules/runtime-info/src/main/java/org/opencastproject/runtimeinfo/rest/RestEndpointData.java
+++ b/modules/runtime-info/src/main/java/org/opencastproject/runtimeinfo/rest/RestEndpointData.java
@@ -28,7 +28,7 @@ import org.opencastproject.util.doc.DocData;
 import org.opencastproject.util.doc.rest.RestParameter;
 import org.opencastproject.util.doc.rest.RestResponse;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -462,7 +462,7 @@ public class RestEndpointData implements Comparable<RestEndpointData> {
   }
 
   public String getEscapedReturnTypeSchema() {
-    return StringEscapeUtils.escapeXml(returnTypeSchema);
+    return StringEscapeUtils.escapeXml10(returnTypeSchema);
   }
 
 }

--- a/modules/runtime-info/src/main/java/org/opencastproject/runtimeinfo/rest/RestParamData.java
+++ b/modules/runtime-info/src/main/java/org/opencastproject/runtimeinfo/rest/RestParamData.java
@@ -25,7 +25,7 @@ import org.opencastproject.util.JaxbXmlSchemaGenerator;
 import org.opencastproject.util.doc.DocData;
 import org.opencastproject.util.doc.rest.RestParameter;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -175,7 +175,7 @@ public final class RestParamData {
    * @return an HTML formatted version of the xml schema for display
    */
   public String getEscapedXmlSchema() {
-    return StringEscapeUtils.escapeXml(xmlSchema);
+    return StringEscapeUtils.escapeXml10(xmlSchema);
   }
 
   /**


### PR DESCRIPTION
Replace calls to deprecated commons-lang3 methods: NumberUtils.isNumber with isCreatable, RandomStringUtils.randomAlphanumeric with secure().nextAlphanumeric, and ObjectUtils.equals with java.util.Objects.equals. StringEscapeUtils and WordUtils (text package) are deprecated in favor of their commons-text equivalents, so switch to those and add the commons-text dependency where needed; escapeXml becomes escapeXml10 to match its documented successor.

### How to test this patch

### AI Usage

The changes were made by Claude Sonnet 5.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
