### PR TITLE
Modernize deprecated url constructor usages

### DIFF
--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/AdopterRegistrationSender.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/AdopterRegistrationSender.java
@@ -34,8 +34,8 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -141,7 +141,12 @@ public class AdopterRegistrationSender {
    */
   private void send(String json, String urlSuffix, String method) throws IOException {
     try (CloseableHttpClient client = HttpClientBuilder.create().useSystemProperties().build()) {
-      String url = new URL(baseUrl + urlSuffix).toString();
+      String url;
+      try {
+        url = URI.create(baseUrl + urlSuffix).toURL().toString();
+      } catch (IllegalArgumentException e) {
+        throw new MalformedURLException(baseUrl + urlSuffix + " is not a valid URL");
+      }
       HttpEntityEnclosingRequestBase request = null;
       if ("DELETE".equals(method)) {
         request = new HttpDeleteWithEntity(url);

--- a/modules/common/src/main/java/org/opencastproject/mediapackage/AdaptivePlaylist.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/AdaptivePlaylist.java
@@ -37,7 +37,6 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -205,8 +204,8 @@ public interface AdaptivePlaylist extends Track {
 
     for (String f : variants) {
       try {
-        new URL(f); // ignore external paths
-      } catch (MalformedURLException e) {
+        URI.create(f).toURL(); // ignore external paths
+      } catch (MalformedURLException | IllegalArgumentException e) {
         // is relative path - read the variant playlist
         String name = FilenameUtils.concat(FilenameUtils.getFullPath(file.getAbsolutePath()), f);
         allFiles.addAll(getReferencedFiles(new File(name), true));

--- a/modules/cover-image-workflowoperation/src/main/java/org/opencastproject/workflow/handler/coverimage/CoverImageWorkflowOperationHandlerBase.java
+++ b/modules/cover-image-workflowoperation/src/main/java/org/opencastproject/workflow/handler/coverimage/CoverImageWorkflowOperationHandlerBase.java
@@ -219,7 +219,7 @@ public abstract class CoverImageWorkflowOperationHandlerBase extends AbstractWor
 
     URL url = null;
     try {
-      url = new URL(posterimageUrlOpt);
+      url = URI.create(posterimageUrlOpt).toURL();
     } catch (Exception e) {
       logger.debug("Given poster image URI '{}' is not valid", posterimageUrlOpt);
     }

--- a/modules/cover-image-workflowoperation/src/test/java/org/opencastproject/workflow/handler/coverimage/CoverImageWorkflowOperationHandlerTest.java
+++ b/modules/cover-image-workflowoperation/src/test/java/org/opencastproject/workflow/handler/coverimage/CoverImageWorkflowOperationHandlerTest.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.File;
+import java.net.URI;
 import java.net.URL;
 
 /**
@@ -61,7 +62,7 @@ public class CoverImageWorkflowOperationHandlerTest {
     String fileUrlString = "file:/path/to/the/image.png";
     String httpUrlString = "http://foo.bar/image.png";
     String fileHttpUrlString = "file:/path/to/storage/foo_bar_image.png";
-    URL httpUri = new URL(httpUrlString);
+    URL httpUri = URI.create(httpUrlString).toURL();
     File httpFile = new File(fileHttpUrlString);
 
     // setup mock

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java
@@ -434,7 +434,11 @@ public class PublishEngageWorkflowOperationHandler extends AbstractWorkflowOpera
         Organization organization = organizationDirectoryService.getOrganization(workflowInstance.getOrganizationId());
         engageUrlString = StringUtils.trimToNull(organization.getProperties().get(ENGAGE_URL_PROPERTY));
         if (engageUrlString != null) {
-          engageBaseUrl = new URL(engageUrlString);
+          try {
+            engageBaseUrl = URI.create(engageUrlString).toURL();
+          } catch (IllegalArgumentException e) {
+            throw new MalformedURLException(engageUrlString + " is not a valid URL");
+          }
         } else {
           engageBaseUrl = serverUrl;
           logger.info(

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/OrganizationDirectoryServiceImpl.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/OrganizationDirectoryServiceImpl.java
@@ -45,6 +45,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Dictionary;
@@ -206,9 +207,9 @@ public class OrganizationDirectoryServiceImpl implements OrganizationDirectorySe
         String tenantSpecificHost = StringUtils.trimToNull((String) properties.get(key));
         if (tenantSpecificHost != null) {
           try {
-            Tuple<String, Integer> hostPort = hostAndPort(new URL(tenantSpecificHost));
+            Tuple<String, Integer> hostPort = hostAndPort(URI.create(tenantSpecificHost).toURL());
             servers.put(hostPort.getA(), hostPort.getB());
-          } catch (MalformedURLException malformedURLException) {
+          } catch (MalformedURLException | IllegalArgumentException malformedURLException) {
             logger.error("{} is not a URL", tenantSpecificHost);
           }
         }

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/OrganizationFilter.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/OrganizationFilter.java
@@ -38,6 +38,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.List;
 
@@ -117,7 +119,12 @@ public class OrganizationFilter implements Filter {
           ServletException {
     HttpServletRequest httpRequest = (HttpServletRequest) request;
     HttpServletResponse httpResponse = (HttpServletResponse) response;
-    URL url = new URL(httpRequest.getRequestURL().toString());
+    URL url;
+    try {
+      url = URI.create(httpRequest.getRequestURL().toString()).toURL();
+    } catch (IllegalArgumentException e) {
+      throw new MalformedURLException(httpRequest.getRequestURL() + " is not a valid URL");
+    }
 
     Organization org = null;
 

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
@@ -60,6 +60,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -302,7 +303,7 @@ public class YouTubeV3PublicationServiceImpl
       }
       youTubeService.addPlaylistItem(playlist.getId(), video.getId());
       // Create new publication element
-      final URL url = new URL("http://www.youtube.com/watch?v=" + video.getId());
+      final URL url = URI.create("http://www.youtube.com/watch?v=" + video.getId()).toURL();
       return PublicationImpl.publication(
           UUID.randomUUID().toString(), CHANNEL_NAME, url.toURI(), MimeTypes.parseMimeType(MIME_TYPE));
     } catch (Exception e) {

--- a/modules/redirect/src/main/java/org/opencastproject/redirect/RedirectEndpoint.java
+++ b/modules/redirect/src/main/java/org/opencastproject/redirect/RedirectEndpoint.java
@@ -33,10 +33,7 @@ import org.opencastproject.util.doc.rest.RestService;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsResource;
 
-import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
 
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
@@ -102,15 +99,16 @@ public class RedirectEndpoint {
 
     URI baseUri = uriInfo.getBaseUri();
     try {
-      URI targetUri = new URL(baseUri.toURL(), target).toURI();
-      if (!targetUri.getAuthority().equals(baseUri.getAuthority())
+      URI targetUri = baseUri.resolve(target);
+      if (targetUri.getAuthority() == null
+              || !targetUri.getAuthority().equals(baseUri.getAuthority())
               || !targetUri.getScheme().equals(baseUri.getScheme())) {
         return Response.status(Status.BAD_REQUEST).entity("non-relative redirect").build();
       }
 
       return Response.seeOther(targetUri).build();
 
-    } catch (MalformedURLException | URISyntaxException e) {
+    } catch (IllegalArgumentException e) {
       return Response.status(Status.BAD_REQUEST).entity("invalid `target` URL").build();
     }
   }

--- a/modules/redirect/src/test/java/org/opencastproject/redirect/RedirectEndpointTest.java
+++ b/modules/redirect/src/test/java/org/opencastproject/redirect/RedirectEndpointTest.java
@@ -28,9 +28,7 @@ import static org.easymock.EasyMock.replay;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
@@ -50,11 +48,11 @@ public class RedirectEndpointTest {
 
   /** Test the `POST /redirect/get` endpoint */
   @Test
-  public void testPostRedirectGet() throws MalformedURLException {
+  public void testPostRedirectGet() {
     String target = "/studio";
     Response response = endpoint.get(target, uriInfo);
     Assert.assertEquals(303, response.getStatus());
-    String expected = new URL(uriInfo.getBaseUri().toURL(), target).toString();
+    String expected = uriInfo.getBaseUri().resolve(target).toString();
     Assert.assertEquals(response.getLocation().toString(), expected);
   }
 
@@ -76,6 +74,13 @@ public class RedirectEndpointTest {
   @Test
   public void testPostRedirectGetNonRelativeTarget() {
     Response response = endpoint.get("https://opencast.org", uriInfo);
+    Assert.assertEquals(400, response.getStatus());
+  }
+
+  /** Test `POST /redirect/get` with a target that has its own scheme but no authority */
+  @Test
+  public void testPostRedirectGetOpaqueTarget() {
+    Response response = endpoint.get("javascript:alert(1)", uriInfo);
     Assert.assertEquals(400, response.getStatus());
   }
 }

--- a/modules/runtime-info/src/main/java/org/opencastproject/runtimeinfo/RuntimeInfo.java
+++ b/modules/runtime-info/src/main/java/org/opencastproject/runtimeinfo/RuntimeInfo.java
@@ -173,7 +173,12 @@ public class RuntimeInfo {
   public void activate(ComponentContext cc) throws MalformedURLException {
     logger.debug("start()");
     this.bundleContext = cc.getBundleContext();
-    serverUrl = new URL(bundleContext.getProperty(OpencastConstants.SERVER_URL_PROPERTY));
+    String serverUrlProperty = bundleContext.getProperty(OpencastConstants.SERVER_URL_PROPERTY);
+    try {
+      serverUrl = URI.create(serverUrlProperty).toURL();
+    } catch (IllegalArgumentException e) {
+      throw new MalformedURLException(serverUrlProperty + " is not a valid URL");
+    }
   }
 
   @GET

--- a/modules/runtime-info/src/main/java/org/opencastproject/runtimeinfo/RuntimeInfo.java
+++ b/modules/runtime-info/src/main/java/org/opencastproject/runtimeinfo/RuntimeInfo.java
@@ -56,6 +56,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -206,8 +207,8 @@ public class RuntimeInfo {
     final String orgEngageBaseUrl = organization.getProperties().get(ENGAGE_URL_PROPERTY);
     if (StringUtils.isNotBlank(orgEngageBaseUrl)) {
       try {
-        targetEngageBaseUrl = new URL(orgEngageBaseUrl);
-      } catch (MalformedURLException e) {
+        targetEngageBaseUrl = URI.create(orgEngageBaseUrl).toURL();
+      } catch (MalformedURLException | IllegalArgumentException e) {
         logger.warn("Engage url '{}' of organization '{}' is malformed", orgEngageBaseUrl, organization.getId());
       }
     }
@@ -225,8 +226,8 @@ public class RuntimeInfo {
     final String orgAdminBaseUrl = organization.getProperties().get(ADMIN_URL_PROPERTY);
     if (StringUtils.isNotBlank(orgAdminBaseUrl)) {
       try {
-        targetAdminBaseUrl = new URL(orgAdminBaseUrl);
-      } catch (MalformedURLException e) {
+        targetAdminBaseUrl = URI.create(orgAdminBaseUrl).toURL();
+      } catch (MalformedURLException | IllegalArgumentException e) {
         logger.warn("Admin url '{}' of organization '{}' is malformed", orgAdminBaseUrl, organization.getId());
       }
     }

--- a/modules/runtime-info/src/main/java/org/opencastproject/runtimeinfo/RuntimeInfo.java
+++ b/modules/runtime-info/src/main/java/org/opencastproject/runtimeinfo/RuntimeInfo.java
@@ -57,6 +57,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -169,6 +170,14 @@ public class RuntimeInfo {
     return bundleContext.getAllServiceReferences(Servlet.class.getName(), "(&(alias=*)(classpath=*))");
   }
 
+  private static URL buildUrl(String scheme, String host, int port, String path) throws MalformedURLException {
+    try {
+      return new URI(scheme, null, host, port, path, null, null).toURL();
+    } catch (URISyntaxException e) {
+      throw new MalformedURLException(scheme + "://" + host + ":" + port + path + " is not a valid URL");
+    }
+  }
+
   @Activate
   public void activate(ComponentContext cc) throws MalformedURLException {
     logger.debug("start()");
@@ -223,7 +232,7 @@ public class RuntimeInfo {
           "Using 'org.opencastproject.server.url' as a fallback for the non-existing organization "
               + "level key '{}' for the components.json response",
           ENGAGE_URL_PROPERTY);
-      targetEngageBaseUrl = new URL(targetScheme, serverUrl.getHost(), serverUrl.getPort(), serverUrl.getFile());
+      targetEngageBaseUrl = buildUrl(targetScheme, serverUrl.getHost(), serverUrl.getPort(), serverUrl.getFile());
     }
 
     // Create the admin target URL
@@ -242,7 +251,7 @@ public class RuntimeInfo {
           "Using 'org.opencastproject.server.url' as a fallback for the non-existing "
               + "organization level key '{}' for the components.json response",
           ADMIN_URL_PROPERTY);
-      targetAdminBaseUrl = new URL(targetScheme, serverUrl.getHost(), serverUrl.getPort(), serverUrl.getFile());
+      targetAdminBaseUrl = buildUrl(targetScheme, serverUrl.getHost(), serverUrl.getPort(), serverUrl.getFile());
     }
 
     Map<String, Object> json = new HashMap<>();
@@ -542,7 +551,7 @@ public class RuntimeInfo {
       endpoint.put("description", (String) servletRef.getProperty(Constants.SERVICE_DESCRIPTION));
       endpoint.put("version", servletRef.getBundle().getVersion().toString());
       endpoint.put("type", (String) servletRef.getProperty(RestConstants.SERVICE_TYPE_PROPERTY));
-      URL url = new URL(request.getScheme(), request.getServerName(), request.getServerPort(), servletContextPath);
+      URL url = buildUrl(request.getScheme(), request.getServerName(), request.getServerPort(), servletContextPath);
       endpoint.put("path", servletContextPath);
       endpoint.put("docs", UrlSupport.concat(url.toExternalForm(), "/docs")); // This is a Opencast convention
       result.add(endpoint);

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/endpoint/ServiceRegistryEndpoint.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/endpoint/ServiceRegistryEndpoint.java
@@ -68,6 +68,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsResource;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
@@ -410,7 +411,7 @@ public class ServiceRegistryEndpoint {
     try {
       for (ServiceRegistration reg : serviceRegistry.getServiceRegistrationsByLoad(serviceType)) {
         JaxbServiceRegistration jaxbReg = new JaxbServiceRegistration(reg);
-        URL internalHostUrl = new URL(jaxbReg.getHost());
+        URL internalHostUrl = URI.create(jaxbReg.getHost()).toURL();
         String tenantSpecificHost = StringUtils.trimToNull(properties.get("org.opencastproject.host."
             + internalHostUrl.getHost()));
         if (StringUtils.isNotBlank(tenantSpecificHost)) {
@@ -419,7 +420,7 @@ public class ServiceRegistryEndpoint {
         registrations.add(jaxbReg);
       }
       return Response.ok(registrations).build();
-    } catch (ServiceRegistryException | MalformedURLException e) {
+    } catch (ServiceRegistryException | MalformedURLException | IllegalArgumentException e) {
       throw new WebApplicationException(e);
     }
   }

--- a/modules/transcription-service-microsoft-azure/src/main/java/org/opencastproject/transcription/microsoft/azure/MicrosoftAzureStorageClient.java
+++ b/modules/transcription-service-microsoft-azure/src/main/java/org/opencastproject/transcription/microsoft/azure/MicrosoftAzureStorageClient.java
@@ -40,6 +40,8 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -147,7 +149,12 @@ public class MicrosoftAzureStorageClient {
     String containerUrl = getContainerUrl(azureContainerName);
     String blobPath = Paths.get(StringUtils.trimToEmpty(azureBlobPath), StringUtils.trimToEmpty(azureBlobName))
         .normalize().toString();
-    URL blobUrl = new URL(containerUrl + "/" + blobPath);
+    URL blobUrl;
+    try {
+      blobUrl = URI.create(containerUrl + "/" + blobPath).toURL();
+    } catch (IllegalArgumentException e) {
+      throw new MalformedURLException(containerUrl + "/" + blobPath + " is not a valid URL");
+    }
     int blockSize = 100000000; // 100MB
     String sasToken = azureAuthorization.generateServiceSasToken("w", null, null, blobUrl.getPath(), "b");
     try (FileInputStream trackStream = new FileInputStream(trackFile)) {

--- a/modules/transcription-service-microsoft-azure/src/main/java/org/opencastproject/transcription/microsoft/azure/MicrosoftAzureTranscriptionService.java
+++ b/modules/transcription-service-microsoft-azure/src/main/java/org/opencastproject/transcription/microsoft/azure/MicrosoftAzureTranscriptionService.java
@@ -75,7 +75,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URL;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -716,8 +715,9 @@ public class MicrosoftAzureTranscriptionService extends AbstractJobProducer impl
       }
       if (StringUtils.isNotBlank(transcriptionJson.source)) {
         try {
-          azureStorageClient.deleteFile(new URL(transcriptionJson.source));
-        } catch (IOException | MicrosoftAzureNotAllowedException | MicrosoftAzureStorageClientException e) {
+          azureStorageClient.deleteFile(URI.create(transcriptionJson.source).toURL());
+        } catch (IOException | MicrosoftAzureNotAllowedException | MicrosoftAzureStorageClientException
+            | IllegalArgumentException e) {
           throw new TranscriptionServiceException(String.format(
               "Unable to delete audio source file for media package %s.", mpId, e));
         }

--- a/modules/transcription-service-microsoft-azure/src/test/java/org/opencastproject/transcription/microsoft/azure/MicrosoftAzureStorageClientTest.java
+++ b/modules/transcription-service-microsoft-azure/src/test/java/org/opencastproject/transcription/microsoft/azure/MicrosoftAzureStorageClientTest.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Map;
@@ -142,6 +143,6 @@ public class MicrosoftAzureStorageClientTest {
     File testFile = new File(testFileUrl.toURI());
     String blobUrl = azureStorageClient.uploadFile(testFile, azureStorageContainerName, null, "test.txt");
     Assert.assertNotNull(blobUrl);
-    azureStorageClient.deleteFile(new URL(blobUrl));
+    azureStorageClient.deleteFile(URI.create(blobUrl).toURL());
   }
 }

--- a/modules/userdirectory-sakai/src/main/java/org/opencastproject/userdirectory/sakai/SakaiUserProviderInstance.java
+++ b/modules/userdirectory-sakai/src/main/java/org/opencastproject/userdirectory/sakai/SakaiUserProviderInstance.java
@@ -51,6 +51,7 @@ import java.io.BufferedInputStream;
 import java.io.FileNotFoundException;
 import java.io.StringReader;
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -341,7 +342,7 @@ public class SakaiUserProviderInstance implements UserProvider, RoleProvider {
 
     try {
       // This webservice does not require authentication
-      URL url = new URL(sakaiUrl + "/direct/user/" + userId + "/exists");
+      URL url = URI.create(sakaiUrl + "/direct/user/" + userId + "/exists").toURL();
 
       HttpURLConnection connection = (HttpURLConnection) url.openConnection();
       connection.setRequestMethod("GET");
@@ -382,7 +383,7 @@ public class SakaiUserProviderInstance implements UserProvider, RoleProvider {
 
     try {
       // This webservice does not require authentication
-      URL url = new URL(sakaiUrl + "/direct/site/" + siteId + "/exists");
+      URL url = URI.create(sakaiUrl + "/direct/site/" + siteId + "/exists").toURL();
 
       HttpURLConnection connection = (HttpURLConnection) url.openConnection();
       connection.setRequestMethod("GET");
@@ -403,7 +404,7 @@ public class SakaiUserProviderInstance implements UserProvider, RoleProvider {
     logger.debug("getRolesFromSakai(" + userId + ")");
     try {
 
-      URL url = new URL(sakaiUrl + "/direct/membership/fastroles/" + userId + ".xml" + "?__auth=basic");
+      URL url = URI.create(sakaiUrl + "/direct/membership/fastroles/" + userId + ".xml" + "?__auth=basic").toURL();
       String encoded = Base64.encodeBase64String((sakaiUsername + ":" + sakaiPassword).getBytes("utf8"));
 
       HttpURLConnection connection = (HttpURLConnection) url.openConnection();
@@ -465,7 +466,7 @@ public class SakaiUserProviderInstance implements UserProvider, RoleProvider {
 
     try {
 
-      URL url = new URL(sakaiUrl + "/direct/user/" + eid + ".xml" + "?__auth=basic");
+      URL url = URI.create(sakaiUrl + "/direct/user/" + eid + ".xml" + "?__auth=basic").toURL();
       logger.debug("Sakai URL: " + sakaiUrl);
       String encoded = Base64.encodeBase64String((sakaiUsername + ":" + sakaiPassword).getBytes("utf8"));
       HttpURLConnection connection = (HttpURLConnection) url.openConnection();


### PR DESCRIPTION
Replaces all uses of the deprecated `java.net.URL(String)` (and related) constructors across the codebase with `URI`-based equivalents, ahead of `URL`'s planned removal in a future JDK. Because `URI.create(String)` throws an unchecked `IllegalArgumentException` where `URL(String)` threw a checked `MalformedURLException`, this couldn't be a single mechanical find-and-replace — each of the 21 call sites needed its surrounding exception handling checked individually. The work is split into five incremental commits by risk/technique, plus a final cleanup commit for two incidental test-file sites found along the way.


### How to test this patch

### AI Usage

The changes were made by Claude Sonnet 5.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
