### PR TITLE
Modernize deprecated commons-collections4 API usages

### DIFF
--- a/modules/dublincore/pom.xml
+++ b/modules/dublincore/pom.xml
@@ -62,10 +62,6 @@
       <artifactId>jaxb-runtime</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-collections4</artifactId>
-    </dependency>
-    <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
     </dependency>

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreCatalog.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreCatalog.java
@@ -29,10 +29,6 @@ import org.opencastproject.util.XmlNamespaceContext;
 
 import com.google.gson.annotations.JsonAdapter;
 
-import org.apache.commons.collections4.Closure;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections4.Predicate;
-import org.apache.commons.collections4.Transformer;
 import org.w3c.dom.Document;
 import org.xml.sax.Attributes;
 
@@ -92,31 +88,22 @@ public class DublinCoreCatalog extends XMLCatalogImpl implements DublinCore, Met
   }
 
   @Override
-  @SuppressWarnings("unchecked")
   public List<String> get(EName property, final String language) {
     RequireUtil.notNull(property, "property");
     RequireUtil.notNull(language, "language");
     if (LANGUAGE_ANY.equals(language)) {
-      return (List<String>) CollectionUtils.collect(getValuesAsList(property), new Transformer() {
-        @Override
-        public Object transform(Object o) {
-          return ((CatalogEntry) o).getValue();
-        }
-      });
+      return getValuesAsList(property).stream()
+          .map(CatalogEntry::getValue)
+          .collect(Collectors.toList());
     } else {
-      final List<String> values = new ArrayList<String>();
       final boolean langUndef = LANGUAGE_UNDEFINED.equals(language);
-      CollectionUtils.forAllDo(getValuesAsList(property), new Closure() {
-        @Override
-        public void execute(Object o) {
-          CatalogEntry c = (CatalogEntry) o;
-          String lang = c.getAttribute(XML_LANG_ATTR);
-          if ((langUndef && lang == null) || (language.equals(lang))) {
-            values.add(c.getValue());
-          }
-        }
-      });
-      return values;
+      return getValuesAsList(property).stream()
+          .filter(c -> {
+            String lang = c.getAttribute(XML_LANG_ATTR);
+            return (langUndef && lang == null) || language.equals(lang);
+          })
+          .map(CatalogEntry::getValue)
+          .collect(Collectors.toList());
     }
   }
 
@@ -303,12 +290,8 @@ public class DublinCoreCatalog extends XMLCatalogImpl implements DublinCore, Met
     if (LANGUAGE_ANY.equals(language)) {
       return getValuesAsList(property).size() > 0;
     } else {
-      return CollectionUtils.find(getValuesAsList(property), new Predicate() {
-        @Override
-        public boolean evaluate(Object o) {
-          return equalLanguage(((CatalogEntry) o).getAttribute(XML_LANG_ATTR), language);
-        }
-      }) != null;
+      return getValuesAsList(property).stream()
+          .anyMatch(c -> equalLanguage(c.getAttribute(XML_LANG_ATTR), language));
     }
   }
 

--- a/modules/serviceregistry/pom.xml
+++ b/modules/serviceregistry/pom.xml
@@ -75,10 +75,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
-      <artifactId>commons-collections4</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
Replace CollectionUtils.collect/forAllDo/find and the deprecated Transformer/Closure/Predicate interfaces in DublinCoreCatalog with native Java streams. Drop the now-unused commons-collections4 dependency from dublincore, and also from serviceregistry, which declared it without any actual usage.

### How to test this patch

### AI Usage

The changes were made by Claude Sonnet 5.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
