### PR TITLE
Fix workflow conditions silently misevaluating on case mismatches

### DIFF
--- a/docs/guides/admin/docs/configuration/workflow.md
+++ b/docs/guides/admin/docs/configuration/workflow.md
@@ -320,6 +320,10 @@ operation should be executed. This so-called execution condition is a boolean ex
     <bool-literal> ::= "true" | "false"
     <atom> ::= <number> | <string>
 
+Note that `AND`, `OR`, `NOT`, `true` and `false` are case-sensitive keywords: they must be written exactly as shown
+above (`AND`/`OR`/`NOT` in upper-case, `true`/`false` in lower-case). Any other casing, such as `and` or `TRUE`, is
+not recognized and causes the condition to be rejected as invalid.
+
 As the formal description above explains, such boolean expressions may contain…
 
 - …the boolean constants `true` and `false`.

--- a/modules/workflow-condition-parser/src/main/antlr4/org/opencastproject/workflow/conditionparser/antlr/WorkflowCondition.g4
+++ b/modules/workflow-condition-parser/src/main/antlr4/org/opencastproject/workflow/conditionparser/antlr/WorkflowCondition.g4
@@ -1,5 +1,6 @@
 grammar WorkflowCondition;
 
+parse : booleanExpression EOF ;
 booleanExpression : booleanTerm ( OR booleanExpression )? ;
 booleanTerm : booleanValue ( AND booleanTerm )? ;
 booleanValue : ( NOT )* ( '(' booleanExpression ')' | relation | BOOL ) ;

--- a/modules/workflow-condition-parser/src/main/java/org/opencastproject/workflow/conditionparser/WorkflowConditionInterpreter.java
+++ b/modules/workflow-condition-parser/src/main/java/org/opencastproject/workflow/conditionparser/WorkflowConditionInterpreter.java
@@ -149,10 +149,11 @@ public final class WorkflowConditionInterpreter {
         throw new IllegalArgumentException("line " + line + ":" + charPositionInLine + " " + msg);
       }
     };
+    l.addErrorListener(listener);
     final WorkflowConditionParser p = new WorkflowConditionParser(new CommonTokenStream(l));
     p.removeErrorListeners();
     p.addErrorListener(listener);
-    ParseTree tree = p.booleanExpression();
+    ParseTree tree = p.parse().booleanExpression();
     return new WorkflowConditionBooleanInterpreter().visit(tree);
   }
 

--- a/modules/workflow-condition-parser/src/test/java/org/opencastproject/workflow/conditionparser/WorkflowConditionInterpreterTest.java
+++ b/modules/workflow-condition-parser/src/test/java/org/opencastproject/workflow/conditionparser/WorkflowConditionInterpreterTest.java
@@ -112,4 +112,24 @@ public class WorkflowConditionInterpreterTest {
   public void interpretDecimalEquality() {
     assertTrue(WorkflowConditionInterpreter.interpret("5.0 == 5"));
   }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void interpretLowerCaseAndFails() {
+    WorkflowConditionInterpreter.interpret("true and false");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void interpretLowerCaseOrFails() {
+    WorkflowConditionInterpreter.interpret("true or false");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void interpretLowerCaseNotFails() {
+    WorkflowConditionInterpreter.interpret("not true");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void interpretTrailingGarbageFails() {
+    WorkflowConditionInterpreter.interpret("true true");
+  }
 }


### PR DESCRIPTION
Fixes #1336, where #1336 is interpreted to mean

*"Workflows with faulty boolean syntax should fail fast and loud"*

and not

*"Booleans in workflows should be case-insensitive"*.

So this now fails the workflow and logs an error like

```
ERROR | (AssertWorkflowOperationHandler:82) - Invalid assertion that-1: true and false
```



### How to test this patch

Can for example be tested with a workflow using assert operations like so:

```
id: test-booleans
title: Regression test for workflow condition case sensitivity
tags:
  - upload
  - archive
operations:
  - id: assert
    description: Uppercase AND/OR/NOT must evaluate correctly
    configurations:
      - that-1: "true AND NOT false"
      - that-2: "false OR true"

  - id: assert
    description: Lowercase 'and' must fail the workflow instead of silently passing
    configurations:
      - that-1: "true and false"
```

### AI Usage

Claude Sonnet 5 was used for this PR.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://docs.opencast.org/develop/developer/#participate/development-process/#automatically-closing-issues-when-a-pr-is-merged) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] does not incorrectly update the submodules
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
* [ ] explain why it needs to be merged into the legacy branch, if it is targeting the legacy branch
* [ ] include a [release note](https://docs.opencast.org/develop/developer/#participate/development-process/#release-notes) if a feature, or supports a feature (ie, backend part of a frontend feature)
