### PR TITLE
Modernize remaining one-off deprecated API usages

### DIFF
--- a/modules/distribution-service-aws-s3/src/main/java/org/opencastproject/distribution/aws/s3/AwsS3DistributionServiceImpl.java
+++ b/modules/distribution-service-aws-s3/src/main/java/org/opencastproject/distribution/aws/s3/AwsS3DistributionServiceImpl.java
@@ -67,6 +67,7 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.BucketWebsiteConfiguration;
 import com.amazonaws.services.s3.model.SetBucketWebsiteConfigurationRequest;
 import com.amazonaws.services.s3.transfer.TransferManager;
+import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
 import com.amazonaws.services.s3.transfer.Upload;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -360,7 +361,7 @@ public class AwsS3DistributionServiceImpl extends AbstractDistributionService
               .withClientConfiguration(clientConfiguration)
               .withPathStyleAccessEnabled(pathStyle).withCredentials(provider).build();
 
-      s3TransferManager = new TransferManager(s3);
+      s3TransferManager = TransferManagerBuilder.standard().withS3Client(s3).build();
 
       // Create AWS S3 bucket if not there yet
       createAWSBucket();

--- a/modules/graphql/src/main/java/org/opencastproject/graphql/execution/QueryCache.java
+++ b/modules/graphql/src/main/java/org/opencastproject/graphql/execution/QueryCache.java
@@ -40,7 +40,10 @@ public class QueryCache implements PreparsedDocumentProvider {
       .maximumSize(2048)
       .build();
 
+  // getDocument is deprecated in favor of getDocumentAsync, but PreparsedDocumentProvider still
+  // declares it abstract, so implementations must still provide it.
   @Override
+  @SuppressWarnings("deprecation")
   public PreparsedDocumentEntry getDocument(ExecutionInput executionInput,
       Function<ExecutionInput, PreparsedDocumentEntry> parseAndValidateFunction) {
     try {

--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
@@ -532,7 +532,7 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
       // Indicates if zip has a root folder or not, initialized as true
       boolean hasRootFolder = true;
       // While there are entries write them to a collection
-      while ((entry = zis.getNextZipEntry()) != null) {
+      while ((entry = zis.getNextEntry()) != null) {
         try {
           if (entry.isDirectory() || entry.getName().contains("__MACOSX")) {
             continue;


### PR DESCRIPTION
Replace new TransferManager(s3) with TransferManagerBuilder, and ZipArchiveInputStream.getNextZipEntry() with getNextEntry(), both direct drop-in replacements for their deprecated equivalents. QueryCache still must implement PreparsedDocumentProvider's deprecated getDocument() since the interface keeps it abstract, so suppress that one specifically since it can't be removed.



### How to test this patch


### AI Usage

The changes were made by Claude Sonnet 5.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
