### PR TITLE
Modernize deprecated Apache HttpClient API usages

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/security/util/HttpResponseWrapper.java
+++ b/modules/common/src/main/java/org/opencastproject/security/util/HttpResponseWrapper.java
@@ -160,11 +160,17 @@ public final class HttpResponseWrapper implements HttpResponse {
     return response.headerIterator(s);
   }
 
-  @Override public HttpParams getParams() {
+  // getParams/setParams are deprecated on HttpMessage itself, but this class implements the full
+  // HttpResponse interface and must still provide them.
+  @Override
+  @SuppressWarnings("deprecation")
+  public HttpParams getParams() {
     return response.getParams();
   }
 
-  @Override public void setParams(HttpParams httpParams) {
+  @Override
+  @SuppressWarnings("deprecation")
+  public void setParams(HttpParams httpParams) {
     response.setParams(httpParams);
   }
 }

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/TrustedHttpClientImpl.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/TrustedHttpClientImpl.java
@@ -60,6 +60,7 @@ import org.apache.http.impl.auth.DigestScheme;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.protocol.BasicHttpContext;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -595,7 +596,7 @@ public class TrustedHttpClientImpl implements TrustedHttpClient {
 
       // Add the authentication header
       try {
-        httpUriRequest.setHeader(digestAuth.authenticate(creds, httpUriRequest));
+        httpUriRequest.setHeader(digestAuth.authenticate(creds, httpUriRequest, new BasicHttpContext()));
       } catch (Exception e) {
         // close the http connection(s)
         try {

--- a/modules/urlsigning-common/src/main/java/org/opencastproject/urlsigning/utils/ResourceRequestUtil.java
+++ b/modules/urlsigning-common/src/main/java/org/opencastproject/urlsigning/utils/ResourceRequestUtil.java
@@ -339,7 +339,7 @@ public final class ResourceRequestUtil {
    * @return True if signed, false if not.
    */
   public static boolean isSigned(URI uri) {
-    List<NameValuePair> queryStringParameters = URLEncodedUtils.parse(uri, StandardCharsets.UTF_8.toString());
+    List<NameValuePair> queryStringParameters = URLEncodedUtils.parse(uri, StandardCharsets.UTF_8);
     boolean hasKeyId = false;
     boolean hasPolicy = false;
     boolean hasSignature = false;


### PR DESCRIPTION
Replace DigestScheme.authenticate(Credentials, HttpRequest) with the non-deprecated 3-arg overload, and URLEncodedUtils.parse(URI, String) with the Charset-based overload. HttpResponseWrapper still must implement HttpMessage's deprecated getParams/setParams to satisfy the HttpResponse interface, so suppress those two specifically since they can't be removed.

### How to test this patch

### AI Usage

The changes were made by Claude Sonnet 5.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
